### PR TITLE
[Feature] Enable results output conversion to YAML (fixes #12)

### DIFF
--- a/src/mcpbr/cli.py
+++ b/src/mcpbr/cli.py
@@ -13,7 +13,7 @@ from .docker_env import cleanup_orphaned_containers, register_signal_handlers
 from .harness import run_evaluation
 from .harnesses import list_available_harnesses
 from .models import DEFAULT_MODEL, list_supported_models
-from .reporting import print_summary, save_json_results, save_markdown_report
+from .reporting import print_summary, save_json_results, save_markdown_report, save_yaml_results
 
 console = Console()
 
@@ -192,6 +192,14 @@ def main() -> None:
     is_flag=True,
     help="Disable pre-built SWE-bench images (build from scratch)",
 )
+@click.option(
+    "--yaml",
+    "-y",
+    "yaml_output",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Path to save YAML results (alternative to --output for YAML format)",
+)
 def run(
     config_path: Path,
     model_override: str | None,
@@ -210,6 +218,7 @@ def run(
     task_ids: tuple[str, ...],
     prompt_override: str | None,
     no_prebuilt: bool,
+    yaml_output: Path | None,
 ) -> None:
     """Run SWE-bench evaluation with the configured MCP server.
 
@@ -221,6 +230,7 @@ def run(
       mcpbr run -c config.yaml -n 10     # Sample 10 tasks
       mcpbr run -c config.yaml -v        # Verbose output
       mcpbr run -c config.yaml -o out.json -r report.md
+      mcpbr run -c config.yaml --yaml out.yaml  # Save as YAML
     """
     register_signal_handlers()
 
@@ -319,6 +329,10 @@ def run(
     if output_path:
         save_json_results(results, output_path)
         console.print(f"\n[green]Results saved to {output_path}[/green]")
+
+    if yaml_output:
+        save_yaml_results(results, yaml_output)
+        console.print(f"[green]YAML results saved to {yaml_output}[/green]")
 
     if report_path:
         save_markdown_report(results, report_path)

--- a/src/mcpbr/reporting.py
+++ b/src/mcpbr/reporting.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import yaml
 from rich.console import Console
 from rich.table import Table
 
@@ -211,3 +212,31 @@ def save_markdown_report(results: "EvaluationResults", output_path: Path) -> Non
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text("\n".join(lines))
+
+
+def save_yaml_results(results: "EvaluationResults", output_path: Path) -> None:
+    """Save evaluation results to a YAML file.
+
+    Args:
+        results: Evaluation results.
+        output_path: Path to save the YAML file.
+    """
+    data = {
+        "metadata": results.metadata,
+        "summary": results.summary,
+        "tasks": [],
+    }
+
+    for task in results.tasks:
+        task_data = {
+            "instance_id": task.instance_id,
+        }
+        if task.mcp:
+            task_data["mcp"] = task.mcp
+        if task.baseline:
+            task_data["baseline"] = task.baseline
+        data["tasks"].append(task_data)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,274 @@
+"""Tests for reporting utilities."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from mcpbr.harness import EvaluationResults, TaskResult
+from mcpbr.reporting import save_json_results, save_markdown_report, save_yaml_results
+
+
+@pytest.fixture
+def sample_results() -> EvaluationResults:
+    """Create sample evaluation results for testing."""
+    return EvaluationResults(
+        metadata={
+            "timestamp": "2026-01-20T12:00:00Z",
+            "config": {
+                "model": "claude-sonnet-4-5-20250929",
+                "provider": "anthropic",
+                "agent_harness": "claude-code",
+                "dataset": "SWE-bench/SWE-bench_Lite",
+                "sample_size": 2,
+                "timeout_seconds": 300,
+                "max_iterations": 10,
+            },
+            "mcp_server": {
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-filesystem", "{workdir}"],
+            },
+        },
+        summary={
+            "mcp": {"resolved": 1, "total": 2, "rate": 0.5},
+            "baseline": {"resolved": 0, "total": 2, "rate": 0.0},
+            "improvement": "+100.0%",
+        },
+        tasks=[
+            TaskResult(
+                instance_id="test-task-1",
+                mcp={
+                    "patch_generated": True,
+                    "tokens": {"input": 100, "output": 500},
+                    "iterations": 5,
+                    "tool_calls": 10,
+                    "tool_usage": {"Read": 3, "Write": 2, "Bash": 5},
+                    "resolved": True,
+                    "patch_applied": True,
+                },
+                baseline={
+                    "patch_generated": True,
+                    "tokens": {"input": 50, "output": 300},
+                    "iterations": 3,
+                    "tool_calls": 5,
+                    "tool_usage": {"Read": 2, "Write": 1, "Bash": 2},
+                    "resolved": False,
+                    "patch_applied": True,
+                },
+            ),
+            TaskResult(
+                instance_id="test-task-2",
+                mcp={
+                    "patch_generated": False,
+                    "tokens": {"input": 80, "output": 400},
+                    "iterations": 4,
+                    "tool_calls": 8,
+                    "tool_usage": {"Read": 4, "Bash": 4},
+                    "resolved": False,
+                    "patch_applied": False,
+                },
+                baseline={
+                    "patch_generated": False,
+                    "tokens": {"input": 40, "output": 200},
+                    "iterations": 2,
+                    "tool_calls": 3,
+                    "tool_usage": {"Read": 1, "Bash": 2},
+                    "resolved": False,
+                    "patch_applied": False,
+                },
+            ),
+        ],
+    )
+
+
+class TestSaveJsonResults:
+    """Tests for save_json_results function."""
+
+    def test_saves_valid_json(self, sample_results: EvaluationResults) -> None:
+        """Test that JSON output is valid and contains expected data."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "results.json"
+            save_json_results(sample_results, output_path)
+
+            assert output_path.exists()
+
+            with open(output_path) as f:
+                data = json.load(f)
+
+            assert "metadata" in data
+            assert "summary" in data
+            assert "tasks" in data
+            assert len(data["tasks"]) == 2
+            assert data["tasks"][0]["instance_id"] == "test-task-1"
+            assert data["tasks"][0]["mcp"]["resolved"] is True
+            assert data["tasks"][0]["baseline"]["resolved"] is False
+
+    def test_creates_parent_directories(self, sample_results: EvaluationResults) -> None:
+        """Test that parent directories are created if they don't exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "subdir" / "nested" / "results.json"
+            save_json_results(sample_results, output_path)
+
+            assert output_path.exists()
+            assert output_path.parent.exists()
+
+
+class TestSaveYamlResults:
+    """Tests for save_yaml_results function."""
+
+    def test_saves_valid_yaml(self, sample_results: EvaluationResults) -> None:
+        """Test that YAML output is valid and contains expected data."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "results.yaml"
+            save_yaml_results(sample_results, output_path)
+
+            assert output_path.exists()
+
+            with open(output_path) as f:
+                data = yaml.safe_load(f)
+
+            assert "metadata" in data
+            assert "summary" in data
+            assert "tasks" in data
+            assert len(data["tasks"]) == 2
+            assert data["tasks"][0]["instance_id"] == "test-task-1"
+            assert data["tasks"][0]["mcp"]["resolved"] is True
+            assert data["tasks"][0]["baseline"]["resolved"] is False
+
+    def test_creates_parent_directories(self, sample_results: EvaluationResults) -> None:
+        """Test that parent directories are created if they don't exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "subdir" / "nested" / "results.yaml"
+            save_yaml_results(sample_results, output_path)
+
+            assert output_path.exists()
+            assert output_path.parent.exists()
+
+    def test_yaml_is_human_readable(self, sample_results: EvaluationResults) -> None:
+        """Test that YAML output is properly formatted and human-readable."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "results.yaml"
+            save_yaml_results(sample_results, output_path)
+
+            content = output_path.read_text()
+
+            # Check for human-readable formatting (not flow style)
+            assert "metadata:" in content
+            assert "summary:" in content
+            assert "tasks:" in content
+            assert "instance_id:" in content
+
+            # Should not use flow style (inline braces)
+            assert "{" not in content or content.count("{") < 5  # Allow minimal braces
+
+    def test_yaml_preserves_order(self, sample_results: EvaluationResults) -> None:
+        """Test that YAML preserves the expected order of fields."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "results.yaml"
+            save_yaml_results(sample_results, output_path)
+
+            content = output_path.read_text()
+            lines = content.split("\n")
+
+            # Find indices of major sections
+            metadata_idx = next(i for i, line in enumerate(lines) if line.startswith("metadata:"))
+            summary_idx = next(i for i, line in enumerate(lines) if line.startswith("summary:"))
+            tasks_idx = next(i for i, line in enumerate(lines) if line.startswith("tasks:"))
+
+            # Check that sections appear in expected order
+            assert metadata_idx < summary_idx < tasks_idx
+
+    def test_yaml_json_equivalence(self, sample_results: EvaluationResults) -> None:
+        """Test that YAML and JSON outputs contain the same data."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            json_path = Path(tmpdir) / "results.json"
+            yaml_path = Path(tmpdir) / "results.yaml"
+
+            save_json_results(sample_results, json_path)
+            save_yaml_results(sample_results, yaml_path)
+
+            with open(json_path) as f:
+                json_data = json.load(f)
+
+            with open(yaml_path) as f:
+                yaml_data = yaml.safe_load(f)
+
+            # Both should contain the same data
+            assert json_data == yaml_data
+
+    def test_handles_unicode(self, sample_results: EvaluationResults) -> None:
+        """Test that YAML properly handles Unicode characters."""
+        # Add unicode to results
+        sample_results.tasks[0].instance_id = "test-task-🔥"
+        sample_results.metadata["config"]["note"] = "测试 unicode"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "results.yaml"
+            save_yaml_results(sample_results, output_path)
+
+            with open(output_path, encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+
+            assert data["tasks"][0]["instance_id"] == "test-task-🔥"
+            assert data["metadata"]["config"]["note"] == "测试 unicode"
+
+    def test_handles_none_values(self) -> None:
+        """Test that YAML properly handles None values."""
+        results = EvaluationResults(
+            metadata={"timestamp": "2026-01-20T12:00:00Z", "config": {}},
+            summary={"mcp": {"resolved": 0, "total": 1, "rate": 0.0}},
+            tasks=[
+                TaskResult(
+                    instance_id="test-task-1",
+                    mcp={"resolved": False, "error": None},
+                    baseline=None,  # Baseline not run
+                )
+            ],
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "results.yaml"
+            save_yaml_results(results, output_path)
+
+            with open(output_path) as f:
+                data = yaml.safe_load(f)
+
+            # None values should be preserved
+            assert data["tasks"][0]["mcp"]["error"] is None
+            assert "baseline" not in data["tasks"][0]
+
+
+class TestSaveMarkdownReport:
+    """Tests for save_markdown_report function."""
+
+    def test_saves_valid_markdown(self, sample_results: EvaluationResults) -> None:
+        """Test that Markdown output is valid and contains expected sections."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "report.md"
+            save_markdown_report(sample_results, output_path)
+
+            assert output_path.exists()
+
+            content = output_path.read_text()
+
+            # Check for expected sections
+            assert "# SWE-bench MCP Evaluation Report" in content
+            assert "## Summary" in content
+            assert "## MCP Server Configuration" in content
+            assert "## Per-Task Results" in content
+            assert "## Analysis" in content
+
+            # Check for task data
+            assert "test-task-1" in content
+            assert "test-task-2" in content
+
+    def test_creates_parent_directories(self, sample_results: EvaluationResults) -> None:
+        """Test that parent directories are created if they don't exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "subdir" / "nested" / "report.md"
+            save_markdown_report(sample_results, output_path)
+
+            assert output_path.exists()
+            assert output_path.parent.exists()


### PR DESCRIPTION
## Summary
- Adds YAML output format for evaluation results
- Users can now export results in YAML format using `--yaml` flag
- Maintains full compatibility with existing JSON output

## Changes
- Added `save_yaml_results()` function to `src/mcpbr/reporting.py`
- Added `--yaml/-y` CLI flag to `mcpbr run` command
- Implemented using PyYAML with proper formatting options:
  - `default_flow_style=False` for human-readable formatting
  - `sort_keys=False` to preserve field order
  - `allow_unicode=True` for proper Unicode handling
- Created comprehensive test suite in `tests/test_reporting.py`

## Test Coverage
Added 11 new tests covering:
- YAML validity and structure
- Human-readable formatting (no flow style)
- Field order preservation
- JSON/YAML output equivalence
- Unicode character handling
- Edge cases (None values, nested structures)
- Directory creation for output files

All tests pass (89 non-integration tests):
```
======================= 89 passed, 8 deselected in 0.55s =======================
```

## Example Usage
```bash
# Save results as YAML
mcpbr run -c config.yaml --yaml results.yaml

# Save both JSON and YAML
mcpbr run -c config.yaml -o results.json --yaml results.yaml
```

## Example Output
```yaml
metadata:
  timestamp: '2026-01-20T12:00:00Z'
  config:
    model: claude-sonnet-4-5-20250929
    provider: anthropic
    agent_harness: claude-code
summary:
  mcp:
    resolved: 8
    total: 25
    rate: 0.32
  baseline:
    resolved: 5
    total: 25
    rate: 0.20
  improvement: +60.0%
tasks:
- instance_id: astropy__astropy-12907
  mcp:
    patch_generated: true
    resolved: true
    tokens:
      input: 115
      output: 6542
```

## Related Issues
Fixes #12

Note: Issue #52 appears to be for the same feature. This PR addresses both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added YAML output format support for evaluation results. Users can now export results as YAML using the new `--yaml` command-line option, providing an alternative to JSON output for compatibility with YAML-based workflows and tools.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->