### PR TITLE
[Feature] Add XML Export for Results (fixes #54)

### DIFF
--- a/src/mcpbr/cli.py
+++ b/src/mcpbr/cli.py
@@ -13,7 +13,7 @@ from .docker_env import cleanup_orphaned_containers, register_signal_handlers
 from .harness import run_evaluation
 from .harnesses import list_available_harnesses
 from .models import DEFAULT_MODEL, list_supported_models
-from .reporting import print_summary, save_json_results, save_markdown_report, save_yaml_results
+from .reporting import print_summary, save_json_results, save_markdown_report, save_xml_results, save_yaml_results
 
 console = Console()
 
@@ -152,6 +152,14 @@ def main() -> None:
     help="Path to save Markdown report",
 )
 @click.option(
+    "--output-xml",
+    "-x",
+    "xml_path",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Path to save XML results",
+)
+@click.option(
     "--verbose",
     "-v",
     "verbosity",
@@ -212,6 +220,7 @@ def run(
     baseline_only: bool,
     output_path: Path | None,
     report_path: Path | None,
+    xml_path: Path | None,
     verbosity: int,
     log_file_path: Path | None,
     log_dir_path: Path | None,
@@ -337,6 +346,10 @@ def run(
     if report_path:
         save_markdown_report(results, report_path)
         console.print(f"[green]Report saved to {report_path}[/green]")
+
+    if xml_path:
+        save_xml_results(results, xml_path)
+        console.print(f"[green]XML results saved to {xml_path}[/green]")
 
 
 @main.command(context_settings={"help_option_names": ["-h", "--help"]})

--- a/src/mcpbr/cli.py
+++ b/src/mcpbr/cli.py
@@ -13,7 +13,13 @@ from .docker_env import cleanup_orphaned_containers, register_signal_handlers
 from .harness import run_evaluation
 from .harnesses import list_available_harnesses
 from .models import DEFAULT_MODEL, list_supported_models
-from .reporting import print_summary, save_json_results, save_markdown_report, save_xml_results, save_yaml_results
+from .reporting import (
+    print_summary,
+    save_json_results,
+    save_markdown_report,
+    save_xml_results,
+    save_yaml_results,
+)
 
 console = Console()
 

--- a/src/mcpbr/reporting.py
+++ b/src/mcpbr/reporting.py
@@ -1,8 +1,10 @@
 """Reporting utilities for evaluation results."""
 
 import json
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import TYPE_CHECKING
+from xml.dom import minidom
 
 import yaml
 from rich.console import Console
@@ -240,3 +242,146 @@ def save_yaml_results(results: "EvaluationResults", output_path: Path) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with open(output_path, "w") as f:
         yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+
+def save_xml_results(results: "EvaluationResults", output_path: Path) -> None:
+    """Save evaluation results to an XML file.
+
+    Args:
+        results: Evaluation results.
+        output_path: Path to save the XML file.
+    """
+    # Create root element
+    root = ET.Element("mcpbr-evaluation")
+    root.set("version", "1.0")
+
+    # Add metadata section
+    metadata = ET.SubElement(root, "metadata")
+    ET.SubElement(metadata, "timestamp").text = results.metadata["timestamp"]
+
+    # Add config subsection
+    config = ET.SubElement(metadata, "config")
+    for key, value in results.metadata["config"].items():
+        if value is not None:
+            ET.SubElement(config, key).text = str(value)
+
+    # Add MCP server subsection
+    mcp_server = ET.SubElement(metadata, "mcp-server")
+    for key, value in results.metadata["mcp_server"].items():
+        if isinstance(value, list):
+            list_elem = ET.SubElement(mcp_server, key)
+            for item in value:
+                ET.SubElement(list_elem, "item").text = str(item)
+        elif isinstance(value, dict):
+            dict_elem = ET.SubElement(mcp_server, key)
+            for k, v in value.items():
+                ET.SubElement(dict_elem, k).text = str(v)
+        else:
+            ET.SubElement(mcp_server, key).text = str(value)
+
+    # Add summary section
+    summary = ET.SubElement(root, "summary")
+
+    # MCP summary
+    mcp_summary = ET.SubElement(summary, "mcp")
+    ET.SubElement(mcp_summary, "resolved").text = str(results.summary["mcp"]["resolved"])
+    ET.SubElement(mcp_summary, "total").text = str(results.summary["mcp"]["total"])
+    ET.SubElement(mcp_summary, "rate").text = f"{results.summary['mcp']['rate']:.4f}"
+
+    # Baseline summary
+    baseline_summary = ET.SubElement(summary, "baseline")
+    ET.SubElement(baseline_summary, "resolved").text = str(results.summary["baseline"]["resolved"])
+    ET.SubElement(baseline_summary, "total").text = str(results.summary["baseline"]["total"])
+    ET.SubElement(baseline_summary, "rate").text = f"{results.summary['baseline']['rate']:.4f}"
+
+    # Improvement
+    ET.SubElement(summary, "improvement").text = results.summary["improvement"]
+
+    # Add tasks section
+    tasks = ET.SubElement(root, "tasks")
+    for task in results.tasks:
+        task_elem = ET.SubElement(tasks, "task")
+        task_elem.set("id", task.instance_id)
+
+        # Add MCP result if present
+        if task.mcp:
+            mcp_result = ET.SubElement(task_elem, "mcp")
+            _add_task_result_elements(mcp_result, task.mcp)
+
+        # Add baseline result if present
+        if task.baseline:
+            baseline_result = ET.SubElement(task_elem, "baseline")
+            _add_task_result_elements(baseline_result, task.baseline)
+
+    # Pretty print the XML
+    xml_string = ET.tostring(root, encoding="unicode")
+    dom = minidom.parseString(xml_string)
+    pretty_xml = dom.toprettyxml(indent="  ")
+
+    # Remove extra blank lines
+    lines = [line for line in pretty_xml.split("\n") if line.strip()]
+    pretty_xml = "\n".join(lines)
+
+    # Save to file
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(pretty_xml)
+
+
+def _add_task_result_elements(parent: ET.Element, result: dict) -> None:
+    """Add task result elements to parent XML element.
+
+    Args:
+        parent: Parent XML element to add result data to.
+        result: Task result dictionary.
+    """
+    # Add simple boolean/string fields
+    if "resolved" in result:
+        ET.SubElement(parent, "resolved").text = str(result["resolved"]).lower()
+    if "patch_generated" in result:
+        ET.SubElement(parent, "patch-generated").text = str(result["patch_generated"]).lower()
+    if "patch_applied" in result:
+        ET.SubElement(parent, "patch-applied").text = str(result["patch_applied"]).lower()
+    if "error" in result:
+        ET.SubElement(parent, "error").text = str(result["error"])
+
+    # Add iterations and tool_calls
+    if "iterations" in result:
+        ET.SubElement(parent, "iterations").text = str(result["iterations"])
+    if "tool_calls" in result:
+        ET.SubElement(parent, "tool-calls").text = str(result["tool_calls"])
+
+    # Add tokens subsection
+    if "tokens" in result:
+        tokens = ET.SubElement(parent, "tokens")
+        ET.SubElement(tokens, "input").text = str(result["tokens"]["input"])
+        ET.SubElement(tokens, "output").text = str(result["tokens"]["output"])
+
+    # Add tool_usage subsection if present
+    if "tool_usage" in result:
+        tool_usage = ET.SubElement(parent, "tool-usage")
+        for tool_name, count in result["tool_usage"].items():
+            tool_elem = ET.SubElement(tool_usage, "tool")
+            tool_elem.set("name", tool_name)
+            tool_elem.text = str(count)
+
+    # Add test results if present
+    if "fail_to_pass" in result:
+        fail_to_pass = ET.SubElement(parent, "fail-to-pass")
+        ET.SubElement(fail_to_pass, "passed").text = str(result["fail_to_pass"]["passed"])
+        ET.SubElement(fail_to_pass, "total").text = str(result["fail_to_pass"]["total"])
+
+    if "pass_to_pass" in result:
+        pass_to_pass = ET.SubElement(parent, "pass-to-pass")
+        ET.SubElement(pass_to_pass, "passed").text = str(result["pass_to_pass"]["passed"])
+        ET.SubElement(pass_to_pass, "total").text = str(result["pass_to_pass"]["total"])
+
+    # Add messages if present
+    if "messages" in result:
+        messages = ET.SubElement(parent, "messages")
+        for msg in result["messages"]:
+            msg_elem = ET.SubElement(messages, "message")
+            if isinstance(msg, dict):
+                for key, value in msg.items():
+                    ET.SubElement(msg_elem, key).text = str(value)
+            else:
+                msg_elem.text = str(msg)

--- a/src/mcpbr/schemas/results.xsd
+++ b/src/mcpbr/schemas/results.xsd
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <!-- Root element -->
+  <xs:element name="mcpbr-evaluation">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="metadata" type="MetadataType"/>
+        <xs:element name="summary" type="SummaryType"/>
+        <xs:element name="tasks" type="TasksType"/>
+      </xs:sequence>
+      <xs:attribute name="version" type="xs:string" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- Metadata section -->
+  <xs:complexType name="MetadataType">
+    <xs:sequence>
+      <xs:element name="timestamp" type="xs:string"/>
+      <xs:element name="config" type="ConfigType"/>
+      <xs:element name="mcp-server" type="McpServerType"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- Configuration section -->
+  <xs:complexType name="ConfigType">
+    <xs:sequence>
+      <xs:element name="model" type="xs:string" minOccurs="0"/>
+      <xs:element name="provider" type="xs:string" minOccurs="0"/>
+      <xs:element name="benchmark" type="xs:string" minOccurs="0"/>
+      <xs:element name="dataset" type="xs:string" minOccurs="0"/>
+      <xs:element name="sample_size" type="xs:string" minOccurs="0"/>
+      <xs:element name="timeout_seconds" type="xs:string" minOccurs="0"/>
+      <xs:element name="max_concurrent" type="xs:string" minOccurs="0"/>
+      <xs:element name="max_iterations" type="xs:string" minOccurs="0"/>
+      <xs:element name="agent_harness" type="xs:string" minOccurs="0"/>
+      <xs:element name="cybergym_level" type="xs:string" minOccurs="0"/>
+      <xs:element name="use_prebuilt_images" type="xs:string" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- MCP Server configuration -->
+  <xs:complexType name="McpServerType">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="0"/>
+      <xs:element name="command" type="xs:string" minOccurs="0"/>
+      <xs:element name="args" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="item" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="env" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- Summary section -->
+  <xs:complexType name="SummaryType">
+    <xs:sequence>
+      <xs:element name="mcp" type="ResultSummaryType"/>
+      <xs:element name="baseline" type="ResultSummaryType"/>
+      <xs:element name="improvement" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- Result summary (mcp or baseline) -->
+  <xs:complexType name="ResultSummaryType">
+    <xs:sequence>
+      <xs:element name="resolved" type="xs:integer"/>
+      <xs:element name="total" type="xs:integer"/>
+      <xs:element name="rate" type="xs:decimal"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- Tasks section -->
+  <xs:complexType name="TasksType">
+    <xs:sequence>
+      <xs:element name="task" type="TaskType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- Individual task -->
+  <xs:complexType name="TaskType">
+    <xs:sequence>
+      <xs:element name="mcp" type="TaskResultType" minOccurs="0"/>
+      <xs:element name="baseline" type="TaskResultType" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <!-- Task result (mcp or baseline) -->
+  <xs:complexType name="TaskResultType">
+    <xs:sequence>
+      <xs:element name="resolved" type="xs:boolean" minOccurs="0"/>
+      <xs:element name="patch-generated" type="xs:boolean" minOccurs="0"/>
+      <xs:element name="patch-applied" type="xs:boolean" minOccurs="0"/>
+      <xs:element name="error" type="xs:string" minOccurs="0"/>
+      <xs:element name="iterations" type="xs:integer" minOccurs="0"/>
+      <xs:element name="tool-calls" type="xs:integer" minOccurs="0"/>
+      <xs:element name="tokens" type="TokensType" minOccurs="0"/>
+      <xs:element name="tool-usage" type="ToolUsageType" minOccurs="0"/>
+      <xs:element name="fail-to-pass" type="TestResultType" minOccurs="0"/>
+      <xs:element name="pass-to-pass" type="TestResultType" minOccurs="0"/>
+      <xs:element name="messages" type="MessagesType" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- Tokens used -->
+  <xs:complexType name="TokensType">
+    <xs:sequence>
+      <xs:element name="input" type="xs:integer"/>
+      <xs:element name="output" type="xs:integer"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- Tool usage -->
+  <xs:complexType name="ToolUsageType">
+    <xs:sequence>
+      <xs:element name="tool" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:integer">
+              <xs:attribute name="name" type="xs:string" use="required"/>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- Test results (fail-to-pass, pass-to-pass) -->
+  <xs:complexType name="TestResultType">
+    <xs:sequence>
+      <xs:element name="passed" type="xs:integer"/>
+      <xs:element name="total" type="xs:integer"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- Messages -->
+  <xs:complexType name="MessagesType">
+    <xs:sequence>
+      <xs:element name="message" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+</xs:schema>

--- a/tests/test_xml_export.py
+++ b/tests/test_xml_export.py
@@ -1,0 +1,339 @@
+"""Tests for XML export functionality."""
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+from mcpbr.harness import EvaluationResults, TaskResult
+from mcpbr.reporting import save_xml_results
+
+
+class TestXMLExport:
+    """Tests for XML export functionality."""
+
+    @pytest.fixture
+    def sample_results(self) -> EvaluationResults:
+        """Create sample evaluation results for testing."""
+        return EvaluationResults(
+            metadata={
+                "timestamp": "2024-01-20T10:30:00Z",
+                "config": {
+                    "model": "claude-sonnet-4-5-20250514",
+                    "provider": "anthropic",
+                    "benchmark": "swe-bench",
+                    "dataset": "SWE-bench/SWE-bench_Lite",
+                    "sample_size": "2",
+                    "timeout_seconds": "300",
+                    "max_concurrent": "4",
+                    "max_iterations": "10",
+                    "agent_harness": "claude-code",
+                },
+                "mcp_server": {
+                    "name": "mcpbr",
+                    "command": "npx",
+                    "args": ["-y", "@modelcontextprotocol/server-filesystem", "{workdir}"],
+                    "env": {},
+                },
+            },
+            summary={
+                "mcp": {"resolved": 1, "total": 2, "rate": 0.5},
+                "baseline": {"resolved": 0, "total": 2, "rate": 0.0},
+                "improvement": "+50.0%",
+            },
+            tasks=[
+                TaskResult(
+                    instance_id="test-123",
+                    mcp={
+                        "resolved": True,
+                        "patch_generated": True,
+                        "patch_applied": True,
+                        "iterations": 5,
+                        "tool_calls": 10,
+                        "tokens": {"input": 1000, "output": 500},
+                        "tool_usage": {"Read": 3, "Write": 2},
+                        "fail_to_pass": {"passed": 2, "total": 2},
+                        "pass_to_pass": {"passed": 5, "total": 5},
+                    },
+                    baseline={
+                        "resolved": False,
+                        "patch_generated": False,
+                        "iterations": 3,
+                        "tool_calls": 5,
+                        "tokens": {"input": 800, "output": 300},
+                        "error": "Test failed",
+                    },
+                ),
+                TaskResult(
+                    instance_id="test-456",
+                    mcp={
+                        "resolved": False,
+                        "patch_generated": True,
+                        "iterations": 8,
+                        "tool_calls": 15,
+                        "tokens": {"input": 1200, "output": 600},
+                    },
+                    baseline={
+                        "resolved": False,
+                        "patch_generated": False,
+                        "iterations": 2,
+                        "tool_calls": 4,
+                        "tokens": {"input": 600, "output": 200},
+                    },
+                ),
+            ],
+        )
+
+    def test_save_xml_results_creates_file(self, tmp_path: Path, sample_results: EvaluationResults) -> None:
+        """Test that save_xml_results creates an XML file."""
+        output_path = tmp_path / "results.xml"
+        save_xml_results(sample_results, output_path)
+        assert output_path.exists()
+        assert output_path.stat().st_size > 0
+
+    def test_xml_structure(self, tmp_path: Path, sample_results: EvaluationResults) -> None:
+        """Test that XML has correct structure."""
+        output_path = tmp_path / "results.xml"
+        save_xml_results(sample_results, output_path)
+
+        tree = ET.parse(output_path)
+        root = tree.getroot()
+
+        # Check root element
+        assert root.tag == "mcpbr-evaluation"
+        assert root.get("version") == "1.0"
+
+        # Check main sections
+        metadata = root.find("metadata")
+        assert metadata is not None
+        summary = root.find("summary")
+        assert summary is not None
+        tasks = root.find("tasks")
+        assert tasks is not None
+
+    def test_xml_metadata(self, tmp_path: Path, sample_results: EvaluationResults) -> None:
+        """Test that metadata is correctly written to XML."""
+        output_path = tmp_path / "results.xml"
+        save_xml_results(sample_results, output_path)
+
+        tree = ET.parse(output_path)
+        root = tree.getroot()
+        metadata = root.find("metadata")
+        assert metadata is not None
+
+        # Check timestamp
+        timestamp = metadata.find("timestamp")
+        assert timestamp is not None
+        assert timestamp.text == "2024-01-20T10:30:00Z"
+
+        # Check config
+        config = metadata.find("config")
+        assert config is not None
+        model = config.find("model")
+        assert model is not None
+        assert model.text == "claude-sonnet-4-5-20250514"
+
+        # Check MCP server
+        mcp_server = metadata.find("mcp-server")
+        assert mcp_server is not None
+        command = mcp_server.find("command")
+        assert command is not None
+        assert command.text == "npx"
+
+    def test_xml_summary(self, tmp_path: Path, sample_results: EvaluationResults) -> None:
+        """Test that summary is correctly written to XML."""
+        output_path = tmp_path / "results.xml"
+        save_xml_results(sample_results, output_path)
+
+        tree = ET.parse(output_path)
+        root = tree.getroot()
+        summary = root.find("summary")
+        assert summary is not None
+
+        # Check MCP summary
+        mcp = summary.find("mcp")
+        assert mcp is not None
+        resolved = mcp.find("resolved")
+        assert resolved is not None
+        assert resolved.text == "1"
+        total = mcp.find("total")
+        assert total is not None
+        assert total.text == "2"
+        rate = mcp.find("rate")
+        assert rate is not None
+        assert rate.text == "0.5000"
+
+        # Check baseline summary
+        baseline = summary.find("baseline")
+        assert baseline is not None
+        resolved = baseline.find("resolved")
+        assert resolved is not None
+        assert resolved.text == "0"
+
+        # Check improvement
+        improvement = summary.find("improvement")
+        assert improvement is not None
+        assert improvement.text == "+50.0%"
+
+    def test_xml_tasks(self, tmp_path: Path, sample_results: EvaluationResults) -> None:
+        """Test that tasks are correctly written to XML."""
+        output_path = tmp_path / "results.xml"
+        save_xml_results(sample_results, output_path)
+
+        tree = ET.parse(output_path)
+        root = tree.getroot()
+        tasks = root.find("tasks")
+        assert tasks is not None
+
+        # Check task elements
+        task_elements = tasks.findall("task")
+        assert len(task_elements) == 2
+
+        # Check first task
+        task1 = task_elements[0]
+        assert task1.get("id") == "test-123"
+
+        # Check MCP result for task 1
+        mcp = task1.find("mcp")
+        assert mcp is not None
+        resolved = mcp.find("resolved")
+        assert resolved is not None
+        assert resolved.text == "true"
+        iterations = mcp.find("iterations")
+        assert iterations is not None
+        assert iterations.text == "5"
+
+        # Check tokens
+        tokens = mcp.find("tokens")
+        assert tokens is not None
+        input_tokens = tokens.find("input")
+        assert input_tokens is not None
+        assert input_tokens.text == "1000"
+
+        # Check tool usage
+        tool_usage = mcp.find("tool-usage")
+        assert tool_usage is not None
+        tools = tool_usage.findall("tool")
+        assert len(tools) == 2
+
+        # Check baseline result for task 1
+        baseline = task1.find("baseline")
+        assert baseline is not None
+        resolved = baseline.find("resolved")
+        assert resolved is not None
+        assert resolved.text == "false"
+        error = baseline.find("error")
+        assert error is not None
+        assert error.text == "Test failed"
+
+    def test_xml_test_results(self, tmp_path: Path, sample_results: EvaluationResults) -> None:
+        """Test that test results (fail-to-pass, pass-to-pass) are correctly written."""
+        output_path = tmp_path / "results.xml"
+        save_xml_results(sample_results, output_path)
+
+        tree = ET.parse(output_path)
+        root = tree.getroot()
+        tasks = root.find("tasks")
+        assert tasks is not None
+
+        task1 = tasks.find("task[@id='test-123']")
+        assert task1 is not None
+        mcp = task1.find("mcp")
+        assert mcp is not None
+
+        # Check fail-to-pass
+        fail_to_pass = mcp.find("fail-to-pass")
+        assert fail_to_pass is not None
+        passed = fail_to_pass.find("passed")
+        assert passed is not None
+        assert passed.text == "2"
+        total = fail_to_pass.find("total")
+        assert total is not None
+        assert total.text == "2"
+
+        # Check pass-to-pass
+        pass_to_pass = mcp.find("pass-to-pass")
+        assert pass_to_pass is not None
+        passed = pass_to_pass.find("passed")
+        assert passed is not None
+        assert passed.text == "5"
+
+    def test_xml_creates_parent_directories(self, tmp_path: Path, sample_results: EvaluationResults) -> None:
+        """Test that save_xml_results creates parent directories."""
+        output_path = tmp_path / "subdir" / "nested" / "results.xml"
+        save_xml_results(sample_results, output_path)
+        assert output_path.exists()
+
+    def test_xml_well_formed(self, tmp_path: Path, sample_results: EvaluationResults) -> None:
+        """Test that generated XML is well-formed and parseable."""
+        output_path = tmp_path / "results.xml"
+        save_xml_results(sample_results, output_path)
+
+        # This should not raise an exception
+        tree = ET.parse(output_path)
+        root = tree.getroot()
+        assert root is not None
+
+    def test_xml_with_minimal_data(self, tmp_path: Path) -> None:
+        """Test XML export with minimal data."""
+        minimal_results = EvaluationResults(
+            metadata={
+                "timestamp": "2024-01-20T10:30:00Z",
+                "config": {"model": "test-model"},
+                "mcp_server": {"command": "test"},
+            },
+            summary={
+                "mcp": {"resolved": 0, "total": 0, "rate": 0.0},
+                "baseline": {"resolved": 0, "total": 0, "rate": 0.0},
+                "improvement": "0.0%",
+            },
+            tasks=[],
+        )
+
+        output_path = tmp_path / "minimal.xml"
+        save_xml_results(minimal_results, output_path)
+
+        tree = ET.parse(output_path)
+        root = tree.getroot()
+        assert root.tag == "mcpbr-evaluation"
+
+    def test_xml_escapes_special_characters(self, tmp_path: Path) -> None:
+        """Test that special XML characters are properly escaped."""
+        results = EvaluationResults(
+            metadata={
+                "timestamp": "2024-01-20T10:30:00Z",
+                "config": {"model": "test-model"},
+                "mcp_server": {"command": "test"},
+            },
+            summary={
+                "mcp": {"resolved": 0, "total": 1, "rate": 0.0},
+                "baseline": {"resolved": 0, "total": 1, "rate": 0.0},
+                "improvement": "0.0%",
+            },
+            tasks=[
+                TaskResult(
+                    instance_id="test-123",
+                    mcp={
+                        "resolved": False,
+                        "error": "Error: <tag> & \"quote\" 'apostrophe'",
+                        "iterations": 1,
+                        "tool_calls": 1,
+                        "tokens": {"input": 100, "output": 50},
+                    },
+                )
+            ],
+        )
+
+        output_path = tmp_path / "escaped.xml"
+        save_xml_results(results, output_path)
+
+        # Parse the XML to ensure it's valid
+        tree = ET.parse(output_path)
+        root = tree.getroot()
+
+        # Find the error element
+        task = root.find(".//task[@id='test-123']/mcp/error")
+        assert task is not None
+        # The error text should be properly unescaped when parsed
+        assert "<tag>" in task.text
+        assert "&" in task.text

--- a/tests/test_xml_export.py
+++ b/tests/test_xml_export.py
@@ -84,7 +84,9 @@ class TestXMLExport:
             ],
         )
 
-    def test_save_xml_results_creates_file(self, tmp_path: Path, sample_results: EvaluationResults) -> None:
+    def test_save_xml_results_creates_file(
+        self, tmp_path: Path, sample_results: EvaluationResults
+    ) -> None:
         """Test that save_xml_results creates an XML file."""
         output_path = tmp_path / "results.xml"
         save_xml_results(sample_results, output_path)
@@ -258,7 +260,9 @@ class TestXMLExport:
         assert passed is not None
         assert passed.text == "5"
 
-    def test_xml_creates_parent_directories(self, tmp_path: Path, sample_results: EvaluationResults) -> None:
+    def test_xml_creates_parent_directories(
+        self, tmp_path: Path, sample_results: EvaluationResults
+    ) -> None:
         """Test that save_xml_results creates parent directories."""
         output_path = tmp_path / "subdir" / "nested" / "results.xml"
         save_xml_results(sample_results, output_path)

--- a/uv.lock
+++ b/uv.lock
@@ -1038,7 +1038,7 @@ wheels = [
 
 [[package]]
 name = "mcpbr"
-version = "0.2.0"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
Implements XML export functionality for evaluation results to support enterprise integrations and CI/CD systems like Jenkins and Azure DevOps.

## Changes
- Added `save_xml_results()` function in `reporting.py` using `xml.etree.ElementTree`
- Added `--output-xml` / `-x` CLI flag for XML output
- Created XSD schema file (`src/mcpbr/schemas/results.xsd`) for validation
- Implemented comprehensive test suite with 10 test cases covering:
  - XML structure validation
  - Metadata and summary sections
  - Task results with all fields
  - Special character escaping
  - Parent directory creation
  - Well-formed XML output

## Features
- Exports all evaluation data: metadata, config, MCP server settings, summary statistics, and per-task results
- Includes tokens, tool usage, test results (fail-to-pass, pass-to-pass), and error messages
- Pretty-printed XML output for readability
- Automatic XML character escaping
- XSD schema for validation against enterprise XML parsers

## Testing
All 88 non-integration tests pass, including 10 new XML export tests.

```bash
pytest tests/test_xml_export.py -v  # 10 passed
pytest tests/ -m "not integration"  # 88 passed
```

## Example Usage
```bash
mcpbr run -c config.yaml --output-xml results.xml
mcpbr run -c config.yaml -x results.xml -o results.json -r report.md
```

Closes #54

Generated with [Claude Code](https://claude.com/claude-code)