### PR TITLE
feat: add incremental saving to prevent data loss on crash

### DIFF
--- a/src/mcpbr/incremental_save.py
+++ b/src/mcpbr/incremental_save.py
@@ -1,0 +1,147 @@
+"""Incremental saving of evaluation results to prevent data loss on crash."""
+
+import fcntl
+import json
+from pathlib import Path
+from typing import Any
+
+
+def save_task_result_incremental(
+    task_result: Any,  # TaskResult from harness module
+    output_path: Path,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    """Save a single task result incrementally to a JSON Lines file.
+
+    Uses file locking to ensure safe concurrent writes. Each task result is
+    written as a separate JSON object on its own line, allowing for easy
+    recovery of partial results if the run crashes.
+
+    Args:
+        task_result: Task result to save (TaskResult dataclass).
+        output_path: Path to the incremental results file (will be created if needed).
+        metadata: Optional metadata to include on first write.
+    """
+    # Convert to .jsonl extension for clarity
+    if output_path.suffix != ".jsonl":
+        output_path = output_path.with_suffix(output_path.suffix + ".jsonl")
+
+    # Prepare task data - TaskResult has mcp and baseline dicts
+    task_data = {
+        "instance_id": task_result.instance_id,
+        "mcp": task_result.mcp,
+        "baseline": task_result.baseline,
+    }
+
+    # On first write, include metadata
+    is_new_file = not output_path.exists()
+
+    # Open file in append mode with exclusive lock
+    with open(output_path, "a") as f:
+        # Acquire exclusive lock (blocks until available)
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+
+        try:
+            # Write metadata header if this is a new file
+            if is_new_file and metadata:
+                header = {"type": "metadata", "data": metadata}
+                f.write(json.dumps(header) + "\n")
+
+            # Write task result
+            result_entry = {"type": "task_result", "data": task_data}
+            f.write(json.dumps(result_entry) + "\n")
+            f.flush()  # Ensure it's written to disk immediately
+        finally:
+            # Release lock
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+
+def load_incremental_results(output_path: Path) -> tuple[dict[str, Any] | None, list[dict]]:
+    """Load partial results from an incremental save file.
+
+    Args:
+        output_path: Path to the incremental results file.
+
+    Returns:
+        Tuple of (metadata, list of task results).
+        Returns (None, []) if file doesn't exist or is empty.
+    """
+    # Handle .jsonl extension
+    if (
+        output_path.suffix != ".jsonl"
+        and (output_path.parent / (output_path.name + ".jsonl")).exists()
+    ):
+        output_path = output_path.parent / (output_path.name + ".jsonl")
+
+    if not output_path.exists():
+        return None, []
+
+    metadata = None
+    task_results = []
+
+    with open(output_path) as f:
+        # Acquire shared lock for reading
+        fcntl.flock(f.fileno(), fcntl.LOCK_SH)
+
+        try:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+
+                try:
+                    entry = json.loads(line)
+                    if entry.get("type") == "metadata":
+                        metadata = entry.get("data")
+                    elif entry.get("type") == "task_result":
+                        task_results.append(entry.get("data"))
+                except json.JSONDecodeError:
+                    # Skip malformed lines (partial writes during crash)
+                    continue
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+    return metadata, task_results
+
+
+def convert_incremental_to_final(
+    incremental_path: Path,
+    final_path: Path,
+    summary: dict[str, Any],
+) -> None:
+    """Convert incremental save file to final JSON results format.
+
+    Args:
+        incremental_path: Path to the incremental .jsonl file.
+        final_path: Path to write the final JSON results.
+        summary: Summary statistics to include in final results.
+    """
+    metadata, task_results = load_incremental_results(incremental_path)
+
+    if metadata is None:
+        metadata = {}
+
+    final_results = {
+        "metadata": metadata,
+        "summary": summary,
+        "tasks": task_results,
+    }
+
+    with open(final_path, "w") as f:
+        json.dump(final_results, f, indent=2)
+
+
+def cleanup_incremental_file(output_path: Path) -> None:
+    """Remove incremental save file after successful completion.
+
+    Args:
+        output_path: Path to the incremental results file.
+    """
+    # Handle .jsonl extension
+    if output_path.suffix != ".jsonl":
+        jsonl_path = output_path.with_suffix(output_path.suffix + ".jsonl")
+    else:
+        jsonl_path = output_path
+
+    if jsonl_path.exists():
+        jsonl_path.unlink()

--- a/src/mcpbr/incremental_save.py
+++ b/src/mcpbr/incremental_save.py
@@ -33,8 +33,8 @@ def save_task_result_incremental(
         "baseline": task_result.baseline,
     }
 
-    # On first write, include metadata
-    is_new_file = not output_path.exists()
+    # Ensure parent directory exists for incremental writes
+    output_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Open file in append mode with exclusive lock
     with open(output_path, "a") as f:
@@ -42,6 +42,8 @@ def save_task_result_incremental(
         fcntl.flock(f.fileno(), fcntl.LOCK_EX)
 
         try:
+            # Determine new/empty file under lock to avoid races
+            is_new_file = f.tell() == 0
             # Write metadata header if this is a new file
             if is_new_file and metadata:
                 header = {"type": "metadata", "data": metadata}

--- a/tests/test_incremental_save.py
+++ b/tests/test_incremental_save.py
@@ -1,0 +1,261 @@
+"""Tests for incremental saving of evaluation results."""
+
+import json
+from pathlib import Path
+
+from mcpbr.harness import TaskResult
+from mcpbr.incremental_save import (
+    cleanup_incremental_file,
+    convert_incremental_to_final,
+    load_incremental_results,
+    save_task_result_incremental,
+)
+
+
+class TestIncrementalSave:
+    """Test incremental saving functionality."""
+
+    def test_save_single_result(self, tmp_path: Path):
+        """Test saving a single task result."""
+        output_file = tmp_path / "results.jsonl"
+
+        task_result = TaskResult(
+            instance_id="test-1",
+            mcp={"resolved": True, "cost": 0.50, "error": None, "patch": "test patch"},
+            baseline=None,
+        )
+
+        metadata = {"timestamp": "2024-01-01T00:00:00Z", "config": {"model": "sonnet"}}
+
+        save_task_result_incremental(task_result, output_file, metadata)
+
+        assert output_file.exists()
+
+        # Verify file content
+        with open(output_file) as f:
+            lines = f.readlines()
+
+        assert len(lines) == 2  # Metadata + one result
+
+        # Check metadata
+        metadata_entry = json.loads(lines[0])
+        assert metadata_entry["type"] == "metadata"
+        assert metadata_entry["data"]["timestamp"] == "2024-01-01T00:00:00Z"
+
+        # Check task result
+        result_entry = json.loads(lines[1])
+        assert result_entry["type"] == "task_result"
+        assert result_entry["data"]["instance_id"] == "test-1"
+        assert result_entry["data"]["mcp"]["resolved"] is True
+        assert result_entry["data"]["mcp"]["cost"] == 0.50
+
+    def test_save_multiple_results(self, tmp_path: Path):
+        """Test saving multiple task results."""
+        output_file = tmp_path / "results.jsonl"
+
+        metadata = {"config": {"model": "sonnet"}}
+
+        # Save first result with metadata
+        task1 = TaskResult(
+            instance_id="test-1",
+            mcp={"resolved": True, "cost": 0.50, "error": None, "patch": "patch1"},
+        )
+        save_task_result_incremental(task1, output_file, metadata)
+
+        # Save second result without metadata (should be None after first save)
+        task2 = TaskResult(
+            instance_id="test-2",
+            mcp={"resolved": False, "cost": 0.25, "error": "Timeout", "patch": None},
+        )
+        save_task_result_incremental(task2, output_file, None)
+
+        # Save third result
+        task3 = TaskResult(
+            instance_id="test-3",
+            mcp={"resolved": True, "cost": 0.75, "error": None, "patch": "patch3"},
+        )
+        save_task_result_incremental(task3, output_file, None)
+
+        # Verify all results saved
+        with open(output_file) as f:
+            lines = f.readlines()
+
+        assert len(lines) == 4  # Metadata + 3 results
+
+    def test_load_incremental_results(self, tmp_path: Path):
+        """Test loading partial results from file."""
+        output_file = tmp_path / "results.jsonl"
+
+        metadata = {"timestamp": "2024-01-01", "config": {"model": "sonnet"}}
+
+        # Save multiple results
+        for i in range(3):
+            task = TaskResult(
+                instance_id=f"test-{i}",
+                mcp={
+                    "resolved": i % 2 == 0,
+                    "cost": 0.1 * i,
+                    "error": None if i % 2 == 0 else "Error",
+                    "patch": f"patch-{i}" if i % 2 == 0 else None,
+                },
+            )
+            save_task_result_incremental(task, output_file, metadata if i == 0 else None)
+
+        # Load results
+        loaded_metadata, task_results = load_incremental_results(output_file)
+
+        assert loaded_metadata is not None
+        assert loaded_metadata["timestamp"] == "2024-01-01"
+        assert len(task_results) == 3
+        assert task_results[0]["instance_id"] == "test-0"
+        assert task_results[1]["instance_id"] == "test-1"
+        assert task_results[2]["instance_id"] == "test-2"
+
+    def test_load_nonexistent_file(self, tmp_path: Path):
+        """Test loading from nonexistent file returns empty results."""
+        output_file = tmp_path / "nonexistent.jsonl"
+
+        metadata, results = load_incremental_results(output_file)
+
+        assert metadata is None
+        assert results == []
+
+    def test_handle_malformed_lines(self, tmp_path: Path):
+        """Test that malformed lines are skipped gracefully."""
+        output_file = tmp_path / "results.jsonl"
+
+        # Write a mix of valid and invalid lines
+        with open(output_file, "w") as f:
+            f.write('{"type": "metadata", "data": {"config": "test"}}\n')
+            f.write('{"type": "task_result", "data": {"instance_id": "test-1"}}\n')
+            f.write("invalid json line\n")  # Malformed
+            f.write('{"type": "task_result", "data": {"instance_id": "test-2"}}\n')
+            f.write("{incomplete\n")  # Malformed
+
+        metadata, results = load_incremental_results(output_file)
+
+        assert metadata is not None
+        assert len(results) == 2  # Should skip malformed lines
+        assert results[0]["instance_id"] == "test-1"
+        assert results[1]["instance_id"] == "test-2"
+
+    def test_convert_to_final_format(self, tmp_path: Path):
+        """Test converting incremental saves to final JSON format."""
+        incremental_file = tmp_path / "results.jsonl"
+        final_file = tmp_path / "results.json"
+
+        metadata = {"timestamp": "2024-01-01", "config": {"model": "sonnet"}}
+
+        # Save incremental results
+        for i in range(2):
+            task = TaskResult(
+                instance_id=f"test-{i}",
+                mcp={"resolved": True, "cost": 0.5, "error": None, "patch": f"patch-{i}"},
+            )
+            save_task_result_incremental(task, incremental_file, metadata if i == 0 else None)
+
+        # Convert to final format
+        summary = {"total": 2, "resolved": 2, "cost": 1.0}
+        convert_incremental_to_final(incremental_file, final_file, summary)
+
+        assert final_file.exists()
+
+        # Verify final format
+        with open(final_file) as f:
+            final_data = json.load(f)
+
+        assert "metadata" in final_data
+        assert "summary" in final_data
+        assert "tasks" in final_data
+        assert len(final_data["tasks"]) == 2
+        assert final_data["summary"]["total"] == 2
+
+    def test_cleanup_incremental_file(self, tmp_path: Path):
+        """Test cleanup of incremental save file."""
+        output_file = tmp_path / "results.json"
+        incremental_file = tmp_path / "results.json.jsonl"  # It appends .jsonl
+
+        # Create incremental file
+        task = TaskResult(
+            instance_id="test-1",
+            mcp={"resolved": True, "cost": 0.5, "error": None, "patch": "patch"},
+        )
+        save_task_result_incremental(task, output_file, None)
+
+        # File should exist with .jsonl extension
+        assert incremental_file.exists()
+
+        # Cleanup
+        cleanup_incremental_file(output_file)
+
+        # File should be removed
+        assert not incremental_file.exists()
+
+    def test_jsonl_extension_handling(self, tmp_path: Path):
+        """Test that .jsonl extension is properly handled."""
+        # Test with .json extension
+        output_file = tmp_path / "results.json"
+
+        task = TaskResult(
+            instance_id="test-1",
+            mcp={"resolved": True, "cost": 0.5, "error": None, "patch": "patch"},
+        )
+        save_task_result_incremental(task, output_file, None)
+
+        # Should create .json.jsonl file
+        jsonl_file = tmp_path / "results.json.jsonl"
+        assert jsonl_file.exists()
+
+        # Loading should work with either path
+        metadata1, results1 = load_incremental_results(output_file)
+        metadata2, results2 = load_incremental_results(jsonl_file)
+
+        assert results1 == results2
+
+    def test_concurrent_writes_safe(self, tmp_path: Path):
+        """Test that file locking makes concurrent writes safe."""
+        import asyncio
+
+        output_file = tmp_path / "results.jsonl"
+
+        async def write_result(idx: int):
+            """Write a single result."""
+            task = TaskResult(
+                instance_id=f"test-{idx}",
+                mcp={"resolved": True, "cost": 0.1, "error": None, "patch": f"patch-{idx}"},
+            )
+            # Simulate delay
+            await asyncio.sleep(0.01)
+            save_task_result_incremental(task, output_file, None)
+
+        async def run_concurrent_writes():
+            """Run multiple concurrent writes."""
+            tasks = [write_result(i) for i in range(10)]
+            await asyncio.gather(*tasks)
+
+        # Run concurrent writes
+        asyncio.run(run_concurrent_writes())
+
+        # Verify all results were saved
+        _, results = load_incremental_results(output_file)
+        assert len(results) == 10
+
+        # Verify all unique IDs
+        ids = [r["instance_id"] for r in results]
+        assert len(set(ids)) == 10
+
+    def test_save_with_none_values(self, tmp_path: Path):
+        """Test saving task results with None values."""
+        output_file = tmp_path / "results.jsonl"
+
+        task = TaskResult(
+            instance_id="test-1",
+            mcp={"resolved": False, "cost": 0.0, "error": "Failed", "patch": None},
+        )
+
+        save_task_result_incremental(task, output_file, None)
+
+        _, results = load_incremental_results(output_file)
+        assert len(results) == 1
+        assert results[0]["mcp"]["patch"] is None
+        assert results[0]["mcp"]["error"] == "Failed"

--- a/uv.lock
+++ b/uv.lock
@@ -1038,7 +1038,7 @@ wheels = [
 
 [[package]]
 name = "mcpbr"
-version = "0.2.3"
+version = "0.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Implements incremental saving of evaluation results to prevent data loss when runs crash or are interrupted. Results are now saved incrementally after each task completion, allowing partial results to be recovered.

Closes #2

## Changes

### Core Implementation
- **New module**: `src/mcpbr/incremental_save.py`
  - `save_task_result_incremental()`: Saves individual task results to JSON Lines format with file locking
  - `load_incremental_results()`: Loads partial results from incremental save files
  - `convert_incremental_to_final()`: Converts incremental saves to final JSON format
  - `cleanup_incremental_file()`: Removes incremental files after successful completion

### Integration
- **Updated `harness.py`**: 
  - Calls `save_task_result_incremental()` after each task completion
  - Saves metadata on first write
  - Works in both verbose and progress bar modes

- **Updated `cli.py`**:
  - Automatically creates incremental save path when output path is specified
  - Cleans up incremental files after successful completion

### Features
- **JSON Lines Format**: Each task result written as a separate JSON object on its own line
- **File Locking**: Uses `fcntl` for safe concurrent writes
- **Crash Recovery**: Malformed lines from incomplete writes are skipped gracefully
- **Automatic Extension**: Files automatically use `.jsonl` extension for clarity

### Testing
- **10 comprehensive tests** covering:
  - Single and multiple result saves
  - Loading incremental results
  - Handling nonexistent files
  - Graceful handling of malformed lines
  - Conversion to final format
  - Cleanup functionality
  - Extension handling
  - Concurrent write safety
  - None value handling

## Test Results

```
tests/test_incremental_save.py::TestIncrementalSave::test_save_single_result PASSED
tests/test_incremental_save.py::TestIncrementalSave::test_save_multiple_results PASSED
tests/test_incremental_save.py::TestIncrementalSave::test_load_incremental_results PASSED
tests/test_incremental_save.py::TestIncrementalSave::test_load_nonexistent_file PASSED
tests/test_incremental_save.py::TestIncrementalSave::test_handle_malformed_lines PASSED
tests/test_incremental_save.py::TestIncrementalSave::test_convert_to_final_format PASSED
tests/test_incremental_save.py::TestIncrementalSave::test_cleanup_incremental_file PASSED
tests/test_incremental_save.py::TestIncrementalSave::test_jsonl_extension_handling PASSED
tests/test_incremental_save.py::TestIncrementalSave::test_concurrent_writes_safe PASSED
tests/test_incremental_save.py::TestIncrementalSave::test_save_with_none_values PASSED

10 passed in 0.42s
```

## Usage

When running evaluations with an output path specified, results are now automatically saved incrementally:

```bash
mcpbr run -c config.yaml -o results.json
```

This creates:
- `results.json.jsonl` - Incremental saves during run
- `results.json` - Final results after completion

If the run crashes, you can recover partial results from the `.jsonl` file.

## Implementation Details

### File Format

The incremental save file uses JSON Lines format:
```jsonl
{"type": "metadata", "data": {"timestamp": "...", "config": {...}}}
{"type": "task_result", "data": {"instance_id": "...", "mcp": {...}, "baseline": {...}}}
{"type": "task_result", "data": {"instance_id": "...", "mcp": {...}, "baseline": {...}}}
```

### Concurrency Safety

Uses `fcntl.flock()` for exclusive locking during writes and shared locking during reads, ensuring safe concurrent access from multiple processes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Evaluation runs now support automatic incremental progress saving with recovery. Results are continuously recorded as they complete, enabling interrupted evaluations to resume from the last saved checkpoint without losing progress. Execution context and run metadata are automatically preserved to maintain full traceability during recovery operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->