### PR TITLE
[Feature] Add MCP Server Configuration Templates (fixes #97)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,6 +28,7 @@ mcpbr init --help
 |---------|-------------|
 | `mcpbr run` | Run benchmark evaluation with configured MCP server |
 | `mcpbr init` | Generate an example configuration file |
+| `mcpbr config` | Manage configuration templates |
 | `mcpbr models` | List supported models for evaluation |
 | `mcpbr providers` | List available model providers |
 | `mcpbr harnesses` | List available agent harnesses |
@@ -149,6 +150,8 @@ mcpbr init [OPTIONS]
 | Option | Short | Type | Default | Description |
 |--------|-------|------|---------|-------------|
 | `--output PATH` | `-o` | Path | `mcpbr.yaml` | Path to write example config |
+| `--template TEXT` | `-t` | String | | Template ID to use (see `mcpbr config list`) |
+| `--interactive` | `-i` | Flag | | Interactive template selection wizard |
 | `--help` | `-h` | Flag | | Show help message |
 
 ### Examples
@@ -157,8 +160,94 @@ mcpbr init [OPTIONS]
 # Create default config
 mcpbr init
 
-# Custom filename
-mcpbr init -o my-config.yaml
+# Use a template
+mcpbr init -t filesystem
+
+# Interactive template selection
+mcpbr init -i
+
+# Custom filename with template
+mcpbr init -t brave-search -o brave.yaml
+```
+
+---
+
+## `mcpbr config`
+
+Manage configuration templates for popular MCP servers.
+
+### Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `mcpbr config list` | List available configuration templates |
+| `mcpbr config apply` | Apply a template to create a configuration file |
+
+---
+
+### `mcpbr config list`
+
+List all available MCP server configuration templates.
+
+#### Usage
+
+```bash
+mcpbr config list
+```
+
+#### Output
+
+```text
+                   Available MCP Server Templates
++-------------+------------------+---------------------+----------+-------------+
+| ID          | Name             | Package             | API Key  | Description |
++-------------+------------------+---------------------+----------+-------------+
+| filesystem  | Filesystem       | @modelcontext...    | No       | File system |
+|             | Server           |                     |          | access      |
+| brave-      | Brave Search     | @modelcontext...    | Yes      | Web search  |
+| search      |                  |                     |          | using Brave |
+| github      | GitHub           | @modelcontext...    | Yes      | GitHub API  |
+|             |                  |                     |          | integration |
++-------------+------------------+---------------------+----------+-------------+
+```
+
+---
+
+### `mcpbr config apply`
+
+Apply a template to create a configuration file.
+
+#### Usage
+
+```bash
+mcpbr config apply TEMPLATE_ID [OPTIONS]
+```
+
+#### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `TEMPLATE_ID` | ID of the template to apply (see `mcpbr config list`) |
+
+#### Options
+
+| Option | Short | Type | Default | Description |
+|--------|-------|------|---------|-------------|
+| `--output PATH` | `-o` | Path | `mcpbr.yaml` | Path to write configuration file |
+| `--force` | `-f` | Flag | | Overwrite existing configuration file |
+| `--help` | `-h` | Flag | | Show help message |
+
+#### Examples
+
+```bash
+# Apply filesystem template
+mcpbr config apply filesystem
+
+# Custom output path
+mcpbr config apply brave-search -o brave.yaml
+
+# Overwrite existing config
+mcpbr config apply github --force
 ```
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,34 @@ mcpbr uses YAML configuration files to define your MCP server settings and evalu
 
 ## Generating a Config File
 
-Create a starter configuration:
+### Using Templates (Recommended)
+
+mcpbr includes pre-configured templates for popular MCP servers. This is the easiest way to get started:
+
+```bash
+# List available templates
+mcpbr config list
+
+# Apply a template
+mcpbr config apply filesystem
+
+# Or use the interactive wizard
+mcpbr init -i
+```
+
+Available templates include:
+
+- **filesystem** - File system access (no API key required)
+- **brave-search** - Web search using Brave Search API
+- **postgres** - PostgreSQL database access
+- **sqlite** - SQLite database access
+- **github** - GitHub API integration
+- **google-maps** - Google Maps APIs
+- **slack** - Slack workspace integration
+
+### Manual Configuration
+
+Create a basic starter configuration:
 
 ```bash
 mcpbr init

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,0 +1,416 @@
+---
+faq:
+  - q: "What are MCP server configuration templates?"
+    a: "Templates are pre-configured settings for popular MCP servers that make it easy to get started without manually writing YAML configuration files."
+  - q: "How do I list available templates?"
+    a: "Run 'mcpbr config list' to see all available templates with their descriptions and requirements."
+  - q: "How do I use a template?"
+    a: "Use 'mcpbr config apply <template-id>' to create a configuration file from a template, or use 'mcpbr init -i' for interactive selection."
+  - q: "Can I contribute my own templates?"
+    a: "Yes! Create a YAML template file following the template format and submit a pull request to add it to the built-in templates."
+---
+
+# Configuration Templates
+
+Configuration templates provide pre-configured settings for popular MCP servers, making it easy to get started with mcpbr without writing YAML configuration files from scratch.
+
+## Using Templates
+
+### List Available Templates
+
+View all available templates:
+
+```bash
+mcpbr config list
+```
+
+This displays a table showing:
+
+- **ID**: Template identifier used to apply the template
+- **Name**: Human-readable name
+- **Package**: NPM or Python package name
+- **Requires API Key**: Whether an API key is needed
+- **Description**: What the MCP server does
+
+### Apply a Template
+
+Create a configuration file from a template:
+
+```bash
+# Apply filesystem template (default output: mcpbr.yaml)
+mcpbr config apply filesystem
+
+# Specify custom output path
+mcpbr config apply brave-search -o brave.yaml
+
+# Overwrite existing config
+mcpbr config apply github --force
+```
+
+### Interactive Template Selection
+
+Use the interactive wizard when running `init`:
+
+```bash
+mcpbr init -i
+```
+
+This shows all available templates and lets you choose one interactively.
+
+### Use Template Directly with Init
+
+Apply a template while creating initial configuration:
+
+```bash
+# Use template during init
+mcpbr init -t filesystem
+
+# Custom output path with template
+mcpbr init -t postgres -o postgres-config.yaml
+```
+
+## Available Templates
+
+### Filesystem Server
+
+**ID**: `filesystem`
+**Package**: `@modelcontextprotocol/server-filesystem`
+**API Key Required**: No
+
+Provides file system access tools for reading, writing, and managing files and directories within the task workspace.
+
+**Use Cases**:
+- Reading and analyzing code files
+- Writing patches and modifications
+- File system navigation and search
+
+**Example**:
+```bash
+mcpbr config apply filesystem
+```
+
+### Brave Search
+
+**ID**: `brave-search`
+**Package**: `@modelcontextprotocol/server-brave-search`
+**API Key Required**: Yes (`BRAVE_API_KEY`)
+
+Web search capabilities using the Brave Search API for finding information online.
+
+**Use Cases**:
+- Looking up documentation
+- Finding error solutions
+- Researching technical concepts
+
+**Setup**:
+1. Get API key from [Brave Search API](https://brave.com/search/api/)
+2. Set environment variable: `export BRAVE_API_KEY="your-key"`
+3. Apply template: `mcpbr config apply brave-search`
+
+### PostgreSQL Database
+
+**ID**: `postgres`
+**Package**: `@modelcontextprotocol/server-postgres`
+**API Key Required**: No (requires connection string)
+
+Query and manage PostgreSQL databases with SQL execution and schema introspection.
+
+**Use Cases**:
+- Database schema analysis
+- SQL query generation
+- Database migrations
+
+**Setup**:
+1. Set connection string: `export POSTGRES_CONNECTION_STRING="postgresql://user:pass@localhost:5432/db"`
+2. Apply template: `mcpbr config apply postgres`
+
+### SQLite Database
+
+**ID**: `sqlite`
+**Package**: `@modelcontextprotocol/server-sqlite`
+**API Key Required**: No
+
+Query and manage SQLite databases with SQL execution and schema introspection.
+
+**Use Cases**:
+- Local database analysis
+- Testing database queries
+- Lightweight data storage
+
+**Example**:
+```bash
+mcpbr config apply sqlite
+```
+
+### GitHub
+
+**ID**: `github`
+**Package**: `@modelcontextprotocol/server-github`
+**API Key Required**: Yes (`GITHUB_PERSONAL_ACCESS_TOKEN`)
+
+Interact with GitHub repositories, issues, pull requests, and other GitHub resources.
+
+**Use Cases**:
+- Creating issues and PRs
+- Repository analysis
+- GitHub API interactions
+
+**Setup**:
+1. Create token at [GitHub Settings](https://github.com/settings/tokens)
+2. Set environment variable: `export GITHUB_PERSONAL_ACCESS_TOKEN="your-token"`
+3. Apply template: `mcpbr config apply github`
+
+### Google Maps
+
+**ID**: `google-maps`
+**Package**: `@modelcontextprotocol/server-google-maps`
+**API Key Required**: Yes (`GOOGLE_MAPS_API_KEY`)
+
+Access Google Maps APIs for geocoding, places, directions, and other location services.
+
+**Use Cases**:
+- Location-based features
+- Geocoding and reverse geocoding
+- Route planning
+
+**Setup**:
+1. Get API key from [Google Cloud Console](https://console.cloud.google.com/)
+2. Set environment variable: `export GOOGLE_MAPS_API_KEY="your-key"`
+3. Apply template: `mcpbr config apply google-maps`
+
+### Slack
+
+**ID**: `slack`
+**Package**: `@modelcontextprotocol/server-slack`
+**API Key Required**: Yes (`SLACK_BOT_TOKEN`)
+
+Send messages, manage channels, and interact with Slack workspaces.
+
+**Use Cases**:
+- Sending notifications
+- Channel management
+- Slack automation
+
+**Setup**:
+1. Create Slack app at [Slack API](https://api.slack.com/apps)
+2. Get bot token and set: `export SLACK_BOT_TOKEN="xoxb-your-token"`
+3. Apply template: `mcpbr config apply slack`
+
+## Template Format
+
+Templates are YAML files with two main sections:
+
+1. **Metadata**: Information about the template
+2. **Configuration**: The actual mcpbr configuration
+
+### Example Template Structure
+
+```yaml
+# Template Metadata
+id: my-server
+name: My MCP Server
+description: Description of what this server does
+package: "@org/my-mcp-server"
+requires_api_key: true
+env_vars:
+  - MY_API_KEY
+
+# Configuration
+config:
+  mcp_server:
+    name: my-server
+    command: npx
+    args:
+      - "-y"
+      - "@org/my-mcp-server"
+    env:
+      MY_API_KEY: "${MY_API_KEY}"
+
+  provider: anthropic
+  agent_harness: claude-code
+  model: sonnet
+  benchmark: swe-bench
+  sample_size: 10
+  timeout_seconds: 300
+  max_concurrent: 4
+  max_iterations: 10
+```
+
+### Metadata Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | Unique identifier for the template |
+| `name` | Yes | Human-readable name |
+| `description` | Yes | What the MCP server does |
+| `package` | No | NPM or Python package name |
+| `requires_api_key` | No | Whether an API key is needed (default: false) |
+| `env_vars` | No | List of required environment variables |
+
+### Configuration Section
+
+The `config` section contains a complete mcpbr configuration. See the [Configuration Guide](configuration.md) for details on all available options.
+
+## Contributing Templates
+
+We welcome community-contributed templates for popular MCP servers!
+
+### Creating a Template
+
+1. Create a new YAML file in `src/mcpbr/data/templates/`
+2. Follow the template format above
+3. Validate your template:
+   ```bash
+   uv run pytest tests/test_templates.py -k "test_builtin_templates_valid"
+   ```
+
+### Submission Guidelines
+
+When submitting a template:
+
+1. **Use clear IDs**: Use lowercase with hyphens (e.g., `my-server`)
+2. **Provide good descriptions**: Explain what the server does clearly
+3. **Document requirements**: List all required environment variables
+4. **Test thoroughly**: Ensure the template works end-to-end
+5. **Add examples**: Include use cases in the description
+
+### Template Checklist
+
+- [ ] Template has unique ID
+- [ ] Name and description are clear
+- [ ] Package name is specified (if applicable)
+- [ ] Environment variables are documented
+- [ ] Configuration is valid and complete
+- [ ] Template is added to built-in templates list
+- [ ] Documentation is updated
+- [ ] Tests pass
+
+### Example Pull Request
+
+```markdown
+Title: Add template for XYZ MCP server
+
+Description:
+This PR adds a configuration template for the XYZ MCP server, which provides
+[description of functionality].
+
+The template includes:
+- Pre-configured command and arguments
+- Environment variable setup for API authentication
+- Sensible defaults for evaluation parameters
+
+Checklist:
+- [x] Template file created
+- [x] Documentation updated
+- [x] Tests pass
+- [x] Example usage tested
+```
+
+## Template Validation
+
+Templates are automatically validated to ensure:
+
+- Required metadata fields are present
+- Configuration has `mcp_server` section
+- MCP server config includes `command` and `args`
+- Environment variables are properly referenced
+- No conflicting IDs with existing templates
+
+Run validation:
+
+```bash
+uv run pytest tests/test_templates.py
+```
+
+## Best Practices
+
+### 1. Use Descriptive IDs
+
+Good:
+- `filesystem`
+- `brave-search`
+- `postgres`
+
+Bad:
+- `fs`
+- `search`
+- `db`
+
+### 2. Document Environment Variables
+
+Always list required environment variables in the metadata:
+
+```yaml
+requires_api_key: true
+env_vars:
+  - API_KEY
+  - OPTIONAL_CONFIG_VAR
+```
+
+### 3. Use ${VAR} Syntax
+
+Reference environment variables using `${VAR}` syntax:
+
+```yaml
+env:
+  API_KEY: "${API_KEY}"
+```
+
+### 4. Provide Reasonable Defaults
+
+Set sensible defaults for evaluation parameters:
+
+```yaml
+sample_size: 10          # Small enough for testing
+timeout_seconds: 300     # 5 minutes
+max_concurrent: 4        # Moderate parallelism
+max_iterations: 10       # Reasonable iteration limit
+```
+
+### 5. Include {workdir} Placeholder
+
+Use `{workdir}` for workspace paths:
+
+```yaml
+args:
+  - "-y"
+  - "my-server"
+  - "{workdir}"  # Will be replaced at runtime
+```
+
+## Troubleshooting
+
+### Template Not Found
+
+If a template doesn't appear in the list:
+
+1. Check the template file is in `src/mcpbr/data/templates/`
+2. Verify the YAML is valid: `cat template.yaml | python -m yaml`
+3. Ensure the template has required metadata fields
+4. Reinstall the package: `uv pip install -e .`
+
+### Environment Variable Not Expanded
+
+If `${VAR}` isn't being replaced:
+
+1. Check the variable is set: `echo $VAR`
+2. Verify it's in the `env` section of `mcp_server`
+3. Ensure you're using `${VAR}` not `$VAR`
+
+### Template Validation Fails
+
+Run the validator to see specific errors:
+
+```python
+from mcpbr.templates import get_template, validate_template
+
+template = get_template("my-template")
+errors = validate_template(template)
+print(errors)
+```
+
+## Next Steps
+
+- [Configuration Guide](configuration.md) - Full configuration reference
+- [CLI Reference](cli.md) - Command-line options
+- [Contributing Guide](contributing.md) - How to contribute to mcpbr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ Changelog = "https://github.com/greynewell/mcpbr/blob/main/CHANGELOG.md"
 [tool.hatch.build.targets.wheel]
 packages = ["src/mcpbr"]
 
+[tool.hatch.build.targets.wheel.shared-data]
+"src/mcpbr/data" = "mcpbr/data"
+
 [tool.hatch.build.targets.sdist]
 exclude = [
     "docs/",

--- a/src/mcpbr/cli.py
+++ b/src/mcpbr/cli.py
@@ -433,7 +433,7 @@ def init(output_path: Path, template_id: str | None, interactive: bool) -> None:
                 console.print(f"  [yellow]{env_var}[/yellow]")
             console.print("\nSet these environment variables before running the evaluation.")
 
-        console.print(f"\nEdit the config file and run:")
+        console.print("\nEdit the config file and run:")
         console.print(f"  mcpbr run --config {output_path}")
         return
 
@@ -720,7 +720,7 @@ def config_apply(template_id: str, output_path: Path, force: bool) -> None:
             console.print(f"  [yellow]{env_var}[/yellow]")
         console.print("\nSet these environment variables before running the evaluation.")
 
-    console.print(f"\nEdit the config file and run:")
+    console.print("\nEdit the config file and run:")
     console.print(f"  mcpbr run --config {output_path}")
 
 

--- a/src/mcpbr/cli.py
+++ b/src/mcpbr/cli.py
@@ -639,7 +639,9 @@ def config_list() -> None:
     table.add_column("Description")
 
     for template in sorted(templates, key=lambda t: t.id):
-        api_key_indicator = "[yellow]Yes[/yellow]" if template.requires_api_key else "[green]No[/green]"
+        api_key_indicator = (
+            "[yellow]Yes[/yellow]" if template.requires_api_key else "[green]No[/green]"
+        )
         table.add_row(
             template.id,
             template.name,

--- a/src/mcpbr/data/templates/brave-search.yaml
+++ b/src/mcpbr/data/templates/brave-search.yaml
@@ -1,0 +1,51 @@
+# Template metadata
+id: brave-search
+name: Brave Search
+description: Web search capabilities using Brave Search API for finding information online
+package: "@modelcontextprotocol/server-brave-search"
+requires_api_key: true
+env_vars:
+  - BRAVE_API_KEY
+
+# Configuration
+config:
+  mcp_server:
+    # Name to register the MCP server as (appears in tool names)
+    name: brave-search
+
+    # Command to start the MCP server
+    command: npx
+
+    # Arguments for the command
+    args:
+      - "-y"
+      - "@modelcontextprotocol/server-brave-search"
+
+    # Environment variables
+    # Set BRAVE_API_KEY in your environment before running
+    env:
+      BRAVE_API_KEY: "${BRAVE_API_KEY}"
+
+  # Model provider
+  provider: anthropic
+
+  # Agent harness
+  agent_harness: claude-code
+
+  # Model ID
+  model: sonnet
+
+  # Benchmark to run
+  benchmark: swe-bench
+
+  # Number of tasks to evaluate (null for full dataset)
+  sample_size: 10
+
+  # Timeout per task in seconds
+  timeout_seconds: 300
+
+  # Maximum parallel evaluations
+  max_concurrent: 4
+
+  # Maximum agent iterations per task
+  max_iterations: 10

--- a/src/mcpbr/data/templates/filesystem.yaml
+++ b/src/mcpbr/data/templates/filesystem.yaml
@@ -1,0 +1,50 @@
+# Template metadata
+id: filesystem
+name: Filesystem Server
+description: Provides file system access tools for reading, writing, and managing files and directories
+package: "@modelcontextprotocol/server-filesystem"
+requires_api_key: false
+env_vars: []
+
+# Configuration
+config:
+  mcp_server:
+    # Name to register the MCP server as (appears in tool names)
+    name: filesystem
+
+    # Command to start the MCP server
+    command: npx
+
+    # Arguments for the command
+    # Use {workdir} as placeholder for task working directory
+    args:
+      - "-y"
+      - "@modelcontextprotocol/server-filesystem"
+      - "{workdir}"
+
+    # Environment variables (optional)
+    env: {}
+
+  # Model provider
+  provider: anthropic
+
+  # Agent harness
+  agent_harness: claude-code
+
+  # Model ID
+  model: sonnet
+
+  # Benchmark to run
+  benchmark: swe-bench
+
+  # Number of tasks to evaluate (null for full dataset)
+  sample_size: 10
+
+  # Timeout per task in seconds
+  timeout_seconds: 300
+
+  # Maximum parallel evaluations
+  max_concurrent: 4
+
+  # Maximum agent iterations per task
+  max_iterations: 10

--- a/src/mcpbr/data/templates/github.yaml
+++ b/src/mcpbr/data/templates/github.yaml
@@ -1,0 +1,51 @@
+# Template metadata
+id: github
+name: GitHub
+description: Interact with GitHub repositories, issues, PRs, and other GitHub resources
+package: "@modelcontextprotocol/server-github"
+requires_api_key: true
+env_vars:
+  - GITHUB_PERSONAL_ACCESS_TOKEN
+
+# Configuration
+config:
+  mcp_server:
+    # Name to register the MCP server as (appears in tool names)
+    name: github
+
+    # Command to start the MCP server
+    command: npx
+
+    # Arguments for the command
+    args:
+      - "-y"
+      - "@modelcontextprotocol/server-github"
+
+    # Environment variables
+    # Create a GitHub Personal Access Token at https://github.com/settings/tokens
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+
+  # Model provider
+  provider: anthropic
+
+  # Agent harness
+  agent_harness: claude-code
+
+  # Model ID
+  model: sonnet
+
+  # Benchmark to run
+  benchmark: swe-bench
+
+  # Number of tasks to evaluate (null for full dataset)
+  sample_size: 10
+
+  # Timeout per task in seconds
+  timeout_seconds: 300
+
+  # Maximum parallel evaluations
+  max_concurrent: 4
+
+  # Maximum agent iterations per task
+  max_iterations: 10

--- a/src/mcpbr/data/templates/google-maps.yaml
+++ b/src/mcpbr/data/templates/google-maps.yaml
@@ -1,0 +1,51 @@
+# Template metadata
+id: google-maps
+name: Google Maps
+description: Access Google Maps APIs for geocoding, places, directions, and other location services
+package: "@modelcontextprotocol/server-google-maps"
+requires_api_key: true
+env_vars:
+  - GOOGLE_MAPS_API_KEY
+
+# Configuration
+config:
+  mcp_server:
+    # Name to register the MCP server as (appears in tool names)
+    name: google-maps
+
+    # Command to start the MCP server
+    command: npx
+
+    # Arguments for the command
+    args:
+      - "-y"
+      - "@modelcontextprotocol/server-google-maps"
+
+    # Environment variables
+    # Get API key at https://console.cloud.google.com/
+    env:
+      GOOGLE_MAPS_API_KEY: "${GOOGLE_MAPS_API_KEY}"
+
+  # Model provider
+  provider: anthropic
+
+  # Agent harness
+  agent_harness: claude-code
+
+  # Model ID
+  model: sonnet
+
+  # Benchmark to run
+  benchmark: swe-bench
+
+  # Number of tasks to evaluate (null for full dataset)
+  sample_size: 10
+
+  # Timeout per task in seconds
+  timeout_seconds: 300
+
+  # Maximum parallel evaluations
+  max_concurrent: 4
+
+  # Maximum agent iterations per task
+  max_iterations: 10

--- a/src/mcpbr/data/templates/postgres.yaml
+++ b/src/mcpbr/data/templates/postgres.yaml
@@ -1,0 +1,52 @@
+# Template metadata
+id: postgres
+name: PostgreSQL Database
+description: Query and manage PostgreSQL databases with SQL execution and schema introspection
+package: "@modelcontextprotocol/server-postgres"
+requires_api_key: false
+env_vars:
+  - POSTGRES_CONNECTION_STRING
+
+# Configuration
+config:
+  mcp_server:
+    # Name to register the MCP server as (appears in tool names)
+    name: postgres
+
+    # Command to start the MCP server
+    command: npx
+
+    # Arguments for the command
+    args:
+      - "-y"
+      - "@modelcontextprotocol/server-postgres"
+      - "${POSTGRES_CONNECTION_STRING}"
+
+    # Environment variables
+    # Example: postgresql://user:password@localhost:5432/dbname
+    env:
+      POSTGRES_CONNECTION_STRING: "${POSTGRES_CONNECTION_STRING}"
+
+  # Model provider
+  provider: anthropic
+
+  # Agent harness
+  agent_harness: claude-code
+
+  # Model ID
+  model: sonnet
+
+  # Benchmark to run
+  benchmark: swe-bench
+
+  # Number of tasks to evaluate (null for full dataset)
+  sample_size: 10
+
+  # Timeout per task in seconds
+  timeout_seconds: 300
+
+  # Maximum parallel evaluations
+  max_concurrent: 4
+
+  # Maximum agent iterations per task
+  max_iterations: 10

--- a/src/mcpbr/data/templates/slack.yaml
+++ b/src/mcpbr/data/templates/slack.yaml
@@ -1,0 +1,51 @@
+# Template metadata
+id: slack
+name: Slack
+description: Send messages, manage channels, and interact with Slack workspaces
+package: "@modelcontextprotocol/server-slack"
+requires_api_key: true
+env_vars:
+  - SLACK_BOT_TOKEN
+
+# Configuration
+config:
+  mcp_server:
+    # Name to register the MCP server as (appears in tool names)
+    name: slack
+
+    # Command to start the MCP server
+    command: npx
+
+    # Arguments for the command
+    args:
+      - "-y"
+      - "@modelcontextprotocol/server-slack"
+
+    # Environment variables
+    # Create a Slack app and get bot token at https://api.slack.com/apps
+    env:
+      SLACK_BOT_TOKEN: "${SLACK_BOT_TOKEN}"
+
+  # Model provider
+  provider: anthropic
+
+  # Agent harness
+  agent_harness: claude-code
+
+  # Model ID
+  model: sonnet
+
+  # Benchmark to run
+  benchmark: swe-bench
+
+  # Number of tasks to evaluate (null for full dataset)
+  sample_size: 10
+
+  # Timeout per task in seconds
+  timeout_seconds: 300
+
+  # Maximum parallel evaluations
+  max_concurrent: 4
+
+  # Maximum agent iterations per task
+  max_iterations: 10

--- a/src/mcpbr/data/templates/sqlite.yaml
+++ b/src/mcpbr/data/templates/sqlite.yaml
@@ -1,0 +1,50 @@
+# Template metadata
+id: sqlite
+name: SQLite Database
+description: Query and manage SQLite databases with SQL execution and schema introspection
+package: "@modelcontextprotocol/server-sqlite"
+requires_api_key: false
+env_vars: []
+
+# Configuration
+config:
+  mcp_server:
+    # Name to register the MCP server as (appears in tool names)
+    name: sqlite
+
+    # Command to start the MCP server
+    command: npx
+
+    # Arguments for the command
+    # Use {workdir} to reference task directory for database location
+    args:
+      - "-y"
+      - "@modelcontextprotocol/server-sqlite"
+      - "{workdir}/database.db"
+
+    # Environment variables (optional)
+    env: {}
+
+  # Model provider
+  provider: anthropic
+
+  # Agent harness
+  agent_harness: claude-code
+
+  # Model ID
+  model: sonnet
+
+  # Benchmark to run
+  benchmark: swe-bench
+
+  # Number of tasks to evaluate (null for full dataset)
+  sample_size: 10
+
+  # Timeout per task in seconds
+  timeout_seconds: 300
+
+  # Maximum parallel evaluations
+  max_concurrent: 4
+
+  # Maximum agent iterations per task
+  max_iterations: 10

--- a/src/mcpbr/templates.py
+++ b/src/mcpbr/templates.py
@@ -1,0 +1,208 @@
+"""MCP server configuration templates.
+
+This module provides pre-configured templates for popular MCP servers,
+making it easy for users to get started with common configurations.
+"""
+
+import importlib.resources
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field
+
+
+class MCPTemplate(BaseModel):
+    """Metadata for an MCP server configuration template."""
+
+    id: str = Field(description="Unique template identifier")
+    name: str = Field(description="Human-readable template name")
+    description: str = Field(description="Description of what this MCP server does")
+    package: str | None = Field(
+        default=None, description="NPM package or Python package name"
+    )
+    requires_api_key: bool = Field(
+        default=False, description="Whether this server requires an API key"
+    )
+    env_vars: list[str] = Field(
+        default_factory=list, description="Required environment variables"
+    )
+    config: dict[str, Any] = Field(description="Template configuration")
+
+
+# Registry of built-in templates
+TEMPLATES: dict[str, MCPTemplate] = {}
+
+
+def register_template(template: MCPTemplate) -> None:
+    """Register a template in the global registry.
+
+    Args:
+        template: Template to register
+    """
+    TEMPLATES[template.id] = template
+
+
+def get_template(template_id: str) -> MCPTemplate | None:
+    """Get a template by ID.
+
+    Args:
+        template_id: Template identifier
+
+    Returns:
+        Template if found, None otherwise
+    """
+    return TEMPLATES.get(template_id)
+
+
+def list_templates() -> list[MCPTemplate]:
+    """List all available templates.
+
+    Returns:
+        List of all registered templates
+    """
+    return list(TEMPLATES.values())
+
+
+def load_template_from_yaml(yaml_path: Path) -> MCPTemplate:
+    """Load a template from a YAML file.
+
+    Args:
+        yaml_path: Path to YAML file
+
+    Returns:
+        Loaded template
+
+    Raises:
+        FileNotFoundError: If file doesn't exist
+        ValueError: If YAML is invalid
+    """
+    if not yaml_path.exists():
+        raise FileNotFoundError(f"Template file not found: {yaml_path}")
+
+    with open(yaml_path) as f:
+        data = yaml.safe_load(f)
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Invalid template YAML: {yaml_path}")
+
+    return MCPTemplate(**data)
+
+
+def apply_template(template: MCPTemplate, output_path: Path, overrides: dict[str, Any] | None = None) -> None:
+    """Apply a template to create a configuration file.
+
+    Args:
+        template: Template to apply
+        output_path: Path to write configuration file
+        overrides: Optional configuration overrides to merge
+
+    Raises:
+        FileExistsError: If output file already exists
+    """
+    if output_path.exists():
+        raise FileExistsError(f"Configuration file already exists: {output_path}")
+
+    # Start with template config
+    config = template.config.copy()
+
+    # Apply overrides if provided
+    if overrides:
+        config.update(overrides)
+
+    # Write to YAML
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        yaml.dump(config, f, sort_keys=False, default_flow_style=False)
+
+
+def validate_template(template: MCPTemplate) -> list[str]:
+    """Validate that a template is well-formed.
+
+    Args:
+        template: Template to validate
+
+    Returns:
+        List of validation errors (empty if valid)
+    """
+    errors = []
+
+    # Check required fields
+    if not template.id:
+        errors.append("Template must have an id")
+    if not template.name:
+        errors.append("Template must have a name")
+    if not template.description:
+        errors.append("Template must have a description")
+
+    # Validate config structure
+    if not template.config:
+        errors.append("Template must have a config section")
+    elif not isinstance(template.config, dict):
+        errors.append("Template config must be a dictionary")
+    else:
+        # Check for required config keys
+        if "mcp_server" not in template.config:
+            errors.append("Template config must include mcp_server section")
+        else:
+            mcp = template.config["mcp_server"]
+            if not isinstance(mcp, dict):
+                errors.append("mcp_server must be a dictionary")
+            else:
+                if "command" not in mcp:
+                    errors.append("mcp_server must specify command")
+                if "args" not in mcp:
+                    errors.append("mcp_server must specify args")
+
+    # Validate env_vars match config
+    if template.env_vars and "mcp_server" in template.config:
+        mcp = template.config["mcp_server"]
+        if isinstance(mcp, dict) and "env" in mcp:
+            env = mcp["env"]
+            if isinstance(env, dict):
+                config_env_vars = set(env.keys())
+                declared_env_vars = set(template.env_vars)
+                # Check if declared env vars are used in config
+                for var in declared_env_vars:
+                    if var not in config_env_vars:
+                        # Check if it's referenced with ${VAR} syntax
+                        env_str = str(env)
+                        if f"${{{var}}}" not in env_str:
+                            errors.append(
+                                f"Declared env var '{var}' not found in config"
+                            )
+
+    return errors
+
+
+def _load_builtin_templates() -> None:
+    """Load all built-in templates from the templates directory."""
+    try:
+        # Try to load templates from package resources
+        if hasattr(importlib.resources, "files"):
+            # Python 3.9+
+            try:
+                templates_dir = importlib.resources.files("mcpbr") / "data" / "templates"
+                # Use iterdir() for traversable paths
+                for item in templates_dir.iterdir():
+                    if item.name.endswith(".yaml"):
+                        try:
+                            # Read the template file
+                            content = item.read_text()
+                            data = yaml.safe_load(content)
+                            if isinstance(data, dict):
+                                template = MCPTemplate(**data)
+                                register_template(template)
+                        except Exception:
+                            # Skip invalid templates
+                            pass
+            except Exception:
+                # Directory doesn't exist or can't be read
+                pass
+    except Exception:
+        # If loading fails, we just won't have built-in templates
+        pass
+
+
+# Load built-in templates on module import
+_load_builtin_templates()

--- a/src/mcpbr/templates.py
+++ b/src/mcpbr/templates.py
@@ -18,15 +18,11 @@ class MCPTemplate(BaseModel):
     id: str = Field(description="Unique template identifier")
     name: str = Field(description="Human-readable template name")
     description: str = Field(description="Description of what this MCP server does")
-    package: str | None = Field(
-        default=None, description="NPM package or Python package name"
-    )
+    package: str | None = Field(default=None, description="NPM package or Python package name")
     requires_api_key: bool = Field(
         default=False, description="Whether this server requires an API key"
     )
-    env_vars: list[str] = Field(
-        default_factory=list, description="Required environment variables"
-    )
+    env_vars: list[str] = Field(default_factory=list, description="Required environment variables")
     config: dict[str, Any] = Field(description="Template configuration")
 
 
@@ -89,7 +85,9 @@ def load_template_from_yaml(yaml_path: Path) -> MCPTemplate:
     return MCPTemplate(**data)
 
 
-def apply_template(template: MCPTemplate, output_path: Path, overrides: dict[str, Any] | None = None) -> None:
+def apply_template(
+    template: MCPTemplate, output_path: Path, overrides: dict[str, Any] | None = None
+) -> None:
     """Apply a template to create a configuration file.
 
     Args:
@@ -168,9 +166,7 @@ def validate_template(template: MCPTemplate) -> list[str]:
                         # Check if it's referenced with ${VAR} syntax
                         env_str = str(env)
                         if f"${{{var}}}" not in env_str:
-                            errors.append(
-                                f"Declared env var '{var}' not found in config"
-                            )
+                            errors.append(f"Declared env var '{var}' not found in config")
 
     return errors
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,469 @@
+"""Tests for MCP server configuration templates."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from mcpbr.templates import (
+    MCPTemplate,
+    apply_template,
+    get_template,
+    list_templates,
+    load_template_from_yaml,
+    register_template,
+    validate_template,
+)
+
+
+class TestMCPTemplate:
+    """Tests for MCPTemplate model."""
+
+    def test_basic_creation(self) -> None:
+        """Test basic template creation."""
+        template = MCPTemplate(
+            id="test",
+            name="Test Template",
+            description="A test template",
+            config={
+                "mcp_server": {
+                    "command": "npx",
+                    "args": ["-y", "test-server"],
+                }
+            },
+        )
+        assert template.id == "test"
+        assert template.name == "Test Template"
+        assert template.description == "A test template"
+        assert not template.requires_api_key
+        assert template.env_vars == []
+
+    def test_template_with_api_key(self) -> None:
+        """Test template with API key requirement."""
+        template = MCPTemplate(
+            id="test",
+            name="Test",
+            description="Test",
+            requires_api_key=True,
+            env_vars=["TEST_API_KEY"],
+            config={
+                "mcp_server": {
+                    "command": "npx",
+                    "args": ["-y", "test-server"],
+                    "env": {"TEST_API_KEY": "${TEST_API_KEY}"},
+                }
+            },
+        )
+        assert template.requires_api_key
+        assert "TEST_API_KEY" in template.env_vars
+
+
+class TestTemplateRegistry:
+    """Tests for template registry functions."""
+
+    def test_register_and_get_template(self) -> None:
+        """Test registering and retrieving a template."""
+        template = MCPTemplate(
+            id="test-registry",
+            name="Test",
+            description="Test",
+            config={
+                "mcp_server": {
+                    "command": "npx",
+                    "args": ["-y", "test"],
+                }
+            },
+        )
+        register_template(template)
+
+        retrieved = get_template("test-registry")
+        assert retrieved is not None
+        assert retrieved.id == "test-registry"
+
+    def test_get_nonexistent_template(self) -> None:
+        """Test getting a template that doesn't exist."""
+        template = get_template("nonexistent-template-xyz")
+        assert template is None
+
+    def test_list_templates(self) -> None:
+        """Test listing all templates."""
+        templates = list_templates()
+        assert isinstance(templates, list)
+        # Should include built-in templates
+        assert len(templates) > 0
+
+    def test_builtin_templates_exist(self) -> None:
+        """Test that built-in templates are loaded."""
+        templates = list_templates()
+        template_ids = {t.id for t in templates}
+
+        # Check for expected built-in templates
+        expected_templates = {
+            "filesystem",
+            "brave-search",
+            "postgres",
+            "sqlite",
+            "github",
+        }
+        for expected in expected_templates:
+            assert expected in template_ids, f"Template {expected} not found"
+
+
+class TestLoadTemplateFromYaml:
+    """Tests for loading templates from YAML files."""
+
+    def test_load_valid_template(self) -> None:
+        """Test loading a valid template from YAML."""
+        yaml_content = """
+id: test-yaml
+name: Test YAML Template
+description: A template loaded from YAML
+package: "@test/package"
+requires_api_key: false
+env_vars: []
+config:
+  mcp_server:
+    command: npx
+    args:
+      - "-y"
+      - "@test/package"
+  provider: anthropic
+  model: sonnet
+"""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as f:
+            f.write(yaml_content)
+            f.flush()
+            temp_path = Path(f.name)
+
+        try:
+            template = load_template_from_yaml(temp_path)
+            assert template.id == "test-yaml"
+            assert template.name == "Test YAML Template"
+            assert template.package == "@test/package"
+            assert "mcp_server" in template.config
+        finally:
+            temp_path.unlink()
+
+    def test_load_nonexistent_file(self) -> None:
+        """Test loading from nonexistent file raises error."""
+        with pytest.raises(FileNotFoundError):
+            load_template_from_yaml(Path("/nonexistent/template.yaml"))
+
+    def test_load_invalid_yaml(self) -> None:
+        """Test loading invalid YAML raises error."""
+        yaml_content = "not: a: valid: template:"
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as f:
+            f.write(yaml_content)
+            f.flush()
+            temp_path = Path(f.name)
+
+        try:
+            with pytest.raises(Exception):
+                load_template_from_yaml(temp_path)
+        finally:
+            temp_path.unlink()
+
+
+class TestApplyTemplate:
+    """Tests for applying templates to create config files."""
+
+    def test_apply_basic_template(self) -> None:
+        """Test applying a basic template."""
+        template = MCPTemplate(
+            id="test-apply",
+            name="Test Apply",
+            description="Test template application",
+            config={
+                "mcp_server": {
+                    "command": "npx",
+                    "args": ["-y", "test-server"],
+                    "env": {},
+                },
+                "provider": "anthropic",
+                "model": "sonnet",
+            },
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "config.yaml"
+            apply_template(template, output_path)
+
+            # Verify file was created
+            assert output_path.exists()
+
+            # Verify content
+            with open(output_path) as f:
+                config = yaml.safe_load(f)
+
+            assert "mcp_server" in config
+            assert config["mcp_server"]["command"] == "npx"
+            assert config["provider"] == "anthropic"
+
+    def test_apply_template_with_overrides(self) -> None:
+        """Test applying template with configuration overrides."""
+        template = MCPTemplate(
+            id="test-override",
+            name="Test Override",
+            description="Test overrides",
+            config={
+                "mcp_server": {
+                    "command": "npx",
+                    "args": ["-y", "test"],
+                },
+                "model": "sonnet",
+                "sample_size": 10,
+            },
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "config.yaml"
+            overrides = {"sample_size": 20, "timeout_seconds": 600}
+            apply_template(template, output_path, overrides)
+
+            with open(output_path) as f:
+                config = yaml.safe_load(f)
+
+            assert config["sample_size"] == 20
+            assert config["timeout_seconds"] == 600
+
+    def test_apply_template_file_exists(self) -> None:
+        """Test that applying to existing file raises error."""
+        template = MCPTemplate(
+            id="test-exists",
+            name="Test",
+            description="Test",
+            config={"mcp_server": {"command": "npx", "args": []}},
+        )
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as f:
+            temp_path = Path(f.name)
+
+        try:
+            with pytest.raises(FileExistsError):
+                apply_template(template, temp_path)
+        finally:
+            temp_path.unlink()
+
+
+class TestValidateTemplate:
+    """Tests for template validation."""
+
+    def test_validate_valid_template(self) -> None:
+        """Test validation of a valid template."""
+        template = MCPTemplate(
+            id="valid-test",
+            name="Valid Template",
+            description="A valid template",
+            config={
+                "mcp_server": {
+                    "command": "npx",
+                    "args": ["-y", "test-server"],
+                }
+            },
+        )
+
+        errors = validate_template(template)
+        assert len(errors) == 0
+
+    def test_validate_missing_id(self) -> None:
+        """Test validation fails for missing id."""
+        template = MCPTemplate(
+            id="",
+            name="Test",
+            description="Test",
+            config={
+                "mcp_server": {
+                    "command": "npx",
+                    "args": [],
+                }
+            },
+        )
+
+        errors = validate_template(template)
+        assert any("id" in error.lower() for error in errors)
+
+    def test_validate_missing_mcp_server(self) -> None:
+        """Test validation fails for missing mcp_server."""
+        template = MCPTemplate(
+            id="test",
+            name="Test",
+            description="Test",
+            config={"provider": "anthropic"},
+        )
+
+        errors = validate_template(template)
+        assert any("mcp_server" in error for error in errors)
+
+    def test_validate_missing_command(self) -> None:
+        """Test validation fails for missing command."""
+        template = MCPTemplate(
+            id="test",
+            name="Test",
+            description="Test",
+            config={"mcp_server": {"args": []}},
+        )
+
+        errors = validate_template(template)
+        assert any("command" in error for error in errors)
+
+    def test_validate_missing_args(self) -> None:
+        """Test validation fails for missing args."""
+        template = MCPTemplate(
+            id="test",
+            name="Test",
+            description="Test",
+            config={"mcp_server": {"command": "npx"}},
+        )
+
+        errors = validate_template(template)
+        assert any("args" in error for error in errors)
+
+
+class TestBuiltinTemplates:
+    """Tests for built-in templates."""
+
+    def test_filesystem_template(self) -> None:
+        """Test filesystem template is valid."""
+        template = get_template("filesystem")
+        assert template is not None
+        assert template.id == "filesystem"
+        assert template.name == "Filesystem Server"
+        assert not template.requires_api_key
+        assert len(template.env_vars) == 0
+
+        # Validate structure
+        errors = validate_template(template)
+        assert len(errors) == 0
+
+    def test_brave_search_template(self) -> None:
+        """Test Brave Search template is valid."""
+        template = get_template("brave-search")
+        assert template is not None
+        assert template.id == "brave-search"
+        assert template.requires_api_key
+        assert "BRAVE_API_KEY" in template.env_vars
+
+        # Validate structure
+        errors = validate_template(template)
+        assert len(errors) == 0
+
+    def test_postgres_template(self) -> None:
+        """Test PostgreSQL template is valid."""
+        template = get_template("postgres")
+        assert template is not None
+        assert template.id == "postgres"
+        assert "POSTGRES_CONNECTION_STRING" in template.env_vars
+
+        # Validate structure
+        errors = validate_template(template)
+        assert len(errors) == 0
+
+    def test_sqlite_template(self) -> None:
+        """Test SQLite template is valid."""
+        template = get_template("sqlite")
+        assert template is not None
+        assert template.id == "sqlite"
+        assert not template.requires_api_key
+
+        # Validate structure
+        errors = validate_template(template)
+        assert len(errors) == 0
+
+    def test_github_template(self) -> None:
+        """Test GitHub template is valid."""
+        template = get_template("github")
+        assert template is not None
+        assert template.id == "github"
+        assert template.requires_api_key
+        assert "GITHUB_PERSONAL_ACCESS_TOKEN" in template.env_vars
+
+        # Validate structure
+        errors = validate_template(template)
+        assert len(errors) == 0
+
+    def test_all_builtin_templates_valid(self) -> None:
+        """Test that all built-in templates are valid."""
+        templates = list_templates()
+        assert len(templates) > 0
+
+        for template in templates:
+            errors = validate_template(template)
+            assert (
+                len(errors) == 0
+            ), f"Template {template.id} has validation errors: {errors}"
+
+    def test_builtin_templates_have_required_fields(self) -> None:
+        """Test that all built-in templates have required config fields."""
+        # Only test known built-in templates
+        builtin_ids = [
+            "filesystem",
+            "brave-search",
+            "postgres",
+            "sqlite",
+            "github",
+            "google-maps",
+            "slack",
+        ]
+
+        for template_id in builtin_ids:
+            template = get_template(template_id)
+            if template is None:
+                continue
+
+            # Check MCP server config
+            assert "mcp_server" in template.config
+            mcp = template.config["mcp_server"]
+            assert "command" in mcp
+            assert "args" in mcp
+
+            # Check common fields
+            assert "provider" in template.config
+            assert "agent_harness" in template.config
+            assert "model" in template.config
+
+
+class TestTemplateIntegration:
+    """Integration tests for template system."""
+
+    def test_load_apply_and_load_config(self) -> None:
+        """Test full workflow: load template, apply it, load config."""
+        from mcpbr.config import load_config
+
+        template = get_template("filesystem")
+        assert template is not None
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "test-config.yaml"
+            apply_template(template, config_path)
+
+            # Load the generated config
+            config = load_config(config_path)
+
+            # Verify it's valid
+            assert config.mcp_server.command == "npx"
+            assert config.provider == "anthropic"
+            assert config.agent_harness == "claude-code"
+
+    def test_template_with_workdir_placeholder(self) -> None:
+        """Test that templates with {workdir} work correctly."""
+        template = get_template("filesystem")
+        assert template is not None
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "test-config.yaml"
+            apply_template(template, config_path)
+
+            # Load and test workdir substitution
+            from mcpbr.config import load_config
+
+            config = load_config(config_path)
+            args = config.mcp_server.get_args_for_workdir("/test/path")
+            assert "/test/path" in args

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -131,9 +131,7 @@ config:
   provider: anthropic
   model: sonnet
 """
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".yaml", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             f.write(yaml_content)
             f.flush()
             temp_path = Path(f.name)
@@ -156,9 +154,7 @@ config:
         """Test loading invalid YAML raises error."""
         yaml_content = "not: a: valid: template:"
 
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".yaml", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             f.write(yaml_content)
             f.flush()
             temp_path = Path(f.name)
@@ -241,9 +237,7 @@ class TestApplyTemplate:
             config={"mcp_server": {"command": "npx", "args": []}},
         )
 
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".yaml", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             temp_path = Path(f.name)
 
         try:
@@ -396,9 +390,7 @@ class TestBuiltinTemplates:
 
         for template in templates:
             errors = validate_template(template)
-            assert (
-                len(errors) == 0
-            ), f"Template {template.id} has validation errors: {errors}"
+            assert len(errors) == 0, f"Template {template.id} has validation errors: {errors}"
 
     def test_builtin_templates_have_required_fields(self) -> None:
         """Test that all built-in templates have required config fields."""

--- a/uv.lock
+++ b/uv.lock
@@ -1038,7 +1038,7 @@ wheels = [
 
 [[package]]
 name = "mcpbr"
-version = "0.2.0"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

This PR implements a comprehensive configuration template system for popular MCP servers, addressing issue #97. Templates reduce configuration friction by providing pre-configured settings for common MCP servers.

## Features Implemented

### Template System
- ✅ Template storage module with Pydantic models
- ✅ Template registry and validation system
- ✅ Built-in template loading from package resources
- ✅ Template validation with detailed error messages

### Built-in Templates (7 total)
- ✅ `filesystem` - File system access (no API key)
- ✅ `brave-search` - Web search using Brave Search API
- ✅ `postgres` - PostgreSQL database access
- ✅ `sqlite` - SQLite database access  
- ✅ `github` - GitHub API integration
- ✅ `google-maps` - Google Maps APIs
- ✅ `slack` - Slack workspace integration

### CLI Commands
- ✅ `mcpbr config list` - List available templates with metadata
- ✅ `mcpbr config apply <template-id>` - Apply template to create config
- ✅ `mcpbr init -t <template-id>` - Use template during init
- ✅ `mcpbr init -i` - Interactive template selection wizard

### Testing & Documentation
- ✅ 26 comprehensive unit tests (all passing)
- ✅ Integration tests for end-to-end workflow
- ✅ Updated CLI documentation with template commands
- ✅ Updated configuration guide with template usage
- ✅ New dedicated template documentation page
- ✅ Template contribution guidelines

## Usage Examples

### List templates
```bash
mcpbr config list
```

### Apply a template
```bash
mcpbr config apply filesystem
mcpbr config apply brave-search -o brave.yaml
```

### Interactive selection
```bash
mcpbr init -i
```

### Use template during init
```bash
mcpbr init -t github
```

## Template Format

Templates include:
- Metadata (id, name, description, package, API key requirements)
- Complete mcpbr configuration
- Environment variable documentation
- Clear setup instructions

## Testing

All tests pass:
```bash
uv run pytest tests/ -m "not integration"
# 104 passed, 8 deselected in 0.50s
```

Template-specific tests:
```bash
uv run pytest tests/test_templates.py -v
# 26 passed
```

## Documentation

- Updated `docs/cli.md` with new config commands
- Updated `docs/configuration.md` with template usage
- Added `docs/templates.md` with comprehensive template guide
- Includes contribution guidelines for community templates

## Breaking Changes

None. This is a purely additive feature.

## Checklist

- [x] Implementation complete with all requested features
- [x] 7+ built-in templates for popular MCP servers
- [x] CLI commands for listing and applying templates
- [x] Interactive wizard integration
- [x] Template validation system
- [x] Comprehensive unit tests (100% passing)
- [x] Documentation updated
- [x] Template contribution guide created
- [x] No breaking changes

## Closes

Closes #97