### PR TITLE
[Feature] Add Config Validation Command (fixes #79)

### DIFF
--- a/src/mcpbr/cli.py
+++ b/src/mcpbr/cli.py
@@ -658,9 +658,7 @@ def validate(config_path: Path) -> None:
         sys.exit(0)
     else:
         console.print("[red bold]Configuration validation failed.[/red bold]")
-        console.print(
-            "[dim]Fix the errors above and run validation again.[/dim]"
-        )
+        console.print("[dim]Fix the errors above and run validation again.[/dim]")
         sys.exit(1)
 
 

--- a/src/mcpbr/config_validator.py
+++ b/src/mcpbr/config_validator.py
@@ -1,0 +1,512 @@
+"""Configuration validation with detailed error messages and suggestions."""
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import ValidationError
+
+from .config import VALID_BENCHMARKS, VALID_HARNESSES, VALID_PROVIDERS, HarnessConfig
+
+
+@dataclass
+class ValidationError:
+    """A validation error with context and suggestions."""
+
+    field: str
+    error: str
+    line_number: int | None = None
+    suggestion: str | None = None
+
+
+@dataclass
+class ValidationResult:
+    """Result of configuration validation."""
+
+    valid: bool
+    errors: list[ValidationError]
+    warnings: list[ValidationError]
+
+    @property
+    def has_errors(self) -> bool:
+        """Check if there are any errors."""
+        return len(self.errors) > 0
+
+    @property
+    def has_warnings(self) -> bool:
+        """Check if there are any warnings."""
+        return len(self.warnings) > 0
+
+
+class ConfigValidator:
+    """Validates YAML/TOML configuration files for mcpbr."""
+
+    def __init__(self) -> None:
+        """Initialize the validator."""
+        self.errors: list[ValidationError] = []
+        self.warnings: list[ValidationError] = []
+
+    def validate_file(self, config_path: str | Path) -> ValidationResult:
+        """Validate a configuration file.
+
+        Args:
+            config_path: Path to the configuration file.
+
+        Returns:
+            ValidationResult with errors and warnings.
+        """
+        self.errors = []
+        self.warnings = []
+
+        path = Path(config_path)
+
+        # Check file exists
+        if not path.exists():
+            self.errors.append(
+                ValidationError(
+                    field="file",
+                    error=f"Configuration file not found: {path}",
+                    suggestion="Check the file path and ensure the file exists.",
+                )
+            )
+            return ValidationResult(valid=False, errors=self.errors, warnings=self.warnings)
+
+        # Check file extension
+        if path.suffix not in [".yaml", ".yml", ".toml"]:
+            self.warnings.append(
+                ValidationError(
+                    field="file",
+                    error=f"Unexpected file extension: {path.suffix}",
+                    suggestion="Configuration files should use .yaml, .yml, or .toml extension.",
+                )
+            )
+
+        # Read and parse file
+        try:
+            with open(path) as f:
+                content = f.read()
+                raw_config = self._parse_config(content, path.suffix)
+        except yaml.YAMLError as e:
+            error_msg = str(e)
+            line_num = None
+            if hasattr(e, "problem_mark"):
+                mark = e.problem_mark
+                line_num = mark.line + 1 if mark else None
+                error_msg = f"YAML syntax error at line {line_num}: {e.problem}"
+
+            self.errors.append(
+                ValidationError(
+                    field="syntax",
+                    error=error_msg,
+                    line_number=line_num,
+                    suggestion="Check YAML syntax. Common issues: incorrect indentation, missing colons, unquoted special characters.",
+                )
+            )
+            return ValidationResult(valid=False, errors=self.errors, warnings=self.warnings)
+        except Exception as e:
+            self.errors.append(
+                ValidationError(
+                    field="parsing",
+                    error=f"Failed to parse configuration file: {e}",
+                    suggestion="Ensure the file is valid YAML or TOML format.",
+                )
+            )
+            return ValidationResult(valid=False, errors=self.errors, warnings=self.warnings)
+
+        # Validate structure and fields
+        self._validate_structure(raw_config)
+
+        # Validate API key format (if Anthropic provider)
+        if raw_config.get("provider", "anthropic") == "anthropic":
+            self._validate_api_key()
+
+        # Try to create HarnessConfig to trigger Pydantic validation
+        if not self.has_errors:
+            self._validate_with_pydantic(raw_config)
+
+        return ValidationResult(
+            valid=not self.has_errors, errors=self.errors, warnings=self.warnings
+        )
+
+    def _parse_config(self, content: str, suffix: str) -> dict[str, Any]:
+        """Parse configuration file content.
+
+        Args:
+            content: File content.
+            suffix: File extension.
+
+        Returns:
+            Parsed configuration dictionary.
+        """
+        if suffix in [".yaml", ".yml"]:
+            return yaml.safe_load(content) or {}
+        elif suffix == ".toml":
+            try:
+                import tomllib
+            except ImportError:
+                try:
+                    import tomli as tomllib  # type: ignore
+                except ImportError:
+                    raise ImportError(
+                        "TOML support requires tomli package. Install with: pip install tomli"
+                    )
+            return tomllib.loads(content)
+        else:
+            raise ValueError(f"Unsupported file format: {suffix}")
+
+    def _validate_structure(self, config: dict[str, Any]) -> None:
+        """Validate the configuration structure.
+
+        Args:
+            config: Parsed configuration dictionary.
+        """
+        # Check for mcp_server section
+        if "mcp_server" not in config:
+            self.errors.append(
+                ValidationError(
+                    field="mcp_server",
+                    error="Missing required field: mcp_server",
+                    suggestion="Add an 'mcp_server' section with 'command' and 'args' fields.",
+                )
+            )
+        else:
+            self._validate_mcp_server(config["mcp_server"])
+
+        # Validate provider
+        provider = config.get("provider", "anthropic")
+        if provider not in VALID_PROVIDERS:
+            self.errors.append(
+                ValidationError(
+                    field="provider",
+                    error=f"Invalid provider: '{provider}'",
+                    suggestion=f"Valid providers: {', '.join(VALID_PROVIDERS)}",
+                )
+            )
+
+        # Validate agent_harness
+        harness = config.get("agent_harness", "claude-code")
+        if harness not in VALID_HARNESSES:
+            self.errors.append(
+                ValidationError(
+                    field="agent_harness",
+                    error=f"Invalid agent_harness: '{harness}'",
+                    suggestion=f"Valid harnesses: {', '.join(VALID_HARNESSES)}",
+                )
+            )
+
+        # Validate benchmark
+        benchmark = config.get("benchmark", "swe-bench")
+        if benchmark not in VALID_BENCHMARKS:
+            self.errors.append(
+                ValidationError(
+                    field="benchmark",
+                    error=f"Invalid benchmark: '{benchmark}'",
+                    suggestion=f"Valid benchmarks: {', '.join(VALID_BENCHMARKS)}",
+                )
+            )
+
+        # Validate model (just check it's a non-empty string)
+        model = config.get("model")
+        if model is not None and (not isinstance(model, str) or not model.strip()):
+            self.errors.append(
+                ValidationError(
+                    field="model",
+                    error="Model must be a non-empty string",
+                    suggestion="Use a valid Anthropic model ID like 'claude-sonnet-4-5-20250514' or 'sonnet'",
+                )
+            )
+
+        # Validate numeric fields
+        self._validate_numeric_field(
+            config, "timeout_seconds", min_value=30, suggestion="Should be at least 30 seconds"
+        )
+        self._validate_numeric_field(
+            config,
+            "max_concurrent",
+            min_value=1,
+            suggestion="Should be at least 1 for concurrent execution",
+        )
+        self._validate_numeric_field(
+            config, "max_iterations", min_value=1, suggestion="Should be at least 1"
+        )
+        self._validate_numeric_field(
+            config, "sample_size", min_value=1, required=False, allow_null=True
+        )
+        self._validate_numeric_field(
+            config,
+            "cybergym_level",
+            min_value=0,
+            max_value=3,
+            required=False,
+            suggestion="CyberGym level must be between 0 and 3",
+        )
+
+        # Validate agent_prompt placeholder
+        agent_prompt = config.get("agent_prompt")
+        if agent_prompt and isinstance(agent_prompt, str):
+            if "{problem_statement}" not in agent_prompt:
+                self.warnings.append(
+                    ValidationError(
+                        field="agent_prompt",
+                        error="agent_prompt doesn't contain {problem_statement} placeholder",
+                        suggestion="Include {problem_statement} placeholder to inject the task description",
+                    )
+                )
+
+    def _validate_mcp_server(self, mcp_server: Any) -> None:
+        """Validate MCP server configuration.
+
+        Args:
+            mcp_server: MCP server configuration dictionary.
+        """
+        if not isinstance(mcp_server, dict):
+            self.errors.append(
+                ValidationError(
+                    field="mcp_server",
+                    error="mcp_server must be a dictionary/object",
+                    suggestion="Use 'mcp_server:' followed by indented fields like 'command:' and 'args:'",
+                )
+            )
+            return
+
+        # Check required command field
+        if "command" not in mcp_server:
+            self.errors.append(
+                ValidationError(
+                    field="mcp_server.command",
+                    error="Missing required field: command",
+                    suggestion="Add 'command' field (e.g., 'npx', 'python', 'uvx')",
+                )
+            )
+        elif not isinstance(mcp_server["command"], str) or not mcp_server["command"].strip():
+            self.errors.append(
+                ValidationError(
+                    field="mcp_server.command",
+                    error="command must be a non-empty string",
+                    suggestion="Provide the executable command like 'npx' or 'python'",
+                )
+            )
+
+        # Validate args field
+        args = mcp_server.get("args", [])
+        if not isinstance(args, list):
+            self.errors.append(
+                ValidationError(
+                    field="mcp_server.args",
+                    error="args must be a list/array",
+                    suggestion="Use YAML list syntax with '-' prefix for each argument",
+                )
+            )
+        else:
+            # Check for {workdir} placeholder
+            has_workdir = any("{workdir}" in str(arg) for arg in args)
+            if not has_workdir:
+                self.warnings.append(
+                    ValidationError(
+                        field="mcp_server.args",
+                        error="args doesn't contain {workdir} placeholder",
+                        suggestion="Include {workdir} placeholder to pass the task working directory to your MCP server",
+                    )
+                )
+
+        # Validate env field (optional)
+        env = mcp_server.get("env")
+        if env is not None:
+            if not isinstance(env, dict):
+                self.errors.append(
+                    ValidationError(
+                        field="mcp_server.env",
+                        error="env must be a dictionary/object",
+                        suggestion="Use key-value pairs for environment variables",
+                    )
+                )
+            else:
+                # Check for environment variable references
+                for key, value in env.items():
+                    if isinstance(value, str) and "${" in value:
+                        # Extract variable names
+                        var_refs = re.findall(r"\$\{(\w+)\}", value)
+                        for var in var_refs:
+                            if var not in os.environ:
+                                self.warnings.append(
+                                    ValidationError(
+                                        field=f"mcp_server.env.{key}",
+                                        error=f"Environment variable ${{{var}}} is not set",
+                                        suggestion=f"Set {var} environment variable before running",
+                                    )
+                                )
+
+        # Validate name field (optional)
+        name = mcp_server.get("name")
+        if name is not None and (not isinstance(name, str) or not name.strip()):
+            self.errors.append(
+                ValidationError(
+                    field="mcp_server.name",
+                    error="name must be a non-empty string if provided",
+                    suggestion="Provide a descriptive name for the MCP server",
+                )
+            )
+
+    def _validate_numeric_field(
+        self,
+        config: dict[str, Any],
+        field: str,
+        min_value: int | None = None,
+        max_value: int | None = None,
+        required: bool = False,
+        allow_null: bool = False,
+        suggestion: str | None = None,
+    ) -> None:
+        """Validate a numeric configuration field.
+
+        Args:
+            config: Configuration dictionary.
+            field: Field name to validate.
+            min_value: Minimum allowed value.
+            max_value: Maximum allowed value.
+            required: Whether the field is required.
+            allow_null: Whether null/None values are allowed.
+            suggestion: Custom suggestion message.
+        """
+        value = config.get(field)
+
+        if value is None:
+            if required and not allow_null:
+                self.errors.append(
+                    ValidationError(
+                        field=field,
+                        error=f"Missing required field: {field}",
+                        suggestion=suggestion or f"Add '{field}' field with a numeric value",
+                    )
+                )
+            return
+
+        if not isinstance(value, (int, float)):
+            self.errors.append(
+                ValidationError(
+                    field=field,
+                    error=f"{field} must be a number, got {type(value).__name__}",
+                    suggestion=suggestion or f"Use a numeric value for {field}",
+                )
+            )
+            return
+
+        if min_value is not None and value < min_value:
+            self.errors.append(
+                ValidationError(
+                    field=field,
+                    error=f"{field} must be at least {min_value}, got {value}",
+                    suggestion=suggestion or f"Set {field} to {min_value} or higher",
+                )
+            )
+
+        if max_value is not None and value > max_value:
+            self.errors.append(
+                ValidationError(
+                    field=field,
+                    error=f"{field} must be at most {max_value}, got {value}",
+                    suggestion=suggestion or f"Set {field} to {max_value} or lower",
+                )
+            )
+
+    def _validate_api_key(self) -> None:
+        """Validate API key format for Anthropic provider."""
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+
+        if not api_key:
+            self.warnings.append(
+                ValidationError(
+                    field="environment",
+                    error="ANTHROPIC_API_KEY environment variable is not set",
+                    suggestion="Set ANTHROPIC_API_KEY before running evaluation",
+                )
+            )
+            return
+
+        # Check basic format (Anthropic keys start with 'sk-ant-')
+        if not api_key.startswith("sk-ant-"):
+            self.warnings.append(
+                ValidationError(
+                    field="environment",
+                    error="ANTHROPIC_API_KEY doesn't match expected format",
+                    suggestion="Anthropic API keys should start with 'sk-ant-'. Verify your API key.",
+                )
+            )
+        elif len(api_key) < 20:
+            self.warnings.append(
+                ValidationError(
+                    field="environment",
+                    error="ANTHROPIC_API_KEY seems too short",
+                    suggestion="Anthropic API keys are typically longer. Verify your API key.",
+                )
+            )
+
+    def _validate_with_pydantic(self, config: dict[str, Any]) -> None:
+        """Validate configuration using Pydantic models.
+
+        Args:
+            config: Configuration dictionary.
+        """
+        try:
+            HarnessConfig(**config)
+        except ValidationError as e:
+            for error in e.errors():
+                field_path = ".".join(str(loc) for loc in error["loc"])
+                error_msg = error["msg"]
+
+                # Try to provide helpful suggestions based on error type
+                suggestion = self._get_pydantic_error_suggestion(error)
+
+                self.errors.append(
+                    ValidationError(
+                        field=field_path,
+                        error=error_msg,
+                        suggestion=suggestion,
+                    )
+                )
+
+    def _get_pydantic_error_suggestion(self, error: dict[str, Any]) -> str | None:
+        """Generate helpful suggestions for Pydantic validation errors.
+
+        Args:
+            error: Pydantic error dictionary.
+
+        Returns:
+            Suggestion string or None.
+        """
+        error_type = error.get("type", "")
+        field = error.get("loc", [])[-1] if error.get("loc") else ""
+
+        suggestions = {
+            "missing": f"Add the required '{field}' field to your configuration",
+            "string_type": f"'{field}' should be a text string, not a number or other type",
+            "int_type": f"'{field}' should be an integer number",
+            "value_error": "Check the field value meets the validation requirements",
+        }
+
+        for error_pattern, suggestion in suggestions.items():
+            if error_pattern in error_type:
+                return suggestion
+
+        return None
+
+    @property
+    def has_errors(self) -> bool:
+        """Check if there are any validation errors."""
+        return len(self.errors) > 0
+
+
+def validate_config(config_path: str | Path) -> ValidationResult:
+    """Validate a configuration file.
+
+    Args:
+        config_path: Path to the configuration file.
+
+    Returns:
+        ValidationResult with errors and warnings.
+    """
+    validator = ConfigValidator()
+    return validator.validate_file(config_path)

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -4,9 +4,7 @@ import os
 import tempfile
 from pathlib import Path
 
-import pytest
-
-from mcpbr.config_validator import ConfigValidator, validate_config
+from mcpbr.config_validator import validate_config
 
 
 class TestConfigValidator:

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -1,0 +1,810 @@
+"""Tests for configuration validation."""
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mcpbr.config_validator import ConfigValidator, validate_config
+
+
+class TestConfigValidator:
+    """Tests for ConfigValidator class."""
+
+    def test_valid_yaml_config(self) -> None:
+        """Test validation of a valid YAML config."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - "-y"
+    - "@modelcontextprotocol/server-filesystem"
+    - "{workdir}"
+
+provider: anthropic
+agent_harness: claude-code
+model: claude-sonnet-4-5-20250514
+benchmark: swe-bench
+sample_size: 10
+timeout_seconds: 300
+max_concurrent: 4
+max_iterations: 10
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            assert result.valid
+            assert not result.has_errors
+        finally:
+            Path(config_path).unlink()
+
+    def test_missing_file(self) -> None:
+        """Test validation of non-existent file."""
+        result = validate_config("/nonexistent/config.yaml")
+
+        assert not result.valid
+        assert result.has_errors
+        assert len(result.errors) == 1
+        assert "not found" in result.errors[0].error.lower()
+
+    def test_invalid_yaml_syntax(self) -> None:
+        """Test validation of file with YAML syntax errors."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - invalid indentation
+   - wrong indent
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            assert not result.valid
+            assert result.has_errors
+            # Should have YAML syntax error
+            assert any("syntax" in err.error.lower() for err in result.errors)
+        finally:
+            Path(config_path).unlink()
+
+    def test_missing_mcp_server(self) -> None:
+        """Test validation when mcp_server is missing."""
+        yaml_content = """
+provider: anthropic
+model: claude-sonnet-4-5-20250514
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            assert not result.valid
+            assert result.has_errors
+            assert any("mcp_server" in err.field for err in result.errors)
+        finally:
+            Path(config_path).unlink()
+
+    def test_missing_command_in_mcp_server(self) -> None:
+        """Test validation when mcp_server.command is missing."""
+        yaml_content = """
+mcp_server:
+  args:
+    - "test"
+
+provider: anthropic
+model: claude-sonnet-4-5-20250514
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            assert not result.valid
+            assert result.has_errors
+            assert any("command" in err.field for err in result.errors)
+        finally:
+            Path(config_path).unlink()
+
+    def test_invalid_provider(self) -> None:
+        """Test validation with invalid provider."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - "test"
+
+provider: invalid-provider
+model: claude-sonnet-4-5-20250514
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            assert not result.valid
+            assert result.has_errors
+            assert any("provider" in err.field for err in result.errors)
+            assert any("invalid" in err.error.lower() for err in result.errors)
+        finally:
+            Path(config_path).unlink()
+
+    def test_invalid_harness(self) -> None:
+        """Test validation with invalid agent_harness."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - "test"
+
+provider: anthropic
+agent_harness: invalid-harness
+model: claude-sonnet-4-5-20250514
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            assert not result.valid
+            assert result.has_errors
+            assert any("agent_harness" in err.field for err in result.errors)
+        finally:
+            Path(config_path).unlink()
+
+    def test_invalid_benchmark(self) -> None:
+        """Test validation with invalid benchmark."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - "test"
+
+provider: anthropic
+benchmark: invalid-benchmark
+model: claude-sonnet-4-5-20250514
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            assert not result.valid
+            assert result.has_errors
+            assert any("benchmark" in err.field for err in result.errors)
+        finally:
+            Path(config_path).unlink()
+
+    def test_timeout_too_low(self) -> None:
+        """Test validation when timeout is below minimum."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - "test"
+
+provider: anthropic
+model: claude-sonnet-4-5-20250514
+timeout_seconds: 10
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            assert not result.valid
+            assert result.has_errors
+            assert any("timeout_seconds" in err.field for err in result.errors)
+            assert any("30" in err.error for err in result.errors)
+        finally:
+            Path(config_path).unlink()
+
+    def test_max_concurrent_too_low(self) -> None:
+        """Test validation when max_concurrent is below minimum."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - "test"
+
+provider: anthropic
+model: claude-sonnet-4-5-20250514
+max_concurrent: 0
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            assert not result.valid
+            assert result.has_errors
+            assert any("max_concurrent" in err.field for err in result.errors)
+        finally:
+            Path(config_path).unlink()
+
+    def test_cybergym_level_out_of_range(self) -> None:
+        """Test validation when cybergym_level is out of range."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - "test"
+
+provider: anthropic
+model: claude-sonnet-4-5-20250514
+benchmark: cybergym
+cybergym_level: 5
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            assert not result.valid
+            assert result.has_errors
+            assert any("cybergym_level" in err.field for err in result.errors)
+        finally:
+            Path(config_path).unlink()
+
+    def test_warning_for_missing_workdir_placeholder(self) -> None:
+        """Test that a warning is issued when {workdir} is missing from args."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - "-y"
+    - "@modelcontextprotocol/server-filesystem"
+
+provider: anthropic
+model: claude-sonnet-4-5-20250514
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            # Should be valid but have warnings
+            assert result.valid
+            assert result.has_warnings
+            assert any("workdir" in warn.error.lower() for warn in result.warnings)
+        finally:
+            Path(config_path).unlink()
+
+    def test_warning_for_missing_problem_statement_placeholder(self) -> None:
+        """Test that a warning is issued when {problem_statement} is missing from agent_prompt."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - "{workdir}"
+
+provider: anthropic
+model: claude-sonnet-4-5-20250514
+agent_prompt: "Fix this bug now"
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            # Should be valid but have warnings
+            assert result.valid
+            assert result.has_warnings
+            assert any("problem_statement" in warn.error.lower() for warn in result.warnings)
+        finally:
+            Path(config_path).unlink()
+
+    def test_args_not_a_list(self) -> None:
+        """Test validation when args is not a list."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args: "not-a-list"
+
+provider: anthropic
+model: claude-sonnet-4-5-20250514
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            assert not result.valid
+            assert result.has_errors
+            assert any("args" in err.field for err in result.errors)
+            assert any("list" in err.error.lower() for err in result.errors)
+        finally:
+            Path(config_path).unlink()
+
+    def test_env_not_a_dict(self) -> None:
+        """Test validation when env is not a dictionary."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - "{workdir}"
+  env: ["not", "a", "dict"]
+
+provider: anthropic
+model: claude-sonnet-4-5-20250514
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            assert not result.valid
+            assert result.has_errors
+            assert any("env" in err.field for err in result.errors)
+        finally:
+            Path(config_path).unlink()
+
+    def test_empty_command(self) -> None:
+        """Test validation when command is empty string."""
+        yaml_content = """
+mcp_server:
+  command: ""
+  args:
+    - "{workdir}"
+
+provider: anthropic
+model: claude-sonnet-4-5-20250514
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            assert not result.valid
+            assert result.has_errors
+            assert any("command" in err.field for err in result.errors)
+        finally:
+            Path(config_path).unlink()
+
+    def test_empty_model(self) -> None:
+        """Test validation when model is empty string."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - "{workdir}"
+
+provider: anthropic
+model: ""
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            assert not result.valid
+            assert result.has_errors
+            assert any("model" in err.field for err in result.errors)
+        finally:
+            Path(config_path).unlink()
+
+    def test_numeric_field_wrong_type(self) -> None:
+        """Test validation when a numeric field has wrong type."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - "{workdir}"
+
+provider: anthropic
+model: claude-sonnet-4-5-20250514
+timeout_seconds: "not-a-number"
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            assert not result.valid
+            assert result.has_errors
+            assert any("timeout_seconds" in err.field for err in result.errors)
+        finally:
+            Path(config_path).unlink()
+
+    def test_multiple_errors(self) -> None:
+        """Test validation with multiple errors."""
+        yaml_content = """
+mcp_server:
+  command: ""
+  args: "not-a-list"
+
+provider: invalid-provider
+agent_harness: invalid-harness
+benchmark: invalid-benchmark
+model: ""
+timeout_seconds: 10
+max_concurrent: 0
+cybergym_level: 5
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            assert not result.valid
+            assert result.has_errors
+            # Should have multiple errors
+            assert len(result.errors) >= 5
+        finally:
+            Path(config_path).unlink()
+
+    def test_warning_for_undefined_env_var(self) -> None:
+        """Test that a warning is issued for undefined environment variables."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - "{workdir}"
+  env:
+    MY_VAR: "${UNDEFINED_ENV_VAR}"
+
+provider: anthropic
+model: claude-sonnet-4-5-20250514
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            # Make sure the variable is not set
+            if "UNDEFINED_ENV_VAR" in os.environ:
+                del os.environ["UNDEFINED_ENV_VAR"]
+
+            result = validate_config(config_path)
+            # Should be valid but have warnings
+            assert result.valid
+            assert result.has_warnings
+            assert any("UNDEFINED_ENV_VAR" in warn.error for warn in result.warnings)
+        finally:
+            Path(config_path).unlink()
+
+    def test_no_warning_for_defined_env_var(self) -> None:
+        """Test that no warning is issued for defined environment variables."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - "{workdir}"
+  env:
+    MY_VAR: "${DEFINED_ENV_VAR}"
+
+provider: anthropic
+model: claude-sonnet-4-5-20250514
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            # Set the variable
+            os.environ["DEFINED_ENV_VAR"] = "test-value"
+
+            result = validate_config(config_path)
+            assert result.valid
+            # Should not have warning about this specific env var
+            assert not any("DEFINED_ENV_VAR" in warn.error for warn in result.warnings)
+        finally:
+            Path(config_path).unlink()
+            if "DEFINED_ENV_VAR" in os.environ:
+                del os.environ["DEFINED_ENV_VAR"]
+
+    def test_valid_config_with_all_optional_fields(self) -> None:
+        """Test validation of config with all optional fields set."""
+        yaml_content = """
+mcp_server:
+  name: my-server
+  command: python
+  args:
+    - "-m"
+    - "myserver"
+    - "{workdir}"
+  env:
+    DEBUG: "true"
+
+provider: anthropic
+agent_harness: claude-code
+benchmark: cybergym
+model: claude-sonnet-4-5-20250514
+dataset: custom/dataset
+agent_prompt: "Fix this: {problem_statement}"
+cybergym_level: 2
+sample_size: 50
+timeout_seconds: 600
+max_concurrent: 8
+max_iterations: 20
+use_prebuilt_images: false
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            assert result.valid
+            assert not result.has_errors
+        finally:
+            Path(config_path).unlink()
+
+    def test_wrong_file_extension_warning(self) -> None:
+        """Test that a warning is issued for unexpected file extensions."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - "{workdir}"
+
+provider: anthropic
+model: claude-sonnet-4-5-20250514
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            # Should be valid but have warning about extension
+            assert result.has_warnings
+            assert any("extension" in warn.error.lower() for warn in result.warnings)
+        finally:
+            Path(config_path).unlink()
+
+    def test_yml_extension_accepted(self) -> None:
+        """Test that .yml extension is accepted."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - "{workdir}"
+
+provider: anthropic
+model: claude-sonnet-4-5-20250514
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            assert result.valid
+            # Should not have warning about extension for .yml
+            assert not any(
+                "extension" in warn.error.lower() and ".yml" in warn.error
+                for warn in result.warnings
+            )
+        finally:
+            Path(config_path).unlink()
+
+    def test_empty_name_error(self) -> None:
+        """Test validation when name is empty string."""
+        yaml_content = """
+mcp_server:
+  name: ""
+  command: npx
+  args:
+    - "{workdir}"
+
+provider: anthropic
+model: claude-sonnet-4-5-20250514
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            assert not result.valid
+            assert result.has_errors
+            assert any("name" in err.field for err in result.errors)
+        finally:
+            Path(config_path).unlink()
+
+    def test_negative_sample_size_error(self) -> None:
+        """Test validation when sample_size is negative."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - "{workdir}"
+
+provider: anthropic
+model: claude-sonnet-4-5-20250514
+sample_size: -5
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            result = validate_config(config_path)
+            assert not result.valid
+            assert result.has_errors
+            assert any("sample_size" in err.field for err in result.errors)
+        finally:
+            Path(config_path).unlink()
+
+
+class TestAPIKeyValidation:
+    """Tests for API key validation."""
+
+    def test_missing_api_key_warning(self) -> None:
+        """Test that a warning is issued when ANTHROPIC_API_KEY is not set."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - "{workdir}"
+
+provider: anthropic
+model: claude-sonnet-4-5-20250514
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            # Temporarily remove the API key
+            old_key = os.environ.pop("ANTHROPIC_API_KEY", None)
+
+            result = validate_config(config_path)
+            # Should be valid but have warning
+            assert result.valid
+            assert result.has_warnings
+            assert any("ANTHROPIC_API_KEY" in warn.error for warn in result.warnings)
+        finally:
+            Path(config_path).unlink()
+            if old_key:
+                os.environ["ANTHROPIC_API_KEY"] = old_key
+
+    def test_valid_api_key_no_warning(self) -> None:
+        """Test that no warning is issued for valid API key format."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - "{workdir}"
+
+provider: anthropic
+model: claude-sonnet-4-5-20250514
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            # Set a valid-looking API key
+            old_key = os.environ.get("ANTHROPIC_API_KEY")
+            os.environ["ANTHROPIC_API_KEY"] = "sk-ant-api03-test-key-12345678901234567890"
+
+            result = validate_config(config_path)
+            assert result.valid
+            # Should not have API key warnings
+            assert not any(
+                "ANTHROPIC_API_KEY" in warn.error and "format" in warn.error.lower()
+                for warn in result.warnings
+            )
+        finally:
+            Path(config_path).unlink()
+            if old_key:
+                os.environ["ANTHROPIC_API_KEY"] = old_key
+            else:
+                os.environ.pop("ANTHROPIC_API_KEY", None)
+
+    def test_invalid_api_key_format_warning(self) -> None:
+        """Test that a warning is issued for invalid API key format."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - "{workdir}"
+
+provider: anthropic
+model: claude-sonnet-4-5-20250514
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            # Set an invalid API key
+            old_key = os.environ.get("ANTHROPIC_API_KEY")
+            os.environ["ANTHROPIC_API_KEY"] = "invalid-key"
+
+            result = validate_config(config_path)
+            assert result.valid
+            assert result.has_warnings
+            assert any(
+                "ANTHROPIC_API_KEY" in warn.error and "format" in warn.error.lower()
+                for warn in result.warnings
+            )
+        finally:
+            Path(config_path).unlink()
+            if old_key:
+                os.environ["ANTHROPIC_API_KEY"] = old_key
+            else:
+                os.environ.pop("ANTHROPIC_API_KEY", None)
+
+    def test_short_api_key_warning(self) -> None:
+        """Test that a warning is issued for too-short API keys."""
+        yaml_content = """
+mcp_server:
+  command: npx
+  args:
+    - "{workdir}"
+
+provider: anthropic
+model: claude-sonnet-4-5-20250514
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            config_path = f.name
+
+        try:
+            # Set a too-short API key
+            old_key = os.environ.get("ANTHROPIC_API_KEY")
+            os.environ["ANTHROPIC_API_KEY"] = "sk-ant-short"
+
+            result = validate_config(config_path)
+            assert result.valid
+            assert result.has_warnings
+            assert any("too short" in warn.error.lower() for warn in result.warnings)
+        finally:
+            Path(config_path).unlink()
+            if old_key:
+                os.environ["ANTHROPIC_API_KEY"] = old_key
+            else:
+                os.environ.pop("ANTHROPIC_API_KEY", None)

--- a/uv.lock
+++ b/uv.lock
@@ -1038,7 +1038,7 @@ wheels = [
 
 [[package]]
 name = "mcpbr"
-version = "0.2.0"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Implements `mcpbr config validate` command for comprehensive configuration file validation
- Validates YAML/TOML syntax, required fields, value ranges, and API key format
- Provides detailed error messages with line numbers and helpful suggestions
- Returns CI-friendly exit codes (0 for valid, 1 for invalid)

## Changes
- **New module:** `src/mcpbr/config_validator.py` - Core validation logic with detailed error reporting
- **CLI enhancement:** Added `config` command group with `validate` subcommand
- **Comprehensive tests:** 30 test cases covering all validation scenarios including:
  - Valid configurations
  - Missing/invalid fields
  - Syntax errors
  - Type validation
  - Range validation
  - API key format validation
  - Environment variable validation
  - Edge cases

## Features
✅ YAML/TOML syntax validation with line numbers
✅ Required field validation
✅ Provider/harness/benchmark validation
✅ Numeric field range validation (timeout, max_concurrent, etc.)
✅ API key format checking (without connectivity test)
✅ Environment variable reference detection
✅ Helpful error messages with actionable suggestions
✅ Warning system for non-blocking issues
✅ CI-friendly exit codes

## Test Plan
- [x] All new tests pass (30 test cases)
- [x] All existing tests pass (108 non-integration tests)
- [x] Manual testing with valid config
- [x] Manual testing with invalid configs
- [x] Manual testing with YAML syntax errors
- [x] Verified error messages are clear and helpful
- [x] Verified exit codes work correctly

## Example Usage
```bash
# Validate a config file
mcpbr config validate config.yaml

# Example output for invalid config
Found 4 error(s):

  1. mcp_server.command
     Error: Missing required field: command
     Suggestion: Add 'command' field (e.g., 'npx', 'python', 'uvx')

  2. provider
     Error: Invalid provider: 'invalid-provider'
     Suggestion: Valid providers: anthropic
```

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)