### PR TITLE
[Feature] Add Configuration Templates (fixes #99)

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,0 +1,467 @@
+# Configuration Templates
+
+mcpbr provides pre-built configuration templates for common MCP server scenarios, making it easy to get started quickly.
+
+## Quick Start
+
+List available templates:
+
+```bash
+mcpbr templates
+```
+
+Create a config from a template:
+
+```bash
+mcpbr init -t filesystem
+```
+
+Interactive template selection:
+
+```bash
+mcpbr init -i
+```
+
+## Available Templates
+
+### File Operations
+
+#### Filesystem Server (Basic)
+**Template ID:** `filesystem`
+
+Basic filesystem access with the official Anthropic MCP server. This is the recommended starting point for most users.
+
+```bash
+mcpbr init -t filesystem
+```
+
+**Features:**
+- Official Anthropic filesystem server
+- Full read/write access to task workspace
+- SWE-bench benchmark
+- 10 task sample for quick testing
+
+**Tags:** `filesystem`, `basic`, `official`, `recommended`
+
+#### Filesystem Server (Read-Only)
+**Template ID:** `filesystem-readonly`
+
+Read-only filesystem access for safe exploration without modification risks.
+
+```bash
+mcpbr init -t filesystem-readonly
+```
+
+**Features:**
+- Official Anthropic filesystem server
+- Read-only mode for safety
+- Perfect for analysis tasks
+- Same settings as basic template
+
+**Tags:** `filesystem`, `readonly`, `safe`, `official`
+
+### Code Analysis
+
+#### Supermodel Codebase Analysis
+**Template ID:** `supermodel`
+
+Advanced codebase analysis with the Supermodel MCP server.
+
+```bash
+mcpbr init -t supermodel
+```
+
+**Features:**
+- Advanced code analysis capabilities
+- Requires SUPERMODEL_API_KEY environment variable
+- Extended timeout for complex analysis
+- Reduced concurrency for API rate limits
+
+**Tags:** `codebase`, `analysis`, `advanced`, `api-key`
+
+**Note:** Set `SUPERMODEL_API_KEY` environment variable before running.
+
+### Security
+
+#### CyberGym Security Testing
+**Template ID:** `cybergym-basic`
+
+Security vulnerability testing with CyberGym benchmark at basic difficulty.
+
+```bash
+mcpbr init -t cybergym-basic
+```
+
+**Features:**
+- CyberGym benchmark for PoC generation
+- Level 1 difficulty (basic context)
+- 5 task sample
+- Standard timeout
+
+**Tags:** `security`, `cybergym`, `vulnerability`, `basic`
+
+#### CyberGym Advanced Security
+**Template ID:** `cybergym-advanced`
+
+Advanced security testing with maximum context (level 3).
+
+```bash
+mcpbr init -t cybergym-advanced
+```
+
+**Features:**
+- CyberGym benchmark
+- Level 3 difficulty (maximum context)
+- Extended timeout for complex exploits
+- Increased iteration limit
+
+**Tags:** `security`, `cybergym`, `vulnerability`, `advanced`
+
+### Testing
+
+#### Quick Test (Single Task)
+**Template ID:** `quick-test`
+
+Fast single-task evaluation for quick testing and development.
+
+```bash
+mcpbr init -t quick-test
+```
+
+**Features:**
+- Single task evaluation
+- Single concurrent task
+- Standard timeout
+- Perfect for development/debugging
+
+**Tags:** `testing`, `quick`, `development`, `single-task`
+
+### Production
+
+#### Production Evaluation
+**Template ID:** `production`
+
+Full-scale production evaluation with optimal settings.
+
+```bash
+mcpbr init -t production
+```
+
+**Features:**
+- Full dataset (no sampling)
+- Extended timeout (600s)
+- High concurrency (8 tasks)
+- Maximum iterations (30)
+- Pre-built images enabled
+
+**Tags:** `production`, `full-scale`, `performance`
+
+### Custom
+
+#### Custom Python MCP Server
+**Template ID:** `custom-python`
+
+Template for custom Python-based MCP servers.
+
+```bash
+mcpbr init -t custom-python
+```
+
+**Features:**
+- Python command with module format
+- Debug logging enabled
+- Standard evaluation settings
+- Ready to customize
+
+**Tags:** `custom`, `python`, `development`
+
+**Note:** Update `args` to point to your Python MCP server module.
+
+#### Custom Node.js MCP Server
+**Template ID:** `custom-node`
+
+Template for custom Node.js-based MCP servers.
+
+```bash
+mcpbr init -t custom-node
+```
+
+**Features:**
+- Node.js runtime
+- Production environment
+- Standard evaluation settings
+- Ready to customize
+
+**Tags:** `custom`, `nodejs`, `development`
+
+**Note:** Update `args` to point to your Node.js server file.
+
+## Using Templates
+
+### Basic Usage
+
+Create a config file using a template:
+
+```bash
+mcpbr init -t <template-id> -o config.yaml
+```
+
+Example:
+
+```bash
+mcpbr init -t filesystem -o my-config.yaml
+```
+
+### Interactive Mode
+
+Launch interactive mode to select a template and customize values:
+
+```bash
+mcpbr init -i
+```
+
+This will:
+1. Display all templates organized by category
+2. Let you select a template
+3. Optionally customize key values (sample size, timeout, concurrency)
+4. Generate the config file
+
+### Listing Templates
+
+List all available templates:
+
+```bash
+mcpbr templates
+```
+
+Filter by category:
+
+```bash
+mcpbr templates -c Security
+```
+
+Filter by tag:
+
+```bash
+mcpbr templates --tag quick
+```
+
+### Template Customization
+
+After creating a config from a template, you can edit it to:
+- Adjust sample sizes
+- Change timeout values
+- Modify MCP server arguments
+- Add custom prompts
+- Configure environment variables
+
+Example workflow:
+
+```bash
+# Create from template
+mcpbr init -t filesystem
+
+# Edit the config
+vim mcpbr.yaml
+
+# Run evaluation
+mcpbr run -c mcpbr.yaml
+```
+
+## Template Categories
+
+### File Operations
+Templates for filesystem access and file manipulation.
+
+### Code Analysis
+Templates for advanced code analysis and understanding.
+
+### Security
+Templates for security testing and vulnerability analysis.
+
+### Testing
+Templates optimized for development and testing workflows.
+
+### Production
+Templates for production-scale evaluations.
+
+### Custom
+Templates for custom MCP server implementations.
+
+## Template Tags
+
+Templates are tagged to help you find the right one:
+
+- `basic` - Simple, beginner-friendly templates
+- `advanced` - Complex templates with more features
+- `official` - Official Anthropic MCP servers
+- `recommended` - Recommended for most users
+- `quick` - Fast, minimal templates for testing
+- `production` - Production-ready settings
+- `custom` - Customizable templates
+- `filesystem` - File operation templates
+- `security` - Security testing templates
+- `cybergym` - CyberGym benchmark templates
+- `safe` - Read-only or safe-mode templates
+- `readonly` - Read-only filesystem access
+
+## Best Practices
+
+### For Development
+
+Use `quick-test` template for rapid iteration:
+
+```bash
+mcpbr init -t quick-test
+mcpbr run -c mcpbr.yaml
+```
+
+### For Testing MCP Servers
+
+Start with `filesystem` template and customize:
+
+```bash
+mcpbr init -t filesystem
+# Edit mcpbr.yaml to point to your MCP server
+mcpbr run -c mcpbr.yaml -n 5  # Test with 5 tasks first
+```
+
+### For Security Research
+
+Use CyberGym templates:
+
+```bash
+# Start with basic
+mcpbr init -t cybergym-basic
+mcpbr run -c mcpbr.yaml
+
+# Progress to advanced
+mcpbr init -t cybergym-advanced -o cybergym-adv.yaml
+mcpbr run -c cybergym-adv.yaml
+```
+
+### For Production Evaluations
+
+Use production template with full dataset:
+
+```bash
+mcpbr init -t production
+# Review and adjust settings
+mcpbr run -c mcpbr.yaml -o results.json -r report.md
+```
+
+## Creating Custom Templates
+
+Templates are defined in `src/mcpbr/templates.py`. To add a new template:
+
+1. Define a new `Template` instance in the `TEMPLATES` dictionary
+2. Specify all required fields: id, name, description, category, config, tags
+3. Ensure the config contains all required fields
+4. Add appropriate tags for discoverability
+
+Example:
+
+```python
+"my-template": Template(
+    id="my-template",
+    name="My Custom Template",
+    description="Description of what this template does",
+    category="Custom",
+    config={
+        "mcp_server": {
+            "command": "npx",
+            "args": ["-y", "my-mcp-server", "{workdir}"],
+            "env": {},
+        },
+        "provider": "anthropic",
+        "agent_harness": "claude-code",
+        "model": DEFAULT_MODEL,
+        "benchmark": "swe-bench",
+        "sample_size": 10,
+        "timeout_seconds": 300,
+        "max_concurrent": 4,
+        "max_iterations": 10,
+    },
+    tags=["custom", "my-tag"],
+)
+```
+
+## FAQ
+
+### Which template should I use?
+
+- **First time user?** Use `filesystem` template
+- **Testing your MCP server?** Start with `quick-test`
+- **Security research?** Use `cybergym-basic` or `cybergym-advanced`
+- **Production evaluation?** Use `production` template
+- **Custom server?** Use `custom-python` or `custom-node`
+
+### Can I modify a template-generated config?
+
+Yes! Templates are just starting points. Edit the generated YAML file to customize any settings.
+
+### How do I see what a template contains?
+
+Use `mcpbr init -t <template-id>` to generate a config file and inspect it, or check the template source in `src/mcpbr/templates.py`.
+
+### Can I create my own templates?
+
+Yes! Add them to `src/mcpbr/templates.py` following the existing pattern. Consider submitting a PR to share useful templates with the community.
+
+## Examples
+
+### Quick Test Workflow
+
+```bash
+# List templates
+mcpbr templates
+
+# Create quick test config
+mcpbr init -t quick-test
+
+# Run single task
+mcpbr run -c mcpbr.yaml -v
+
+# If successful, scale up
+mcpbr init -t filesystem -o full-test.yaml
+# Edit sample_size to 25
+mcpbr run -c full-test.yaml -o results.json
+```
+
+### Security Testing Workflow
+
+```bash
+# Create CyberGym config
+mcpbr init -t cybergym-basic
+
+# Run evaluation
+mcpbr run -c mcpbr.yaml -v --log-dir logs/
+
+# Analyze results
+# If good, try advanced level
+mcpbr init -t cybergym-advanced -o cybergym-adv.yaml
+mcpbr run -c cybergym-adv.yaml -o results-adv.json
+```
+
+### Custom Server Workflow
+
+```bash
+# Create custom Python template
+mcpbr init -t custom-python -o my-server.yaml
+
+# Edit to point to your server
+# Update: args: ["-m", "my_mcp_server", "--workspace", "{workdir}"]
+
+# Test with one task
+mcpbr run -c my-server.yaml -n 1 -vv
+
+# Scale up gradually
+mcpbr run -c my-server.yaml -n 5
+mcpbr run -c my-server.yaml -n 25
+```
+
+## See Also
+
+- [Configuration Guide](configuration.md) - Detailed config reference
+- [CLI Reference](cli.md) - All command options
+- [Quick Start](../README.md#quick-start) - Getting started guide

--- a/src/mcpbr/cli.py
+++ b/src/mcpbr/cli.py
@@ -385,7 +385,8 @@ def init(
       mcpbr init -i                     # Interactive mode
       mcpbr init -l                     # List available templates
     """
-    from .templates import generate_config_yaml, get_template, list_templates as get_all_templates
+    from .templates import generate_config_yaml, get_template
+    from .templates import list_templates as get_all_templates
 
     # Handle list templates flag
     if list_templates:
@@ -528,6 +529,8 @@ def templates(category: str | None, tag: str | None) -> None:
     from .templates import (
         get_templates_by_category,
         get_templates_by_tag,
+    )
+    from .templates import (
         list_templates as get_all_templates,
     )
 

--- a/src/mcpbr/cli.py
+++ b/src/mcpbr/cli.py
@@ -12,7 +12,7 @@ from .config import VALID_BENCHMARKS, VALID_HARNESSES, VALID_PROVIDERS, load_con
 from .docker_env import cleanup_orphaned_containers, register_signal_handlers
 from .harness import run_evaluation
 from .harnesses import list_available_harnesses
-from .models import DEFAULT_MODEL, list_supported_models
+from .models import list_supported_models
 from .reporting import print_summary, save_json_results, save_markdown_report, save_yaml_results
 
 console = Console()

--- a/src/mcpbr/templates.py
+++ b/src/mcpbr/templates.py
@@ -1,0 +1,312 @@
+"""Configuration templates for common MCP server scenarios."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from .models import DEFAULT_MODEL
+
+
+@dataclass
+class Template:
+    """Configuration template with metadata."""
+
+    id: str
+    name: str
+    description: str
+    category: str
+    config: dict[str, Any]
+    tags: list[str]
+
+
+# Template definitions
+TEMPLATES = {
+    "filesystem": Template(
+        id="filesystem",
+        name="Filesystem Server (Basic)",
+        description="Basic filesystem access with the official Anthropic MCP server",
+        category="File Operations",
+        config={
+            "mcp_server": {
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-filesystem", "{workdir}"],
+                "env": {},
+            },
+            "provider": "anthropic",
+            "agent_harness": "claude-code",
+            "model": DEFAULT_MODEL,
+            "benchmark": "swe-bench",
+            "sample_size": 10,
+            "timeout_seconds": 300,
+            "max_concurrent": 4,
+            "max_iterations": 10,
+        },
+        tags=["filesystem", "basic", "official", "recommended"],
+    ),
+    "filesystem-readonly": Template(
+        id="filesystem-readonly",
+        name="Filesystem Server (Read-Only)",
+        description="Read-only filesystem access for safe exploration",
+        category="File Operations",
+        config={
+            "mcp_server": {
+                "command": "npx",
+                "args": [
+                    "-y",
+                    "@modelcontextprotocol/server-filesystem",
+                    "{workdir}",
+                    "--readonly",
+                ],
+                "env": {},
+            },
+            "provider": "anthropic",
+            "agent_harness": "claude-code",
+            "model": DEFAULT_MODEL,
+            "benchmark": "swe-bench",
+            "sample_size": 10,
+            "timeout_seconds": 300,
+            "max_concurrent": 4,
+            "max_iterations": 10,
+        },
+        tags=["filesystem", "readonly", "safe", "official"],
+    ),
+    "supermodel": Template(
+        id="supermodel",
+        name="Supermodel Codebase Analysis",
+        description="Advanced codebase analysis with Supermodel MCP server",
+        category="Code Analysis",
+        config={
+            "mcp_server": {
+                "command": "npx",
+                "args": ["-y", "@supermodeltools/mcp-server"],
+                "env": {"SUPERMODEL_API_KEY": "${SUPERMODEL_API_KEY}"},
+            },
+            "provider": "anthropic",
+            "agent_harness": "claude-code",
+            "model": DEFAULT_MODEL,
+            "benchmark": "swe-bench",
+            "sample_size": 10,
+            "timeout_seconds": 600,
+            "max_concurrent": 2,
+            "max_iterations": 15,
+        },
+        tags=["codebase", "analysis", "advanced", "api-key"],
+    ),
+    "cybergym-basic": Template(
+        id="cybergym-basic",
+        name="CyberGym Security Testing",
+        description="Security vulnerability testing with CyberGym benchmark",
+        category="Security",
+        config={
+            "mcp_server": {
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-filesystem", "{workdir}"],
+                "env": {},
+            },
+            "provider": "anthropic",
+            "agent_harness": "claude-code",
+            "model": DEFAULT_MODEL,
+            "benchmark": "cybergym",
+            "cybergym_level": 1,
+            "sample_size": 5,
+            "timeout_seconds": 300,
+            "max_concurrent": 4,
+            "max_iterations": 10,
+        },
+        tags=["security", "cybergym", "vulnerability", "basic"],
+    ),
+    "cybergym-advanced": Template(
+        id="cybergym-advanced",
+        name="CyberGym Advanced Security",
+        description="Advanced security testing with maximum context (level 3)",
+        category="Security",
+        config={
+            "mcp_server": {
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-filesystem", "{workdir}"],
+                "env": {},
+            },
+            "provider": "anthropic",
+            "agent_harness": "claude-code",
+            "model": DEFAULT_MODEL,
+            "benchmark": "cybergym",
+            "cybergym_level": 3,
+            "sample_size": 5,
+            "timeout_seconds": 600,
+            "max_concurrent": 2,
+            "max_iterations": 20,
+        },
+        tags=["security", "cybergym", "vulnerability", "advanced"],
+    ),
+    "quick-test": Template(
+        id="quick-test",
+        name="Quick Test (Single Task)",
+        description="Fast single-task evaluation for quick testing",
+        category="Testing",
+        config={
+            "mcp_server": {
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-filesystem", "{workdir}"],
+                "env": {},
+            },
+            "provider": "anthropic",
+            "agent_harness": "claude-code",
+            "model": DEFAULT_MODEL,
+            "benchmark": "swe-bench",
+            "sample_size": 1,
+            "timeout_seconds": 300,
+            "max_concurrent": 1,
+            "max_iterations": 10,
+        },
+        tags=["testing", "quick", "development", "single-task"],
+    ),
+    "production": Template(
+        id="production",
+        name="Production Evaluation",
+        description="Full-scale production evaluation with optimal settings",
+        category="Production",
+        config={
+            "mcp_server": {
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-filesystem", "{workdir}"],
+                "env": {},
+            },
+            "provider": "anthropic",
+            "agent_harness": "claude-code",
+            "model": DEFAULT_MODEL,
+            "benchmark": "swe-bench",
+            "sample_size": None,
+            "timeout_seconds": 600,
+            "max_concurrent": 8,
+            "max_iterations": 30,
+            "use_prebuilt_images": True,
+        },
+        tags=["production", "full-scale", "performance"],
+    ),
+    "custom-python": Template(
+        id="custom-python",
+        name="Custom Python MCP Server",
+        description="Template for custom Python-based MCP servers",
+        category="Custom",
+        config={
+            "mcp_server": {
+                "command": "python",
+                "args": ["-m", "my_mcp_server", "--workspace", "{workdir}"],
+                "env": {"LOG_LEVEL": "debug"},
+            },
+            "provider": "anthropic",
+            "agent_harness": "claude-code",
+            "model": DEFAULT_MODEL,
+            "benchmark": "swe-bench",
+            "sample_size": 10,
+            "timeout_seconds": 300,
+            "max_concurrent": 4,
+            "max_iterations": 10,
+        },
+        tags=["custom", "python", "development"],
+    ),
+    "custom-node": Template(
+        id="custom-node",
+        name="Custom Node.js MCP Server",
+        description="Template for custom Node.js-based MCP servers",
+        category="Custom",
+        config={
+            "mcp_server": {
+                "command": "node",
+                "args": ["path/to/server.js", "{workdir}"],
+                "env": {"NODE_ENV": "production"},
+            },
+            "provider": "anthropic",
+            "agent_harness": "claude-code",
+            "model": DEFAULT_MODEL,
+            "benchmark": "swe-bench",
+            "sample_size": 10,
+            "timeout_seconds": 300,
+            "max_concurrent": 4,
+            "max_iterations": 10,
+        },
+        tags=["custom", "nodejs", "development"],
+    ),
+}
+
+
+def list_templates() -> list[Template]:
+    """List all available templates.
+
+    Returns:
+        List of Template objects sorted by category and name.
+    """
+    return sorted(TEMPLATES.values(), key=lambda t: (t.category, t.name))
+
+
+def get_template(template_id: str) -> Template | None:
+    """Get a template by ID.
+
+    Args:
+        template_id: Template identifier.
+
+    Returns:
+        Template object or None if not found.
+    """
+    return TEMPLATES.get(template_id)
+
+
+def get_templates_by_category() -> dict[str, list[Template]]:
+    """Get templates grouped by category.
+
+    Returns:
+        Dictionary mapping category names to lists of templates.
+    """
+    result: dict[str, list[Template]] = {}
+    for template in list_templates():
+        if template.category not in result:
+            result[template.category] = []
+        result[template.category].append(template)
+    return result
+
+
+def get_templates_by_tag(tag: str) -> list[Template]:
+    """Get templates that have a specific tag.
+
+    Args:
+        tag: Tag to filter by.
+
+    Returns:
+        List of templates with the specified tag.
+    """
+    return [t for t in list_templates() if tag in t.tags]
+
+
+def generate_config_yaml(template: Template, custom_values: dict[str, Any] | None = None) -> str:
+    """Generate a YAML configuration string from a template.
+
+    Args:
+        template: Template to use.
+        custom_values: Optional dictionary of values to override in the template.
+
+    Returns:
+        YAML configuration string.
+    """
+    import yaml
+
+    config = template.config.copy()
+
+    # Apply custom values if provided
+    if custom_values:
+        for key, value in custom_values.items():
+            if key in config:
+                config[key] = value
+
+    # Generate YAML with comments header
+    yaml_content = f"""# mcpbr - Model Context Protocol Benchmark Runner
+#
+# Template: {template.name}
+# {template.description}
+#
+# Requires ANTHROPIC_API_KEY environment variable.
+
+"""
+
+    # Convert config to YAML
+    yaml_str = yaml.dump(config, default_flow_style=False, sort_keys=False)
+
+    return yaml_content + yaml_str

--- a/tests/test_cli_templates.py
+++ b/tests/test_cli_templates.py
@@ -3,7 +3,6 @@
 import tempfile
 from pathlib import Path
 
-import pytest
 import yaml
 from click.testing import CliRunner
 

--- a/tests/test_cli_templates.py
+++ b/tests/test_cli_templates.py
@@ -91,9 +91,7 @@ class TestInitCommand:
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = Path(tmpdir) / "config.yaml"
 
-            result = runner.invoke(
-                main, ["init", "-o", str(output_path), "-t", "cybergym-basic"]
-            )
+            result = runner.invoke(main, ["init", "-o", str(output_path), "-t", "cybergym-basic"])
 
             assert result.exit_code == 0
 
@@ -323,4 +321,7 @@ class TestTemplatesHelp:
 
         assert result.exit_code == 0
         assert "templates" in result.output
-        assert "List available configuration templates" in result.output or "templates" in result.output
+        assert (
+            "List available configuration templates" in result.output
+            or "templates" in result.output
+        )

--- a/tests/test_cli_templates.py
+++ b/tests/test_cli_templates.py
@@ -1,0 +1,327 @@
+"""Tests for CLI template commands."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from mcpbr.cli import main
+from mcpbr.templates import TEMPLATES
+
+
+class TestInitCommand:
+    """Tests for the init command with templates."""
+
+    def test_init_default_creates_file(self) -> None:
+        """Test that init creates a file with default template."""
+        runner = CliRunner()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "config.yaml"
+
+            result = runner.invoke(main, ["init", "-o", str(output_path)])
+
+            assert result.exit_code == 0
+            assert output_path.exists()
+            assert "Created config at" in result.output
+
+    def test_init_default_uses_filesystem_template(self) -> None:
+        """Test that default init uses filesystem template."""
+        runner = CliRunner()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "config.yaml"
+
+            result = runner.invoke(main, ["init", "-o", str(output_path)])
+
+            assert result.exit_code == 0
+
+            # Read and parse the config
+            content = output_path.read_text()
+            assert "Filesystem Server (Basic)" in content
+
+            # Parse YAML (skip header comments)
+            lines = content.split("\n")
+            yaml_lines = []
+            in_header = True
+            for line in lines:
+                if in_header and line.strip() and not line.strip().startswith("#"):
+                    in_header = False
+                if not in_header:
+                    yaml_lines.append(line)
+
+            config = yaml.safe_load("\n".join(yaml_lines))
+            assert config["mcp_server"]["command"] == "npx"
+            assert "@modelcontextprotocol/server-filesystem" in config["mcp_server"]["args"]
+
+    def test_init_with_specific_template(self) -> None:
+        """Test init with a specific template."""
+        runner = CliRunner()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "config.yaml"
+
+            result = runner.invoke(main, ["init", "-o", str(output_path), "-t", "quick-test"])
+
+            assert result.exit_code == 0
+            assert output_path.exists()
+
+            content = output_path.read_text()
+            assert "Quick Test" in content
+
+            # Parse and verify
+            lines = content.split("\n")
+            yaml_lines = []
+            in_header = True
+            for line in lines:
+                if in_header and line.strip() and not line.strip().startswith("#"):
+                    in_header = False
+                if not in_header:
+                    yaml_lines.append(line)
+
+            config = yaml.safe_load("\n".join(yaml_lines))
+            assert config["sample_size"] == 1
+            assert config["max_concurrent"] == 1
+
+    def test_init_with_cybergym_template(self) -> None:
+        """Test init with CyberGym template."""
+        runner = CliRunner()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "config.yaml"
+
+            result = runner.invoke(
+                main, ["init", "-o", str(output_path), "-t", "cybergym-basic"]
+            )
+
+            assert result.exit_code == 0
+
+            content = output_path.read_text()
+            assert "CyberGym" in content
+
+            lines = content.split("\n")
+            yaml_lines = []
+            in_header = True
+            for line in lines:
+                if in_header and line.strip() and not line.strip().startswith("#"):
+                    in_header = False
+                if not in_header:
+                    yaml_lines.append(line)
+
+            config = yaml.safe_load("\n".join(yaml_lines))
+            assert config["benchmark"] == "cybergym"
+            assert "cybergym_level" in config
+
+    def test_init_with_invalid_template(self) -> None:
+        """Test init with invalid template ID."""
+        runner = CliRunner()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "config.yaml"
+
+            result = runner.invoke(
+                main, ["init", "-o", str(output_path), "-t", "nonexistent-template"]
+            )
+
+            assert result.exit_code != 0
+            assert not output_path.exists()
+            assert "not found" in result.output
+
+    def test_init_file_already_exists(self) -> None:
+        """Test init fails when file already exists."""
+        runner = CliRunner()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "config.yaml"
+            output_path.write_text("existing content")
+
+            result = runner.invoke(main, ["init", "-o", str(output_path)])
+
+            assert result.exit_code != 0
+            assert "already exists" in result.output
+
+    def test_init_list_templates_flag(self) -> None:
+        """Test init --list-templates shows templates."""
+        runner = CliRunner()
+
+        result = runner.invoke(main, ["init", "--list-templates"])
+
+        assert result.exit_code == 0
+        assert "Available Templates" in result.output
+        assert "filesystem" in result.output
+        assert "quick-test" in result.output
+
+    def test_init_list_templates_short_flag(self) -> None:
+        """Test init -l shows templates."""
+        runner = CliRunner()
+
+        result = runner.invoke(main, ["init", "-l"])
+
+        assert result.exit_code == 0
+        assert "Available Templates" in result.output
+
+
+class TestTemplatesCommand:
+    """Tests for the templates command."""
+
+    def test_templates_lists_all(self) -> None:
+        """Test templates command lists all templates."""
+        runner = CliRunner()
+
+        result = runner.invoke(main, ["templates"])
+
+        assert result.exit_code == 0
+        assert "Available Configuration Templates" in result.output
+
+        # Check for some known templates
+        assert "filesystem" in result.output
+        assert "quick-test" in result.output
+        assert "production" in result.output
+
+    def test_templates_shows_count(self) -> None:
+        """Test templates command shows total count."""
+        runner = CliRunner()
+
+        result = runner.invoke(main, ["templates"])
+
+        assert result.exit_code == 0
+        assert "template(s)" in result.output
+
+    def test_templates_filter_by_category(self) -> None:
+        """Test templates command with category filter."""
+        runner = CliRunner()
+
+        result = runner.invoke(main, ["templates", "-c", "Testing"])
+
+        assert result.exit_code == 0
+        assert "Testing" in result.output
+        assert "quick-test" in result.output
+
+    def test_templates_filter_by_tag(self) -> None:
+        """Test templates command with tag filter."""
+        runner = CliRunner()
+
+        result = runner.invoke(main, ["templates", "--tag", "quick"])
+
+        assert result.exit_code == 0
+        assert "quick" in result.output
+
+    def test_templates_filter_by_nonexistent_category(self) -> None:
+        """Test templates command with nonexistent category."""
+        runner = CliRunner()
+
+        result = runner.invoke(main, ["templates", "-c", "NonexistentCategory"])
+
+        assert result.exit_code == 0
+        assert "No templates found" in result.output
+
+    def test_templates_filter_by_nonexistent_tag(self) -> None:
+        """Test templates command with nonexistent tag."""
+        runner = CliRunner()
+
+        result = runner.invoke(main, ["templates", "--tag", "nonexistent-tag-xyz"])
+
+        assert result.exit_code == 0
+        assert "No templates found" in result.output
+
+
+class TestTemplateIntegration:
+    """Integration tests for template workflow."""
+
+    def test_full_workflow_list_and_init(self) -> None:
+        """Test full workflow: list templates, then init with one."""
+        runner = CliRunner()
+
+        # First, list templates
+        list_result = runner.invoke(main, ["templates"])
+        assert list_result.exit_code == 0
+        assert "filesystem" in list_result.output
+
+        # Then, init with a template
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "config.yaml"
+
+            init_result = runner.invoke(main, ["init", "-o", str(output_path), "-t", "filesystem"])
+
+            assert init_result.exit_code == 0
+            assert output_path.exists()
+
+            # Verify the config is valid
+            content = output_path.read_text()
+            lines = content.split("\n")
+            yaml_lines = []
+            in_header = True
+            for line in lines:
+                if in_header and line.strip() and not line.strip().startswith("#"):
+                    in_header = False
+                if not in_header:
+                    yaml_lines.append(line)
+
+            config = yaml.safe_load("\n".join(yaml_lines))
+            assert config is not None
+            assert "mcp_server" in config
+
+    def test_all_templates_create_valid_configs(self) -> None:
+        """Test that all templates create valid, parseable configs."""
+        runner = CliRunner()
+
+        for template_id in TEMPLATES.keys():
+            with tempfile.TemporaryDirectory() as tmpdir:
+                output_path = Path(tmpdir) / f"{template_id}.yaml"
+
+                result = runner.invoke(main, ["init", "-o", str(output_path), "-t", template_id])
+
+                assert result.exit_code == 0, f"Failed to create config for {template_id}"
+                assert output_path.exists(), f"Config file not created for {template_id}"
+
+                # Verify the config is valid YAML
+                content = output_path.read_text()
+                lines = content.split("\n")
+                yaml_lines = []
+                in_header = True
+                for line in lines:
+                    if in_header and line.strip() and not line.strip().startswith("#"):
+                        in_header = False
+                    if not in_header:
+                        yaml_lines.append(line)
+
+                config = yaml.safe_load("\n".join(yaml_lines))
+                assert config is not None, f"Invalid YAML for {template_id}"
+                assert "mcp_server" in config, f"Missing mcp_server in {template_id}"
+                assert "provider" in config, f"Missing provider in {template_id}"
+                assert "model" in config, f"Missing model in {template_id}"
+
+
+class TestTemplatesHelp:
+    """Tests for help text and documentation."""
+
+    def test_templates_command_help(self) -> None:
+        """Test templates command help text."""
+        runner = CliRunner()
+
+        result = runner.invoke(main, ["templates", "--help"])
+
+        assert result.exit_code == 0
+        assert "List available configuration templates" in result.output
+
+    def test_init_command_help_mentions_templates(self) -> None:
+        """Test init command help mentions templates."""
+        runner = CliRunner()
+
+        result = runner.invoke(main, ["init", "--help"])
+
+        assert result.exit_code == 0
+        assert "template" in result.output.lower()
+        assert "-t" in result.output or "--template" in result.output
+
+    def test_main_help_lists_templates_command(self) -> None:
+        """Test main help lists templates command."""
+        runner = CliRunner()
+
+        result = runner.invoke(main, ["--help"])
+
+        assert result.exit_code == 0
+        assert "templates" in result.output
+        assert "List available configuration templates" in result.output or "templates" in result.output

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,6 +1,5 @@
 """Tests for configuration templates."""
 
-import pytest
 import yaml
 
 from mcpbr.templates import (

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,364 @@
+"""Tests for configuration templates."""
+
+import pytest
+import yaml
+
+from mcpbr.templates import (
+    TEMPLATES,
+    Template,
+    generate_config_yaml,
+    get_template,
+    get_templates_by_category,
+    get_templates_by_tag,
+    list_templates,
+)
+
+
+class TestTemplate:
+    """Tests for Template dataclass."""
+
+    def test_template_creation(self) -> None:
+        """Test creating a template."""
+        template = Template(
+            id="test",
+            name="Test Template",
+            description="A test template",
+            category="Testing",
+            config={"model": "test-model"},
+            tags=["test"],
+        )
+
+        assert template.id == "test"
+        assert template.name == "Test Template"
+        assert template.description == "A test template"
+        assert template.category == "Testing"
+        assert template.config == {"model": "test-model"}
+        assert template.tags == ["test"]
+
+
+class TestListTemplates:
+    """Tests for list_templates function."""
+
+    def test_list_returns_all_templates(self) -> None:
+        """Test that list_templates returns all templates."""
+        templates = list_templates()
+        assert len(templates) == len(TEMPLATES)
+
+    def test_list_is_sorted(self) -> None:
+        """Test that templates are sorted by category and name."""
+        templates = list_templates()
+        # Verify sorting
+        for i in range(len(templates) - 1):
+            curr = templates[i]
+            next_t = templates[i + 1]
+            assert (curr.category, curr.name) <= (next_t.category, next_t.name)
+
+    def test_list_includes_expected_templates(self) -> None:
+        """Test that common templates are included."""
+        templates = list_templates()
+        template_ids = [t.id for t in templates]
+
+        assert "filesystem" in template_ids
+        assert "quick-test" in template_ids
+        assert "production" in template_ids
+
+
+class TestGetTemplate:
+    """Tests for get_template function."""
+
+    def test_get_existing_template(self) -> None:
+        """Test getting an existing template."""
+        template = get_template("filesystem")
+        assert template is not None
+        assert template.id == "filesystem"
+        assert template.name == "Filesystem Server (Basic)"
+
+    def test_get_nonexistent_template(self) -> None:
+        """Test getting a nonexistent template returns None."""
+        template = get_template("nonexistent")
+        assert template is None
+
+    def test_get_all_templates(self) -> None:
+        """Test getting each template by ID."""
+        for template_id in TEMPLATES.keys():
+            template = get_template(template_id)
+            assert template is not None
+            assert template.id == template_id
+
+
+class TestGetTemplatesByCategory:
+    """Tests for get_templates_by_category function."""
+
+    def test_returns_dict(self) -> None:
+        """Test that function returns a dictionary."""
+        result = get_templates_by_category()
+        assert isinstance(result, dict)
+
+    def test_all_templates_included(self) -> None:
+        """Test that all templates are included in the result."""
+        result = get_templates_by_category()
+        total = sum(len(templates) for templates in result.values())
+        assert total == len(TEMPLATES)
+
+    def test_categories_are_correct(self) -> None:
+        """Test that templates are in the right categories."""
+        result = get_templates_by_category()
+
+        for category, templates in result.items():
+            for template in templates:
+                assert template.category == category
+
+    def test_expected_categories_exist(self) -> None:
+        """Test that expected categories exist."""
+        result = get_templates_by_category()
+
+        assert "File Operations" in result
+        assert "Testing" in result
+        assert "Custom" in result
+
+
+class TestGetTemplatesByTag:
+    """Tests for get_templates_by_tag function."""
+
+    def test_filter_by_tag(self) -> None:
+        """Test filtering templates by tag."""
+        templates = get_templates_by_tag("basic")
+        assert len(templates) > 0
+        for template in templates:
+            assert "basic" in template.tags
+
+    def test_filter_by_nonexistent_tag(self) -> None:
+        """Test filtering by nonexistent tag returns empty list."""
+        templates = get_templates_by_tag("nonexistent-tag-xyz")
+        assert len(templates) == 0
+
+    def test_filter_by_recommended(self) -> None:
+        """Test filtering by recommended tag."""
+        templates = get_templates_by_tag("recommended")
+        assert len(templates) > 0
+        # Check filesystem is recommended
+        filesystem_found = any(t.id == "filesystem" for t in templates)
+        assert filesystem_found
+
+    def test_filter_by_quick(self) -> None:
+        """Test filtering by quick tag."""
+        templates = get_templates_by_tag("quick")
+        assert len(templates) > 0
+        # Quick-test should be in quick templates
+        quick_test_found = any(t.id == "quick-test" for t in templates)
+        assert quick_test_found
+
+
+class TestGenerateConfigYaml:
+    """Tests for generate_config_yaml function."""
+
+    def test_generate_basic_yaml(self) -> None:
+        """Test generating YAML from a template."""
+        template = get_template("filesystem")
+        assert template is not None
+
+        yaml_str = generate_config_yaml(template)
+
+        # Check that it's valid YAML
+        assert yaml_str is not None
+        assert len(yaml_str) > 0
+
+        # Check for key sections
+        assert "mcp_server:" in yaml_str
+        assert "provider:" in yaml_str
+        assert "model:" in yaml_str
+
+    def test_yaml_is_valid(self) -> None:
+        """Test that generated YAML can be parsed."""
+        template = get_template("filesystem")
+        assert template is not None
+
+        yaml_str = generate_config_yaml(template)
+
+        # Extract YAML content (skip comments at the top)
+        lines = yaml_str.split("\n")
+        yaml_content_lines = []
+        in_header = True
+        for line in lines:
+            if in_header and line.strip() and not line.strip().startswith("#"):
+                in_header = False
+            if not in_header:
+                yaml_content_lines.append(line)
+
+        yaml_content = "\n".join(yaml_content_lines)
+
+        # Parse YAML
+        config = yaml.safe_load(yaml_content)
+        assert isinstance(config, dict)
+        assert "mcp_server" in config
+        assert "provider" in config
+        assert "model" in config
+
+    def test_yaml_contains_template_info(self) -> None:
+        """Test that generated YAML contains template metadata."""
+        template = get_template("filesystem")
+        assert template is not None
+
+        yaml_str = generate_config_yaml(template)
+
+        # Check for template name and description in comments
+        assert template.name in yaml_str
+        assert template.description in yaml_str
+
+    def test_custom_values_override(self) -> None:
+        """Test that custom values override template defaults."""
+        template = get_template("filesystem")
+        assert template is not None
+
+        custom_values = {
+            "sample_size": 50,
+            "timeout_seconds": 600,
+        }
+
+        yaml_str = generate_config_yaml(template, custom_values)
+
+        # Parse YAML to check values
+        lines = yaml_str.split("\n")
+        yaml_content_lines = []
+        in_header = True
+        for line in lines:
+            if in_header and line.strip() and not line.strip().startswith("#"):
+                in_header = False
+            if not in_header:
+                yaml_content_lines.append(line)
+
+        yaml_content = "\n".join(yaml_content_lines)
+        config = yaml.safe_load(yaml_content)
+
+        assert config["sample_size"] == 50
+        assert config["timeout_seconds"] == 600
+
+    def test_all_templates_generate_valid_yaml(self) -> None:
+        """Test that all templates can generate valid YAML."""
+        for template_id in TEMPLATES.keys():
+            template = get_template(template_id)
+            assert template is not None
+
+            yaml_str = generate_config_yaml(template)
+            assert yaml_str is not None
+            assert len(yaml_str) > 0
+
+            # Verify it contains expected content
+            assert "mcp_server:" in yaml_str
+            assert template.name in yaml_str
+
+
+class TestTemplateContent:
+    """Tests for specific template content."""
+
+    def test_filesystem_template(self) -> None:
+        """Test the filesystem template has correct structure."""
+        template = get_template("filesystem")
+        assert template is not None
+
+        assert template.category == "File Operations"
+        assert "filesystem" in template.tags
+        assert template.config["mcp_server"]["command"] == "npx"
+        assert template.config["benchmark"] == "swe-bench"
+
+    def test_cybergym_templates(self) -> None:
+        """Test CyberGym templates have correct benchmark."""
+        for template_id in ["cybergym-basic", "cybergym-advanced"]:
+            template = get_template(template_id)
+            assert template is not None
+            assert template.config["benchmark"] == "cybergym"
+            assert "cybergym_level" in template.config
+            assert "security" in template.tags
+
+    def test_quick_test_template(self) -> None:
+        """Test quick-test template has minimal settings."""
+        template = get_template("quick-test")
+        assert template is not None
+
+        assert template.config["sample_size"] == 1
+        assert template.config["max_concurrent"] == 1
+        assert "quick" in template.tags
+
+    def test_production_template(self) -> None:
+        """Test production template has optimal settings."""
+        template = get_template("production")
+        assert template is not None
+
+        assert template.config["sample_size"] is None  # Full dataset
+        assert template.config["max_concurrent"] >= 4
+        assert template.config["timeout_seconds"] >= 600
+        assert "production" in template.tags
+
+    def test_custom_templates_have_placeholders(self) -> None:
+        """Test custom templates contain placeholders for user to fill."""
+        custom_templates = ["custom-python", "custom-node"]
+
+        for template_id in custom_templates:
+            template = get_template(template_id)
+            assert template is not None
+            assert "custom" in template.tags
+
+            # Verify command is set to appropriate runtime
+            if template_id == "custom-python":
+                assert template.config["mcp_server"]["command"] == "python"
+            elif template_id == "custom-node":
+                assert template.config["mcp_server"]["command"] == "node"
+
+
+class TestTemplateValidation:
+    """Tests to ensure templates produce valid configurations."""
+
+    def test_all_templates_have_required_fields(self) -> None:
+        """Test that all templates have required configuration fields."""
+        required_fields = [
+            "mcp_server",
+            "provider",
+            "agent_harness",
+            "model",
+            "benchmark",
+        ]
+
+        for template_id, template in TEMPLATES.items():
+            for field in required_fields:
+                assert field in template.config, f"Template {template_id} missing {field}"
+
+    def test_all_mcp_servers_have_command(self) -> None:
+        """Test that all MCP server configs have a command."""
+        for template_id, template in TEMPLATES.items():
+            mcp_config = template.config["mcp_server"]
+            assert "command" in mcp_config, f"Template {template_id} missing command"
+            assert mcp_config["command"], f"Template {template_id} has empty command"
+
+    def test_benchmark_values_are_valid(self) -> None:
+        """Test that benchmark values are valid."""
+        valid_benchmarks = ["swe-bench", "cybergym"]
+
+        for template_id, template in TEMPLATES.items():
+            benchmark = template.config["benchmark"]
+            assert (
+                benchmark in valid_benchmarks
+            ), f"Template {template_id} has invalid benchmark: {benchmark}"
+
+    def test_cybergym_templates_have_level(self) -> None:
+        """Test that CyberGym templates have cybergym_level."""
+        for template_id, template in TEMPLATES.items():
+            if template.config["benchmark"] == "cybergym":
+                assert (
+                    "cybergym_level" in template.config
+                ), f"CyberGym template {template_id} missing cybergym_level"
+                level = template.config["cybergym_level"]
+                assert 0 <= level <= 3, f"Template {template_id} has invalid level: {level}"
+
+    def test_template_ids_match_keys(self) -> None:
+        """Test that template IDs match their dictionary keys."""
+        for key, template in TEMPLATES.items():
+            assert template.id == key, f"Template key {key} doesn't match ID {template.id}"
+
+    def test_all_templates_have_metadata(self) -> None:
+        """Test that all templates have complete metadata."""
+        for template_id, template in TEMPLATES.items():
+            assert template.name, f"Template {template_id} missing name"
+            assert template.description, f"Template {template_id} missing description"
+            assert template.category, f"Template {template_id} missing category"
+            assert template.tags, f"Template {template_id} missing tags"
+            assert len(template.tags) > 0, f"Template {template_id} has empty tags"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -334,17 +334,17 @@ class TestTemplateValidation:
 
         for template_id, template in TEMPLATES.items():
             benchmark = template.config["benchmark"]
-            assert (
-                benchmark in valid_benchmarks
-            ), f"Template {template_id} has invalid benchmark: {benchmark}"
+            assert benchmark in valid_benchmarks, (
+                f"Template {template_id} has invalid benchmark: {benchmark}"
+            )
 
     def test_cybergym_templates_have_level(self) -> None:
         """Test that CyberGym templates have cybergym_level."""
         for template_id, template in TEMPLATES.items():
             if template.config["benchmark"] == "cybergym":
-                assert (
-                    "cybergym_level" in template.config
-                ), f"CyberGym template {template_id} missing cybergym_level"
+                assert "cybergym_level" in template.config, (
+                    f"CyberGym template {template_id} missing cybergym_level"
+                )
                 level = template.config["cybergym_level"]
                 assert 0 <= level <= 3, f"Template {template_id} has invalid level: {level}"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1038,7 +1038,7 @@ wheels = [
 
 [[package]]
 name = "mcpbr"
-version = "0.2.0"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

This PR implements a comprehensive configuration template system for mcpbr, making it easy for users to get started with pre-built configurations for common scenarios.

Fixes #99

## Changes

### New Features
- **9 pre-built templates** covering common use cases:
  - `filesystem`: Basic filesystem access (recommended default)
  - `filesystem-readonly`: Read-only safe exploration
  - `supermodel`: Advanced codebase analysis
  - `cybergym-basic` & `cybergym-advanced`: Security testing
  - `quick-test`: Single task for rapid development
  - `production`: Full-scale evaluation
  - `custom-python` & `custom-node`: Custom server templates

- **Interactive init**: `mcpbr init -i` for guided template selection with customization
- **Template gallery**: `mcpbr templates` command to browse available templates
- **Template filtering**: Filter by category or tags

### CLI Updates
- `mcpbr init -t <template-id>`: Create config from a specific template
- `mcpbr init -i`: Interactive mode with template selection
- `mcpbr init -l`: List available templates
- `mcpbr templates`: Browse all templates in a table
- `mcpbr templates -c <category>`: Filter by category
- `mcpbr templates --tag <tag>`: Filter by tag

### Implementation
- New `src/mcpbr/templates.py` module with template definitions
- Template dataclass with metadata (id, name, description, category, tags)
- YAML generation with template information in comments
- Backward-compatible: default behavior uses filesystem template

### Testing
- 31 unit tests for template functionality
- 19 CLI integration tests
- All existing tests pass (128 total)
- Test coverage for:
  - Template listing and filtering
  - YAML generation and validation
  - CLI command interactions
  - All templates create valid configs

### Documentation
- Comprehensive template guide in `docs/templates.md`
- Detailed description of each template
- Usage examples and best practices
- Template creation guide for contributors

## Example Usage

```bash
# List all templates
mcpbr templates

# Create config with quick-test template
mcpbr init -t quick-test

# Interactive mode
mcpbr init -i

# Filter templates by category
mcpbr templates -c Security

# Filter by tag
mcpbr templates --tag quick
```

## Breaking Changes

None. The changes are fully backward compatible. The default `mcpbr init` behavior now uses the `filesystem` template, which generates the same config as before.

## Checklist

- [x] Implementation complete with all features
- [x] Unit tests written and passing (50 new tests)
- [x] All existing tests pass
- [x] Documentation added (`docs/templates.md`)
- [x] CLI help text updated
- [x] Backward compatibility maintained
- [x] Examples tested manually
- [x] Interactive mode tested

## Screenshots

### Template Gallery
```
mcpbr templates
```
Shows a nice table with all 9 templates, categorized and tagged.

### Interactive Init
```
mcpbr init -i
```
Guides users through template selection and customization.

## Future Enhancements

Possible future improvements (out of scope for this PR):
- Community template contributions
- Template validation against schema
- Template versioning
- Remote template repositories
- Template search functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Template-based configuration system with predefined templates for filesystem, testing, security, production, and custom scenarios.
  * Interactive mode for guided configuration setup.
  * New templates command to browse and filter available templates by category or tag.

* **Documentation**
  * Added comprehensive templates documentation with quick start, examples, and best practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->