### PR TITLE
feat: Benchmark Result Caching

### DIFF
--- a/src/mcpbr/cache.py
+++ b/src/mcpbr/cache.py
@@ -1,0 +1,414 @@
+"""Result caching system for benchmark evaluations.
+
+This module provides a content-based caching mechanism to avoid re-running
+identical evaluations. Cache keys are computed from task content, configuration,
+and prompt to ensure cache hits only occur for truly identical evaluations.
+"""
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .config import HarnessConfig
+
+
+@dataclass
+class CacheStats:
+    """Statistics about cache usage."""
+
+    total_entries: int
+    total_size_bytes: int
+    oldest_entry: datetime | None
+    newest_entry: datetime | None
+    cache_dir: Path
+
+    def format_size(self) -> str:
+        """Format cache size in human-readable format."""
+        size = self.total_size_bytes
+        for unit in ["B", "KB", "MB", "GB"]:
+            if size < 1024.0:
+                return f"{size:.1f} {unit}"
+            size /= 1024.0
+        return f"{size:.1f} TB"
+
+
+@dataclass
+class CachedResult:
+    """A cached evaluation result."""
+
+    instance_id: str
+    cache_key: str
+    result: dict[str, Any]
+    timestamp: datetime
+    config_hash: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "instance_id": self.instance_id,
+            "cache_key": self.cache_key,
+            "result": self.result,
+            "timestamp": self.timestamp.isoformat(),
+            "config_hash": self.config_hash,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "CachedResult":
+        """Create from dictionary loaded from JSON."""
+        return cls(
+            instance_id=data["instance_id"],
+            cache_key=data["cache_key"],
+            result=data["result"],
+            timestamp=datetime.fromisoformat(data["timestamp"]),
+            config_hash=data["config_hash"],
+        )
+
+
+class ResultCache:
+    """File-based cache for benchmark evaluation results.
+
+    Cache keys are computed from:
+    - Task instance_id and problem statement
+    - Model and provider configuration
+    - Agent prompt template
+    - Benchmark type
+    - MCP server configuration (command, args)
+
+    This ensures cache hits only occur when evaluating the exact same task
+    with the exact same configuration.
+    """
+
+    def __init__(self, cache_dir: Path | None = None, enabled: bool = True):
+        """Initialize result cache.
+
+        Args:
+            cache_dir: Directory to store cache files. Defaults to ~/.cache/mcpbr
+            enabled: Whether caching is enabled. If False, all operations are no-ops.
+        """
+        self.enabled = enabled
+        if cache_dir is None:
+            cache_dir = Path.home() / ".cache" / "mcpbr"
+        self.cache_dir = cache_dir
+
+        if self.enabled:
+            self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _compute_cache_key(
+        self,
+        task: dict[str, Any],
+        config: HarnessConfig,
+        prompt: str,
+        is_mcp: bool,
+    ) -> str:
+        """Compute cache key from task and configuration.
+
+        Args:
+            task: Task dictionary with instance_id and problem statement
+            config: Harness configuration
+            prompt: Agent prompt template
+            is_mcp: Whether this is for MCP agent or baseline
+
+        Returns:
+            SHA256 hash as cache key
+        """
+        # Build cache key components
+        key_parts = {
+            "instance_id": task.get("instance_id", ""),
+            "problem_statement": task.get("problem_statement", ""),
+            "model": config.model,
+            "provider": config.provider,
+            "benchmark": config.benchmark,
+            "prompt": prompt,
+            "max_iterations": config.max_iterations,
+            "timeout_seconds": config.timeout_seconds,
+            "is_mcp": is_mcp,
+        }
+
+        # Add MCP server config if this is MCP agent
+        if is_mcp:
+            key_parts["mcp_server"] = {
+                "command": config.mcp_server.command,
+                "args": config.mcp_server.args,
+                # Don't include env vars in cache key as they may contain secrets
+                # and vary between runs without affecting results
+            }
+
+        # For CyberGym, include level in cache key
+        if config.benchmark == "cybergym":
+            key_parts["cybergym_level"] = config.cybergym_level
+
+        # Serialize to JSON with sorted keys for consistent hashing
+        key_json = json.dumps(key_parts, sort_keys=True)
+        return hashlib.sha256(key_json.encode()).hexdigest()
+
+    def _get_cache_file_path(self, cache_key: str) -> Path:
+        """Get file path for a cache key.
+
+        Args:
+            cache_key: SHA256 hash
+
+        Returns:
+            Path to cache file
+        """
+        # Use first 2 chars for subdirectory to avoid too many files in one dir
+        subdir = cache_key[:2]
+        cache_subdir = self.cache_dir / subdir
+        cache_subdir.mkdir(parents=True, exist_ok=True)
+        return cache_subdir / f"{cache_key}.json"
+
+    def get(
+        self,
+        task: dict[str, Any],
+        config: HarnessConfig,
+        prompt: str,
+        is_mcp: bool,
+    ) -> dict[str, Any] | None:
+        """Get cached result if available.
+
+        Args:
+            task: Task dictionary
+            config: Harness configuration
+            prompt: Agent prompt template
+            is_mcp: Whether this is for MCP agent or baseline
+
+        Returns:
+            Cached result dictionary or None if not cached
+        """
+        if not self.enabled:
+            return None
+
+        cache_key = self._compute_cache_key(task, config, prompt, is_mcp)
+        cache_file = self._get_cache_file_path(cache_key)
+
+        if not cache_file.exists():
+            return None
+
+        try:
+            with open(cache_file) as f:
+                cached = CachedResult.from_dict(json.load(f))
+
+            # Verify instance_id matches (sanity check)
+            if cached.instance_id != task.get("instance_id"):
+                # Cache corruption, remove the file
+                cache_file.unlink()
+                return None
+
+            return cached.result
+
+        except (json.JSONDecodeError, KeyError, ValueError):
+            # Cache file is corrupted, remove it
+            cache_file.unlink()
+            return None
+
+    def put(
+        self,
+        task: dict[str, Any],
+        config: HarnessConfig,
+        prompt: str,
+        is_mcp: bool,
+        result: dict[str, Any],
+    ) -> None:
+        """Store result in cache.
+
+        Args:
+            task: Task dictionary
+            config: Harness configuration
+            prompt: Agent prompt template
+            is_mcp: Whether this is for MCP agent or baseline
+            result: Result dictionary to cache
+        """
+        if not self.enabled:
+            return
+
+        cache_key = self._compute_cache_key(task, config, prompt, is_mcp)
+        config_hash = self._compute_config_hash(config)
+
+        cached = CachedResult(
+            instance_id=task.get("instance_id", "unknown"),
+            cache_key=cache_key,
+            result=result,
+            timestamp=datetime.now(timezone.utc),
+            config_hash=config_hash,
+        )
+
+        cache_file = self._get_cache_file_path(cache_key)
+        with open(cache_file, "w") as f:
+            json.dump(cached.to_dict(), f, indent=2)
+
+    def _compute_config_hash(self, config: HarnessConfig) -> str:
+        """Compute hash of relevant config fields for metadata.
+
+        Args:
+            config: Harness configuration
+
+        Returns:
+            SHA256 hash of configuration
+        """
+        config_dict = {
+            "model": config.model,
+            "provider": config.provider,
+            "benchmark": config.benchmark,
+            "max_iterations": config.max_iterations,
+        }
+        config_json = json.dumps(config_dict, sort_keys=True)
+        return hashlib.sha256(config_json.encode()).hexdigest()[:16]
+
+    def invalidate(
+        self,
+        task: dict[str, Any],
+        config: HarnessConfig,
+        prompt: str,
+        is_mcp: bool,
+    ) -> bool:
+        """Invalidate (remove) cached result for a specific task.
+
+        Args:
+            task: Task dictionary
+            config: Harness configuration
+            prompt: Agent prompt template
+            is_mcp: Whether this is for MCP agent or baseline
+
+        Returns:
+            True if cache entry was removed, False if it didn't exist
+        """
+        if not self.enabled:
+            return False
+
+        cache_key = self._compute_cache_key(task, config, prompt, is_mcp)
+        cache_file = self._get_cache_file_path(cache_key)
+
+        if cache_file.exists():
+            cache_file.unlink()
+            return True
+        return False
+
+    def clear(self) -> int:
+        """Clear all cache entries.
+
+        Returns:
+            Number of cache files removed
+        """
+        if not self.enabled or not self.cache_dir.exists():
+            return 0
+
+        count = 0
+        for cache_file in self.cache_dir.rglob("*.json"):
+            cache_file.unlink()
+            count += 1
+
+        # Remove empty subdirectories
+        for subdir in self.cache_dir.iterdir():
+            if subdir.is_dir() and not list(subdir.iterdir()):
+                subdir.rmdir()
+
+        return count
+
+    def get_stats(self) -> CacheStats:
+        """Get cache statistics.
+
+        Returns:
+            CacheStats with information about cache usage
+        """
+        if not self.enabled or not self.cache_dir.exists():
+            return CacheStats(
+                total_entries=0,
+                total_size_bytes=0,
+                oldest_entry=None,
+                newest_entry=None,
+                cache_dir=self.cache_dir,
+            )
+
+        cache_files = list(self.cache_dir.rglob("*.json"))
+        total_entries = len(cache_files)
+        total_size_bytes = sum(f.stat().st_size for f in cache_files)
+
+        oldest_entry = None
+        newest_entry = None
+
+        for cache_file in cache_files:
+            try:
+                with open(cache_file) as f:
+                    cached = CachedResult.from_dict(json.load(f))
+                    if oldest_entry is None or cached.timestamp < oldest_entry:
+                        oldest_entry = cached.timestamp
+                    if newest_entry is None or cached.timestamp > newest_entry:
+                        newest_entry = cached.timestamp
+            except (json.JSONDecodeError, KeyError, ValueError):
+                # Skip corrupted cache files
+                continue
+
+        return CacheStats(
+            total_entries=total_entries,
+            total_size_bytes=total_size_bytes,
+            oldest_entry=oldest_entry,
+            newest_entry=newest_entry,
+            cache_dir=self.cache_dir,
+        )
+
+    def prune(self, max_age_days: int | None = None, max_size_mb: int | None = None) -> int:
+        """Remove old cache entries based on age or size limits.
+
+        Args:
+            max_age_days: Remove entries older than this many days
+            max_size_mb: Remove oldest entries if cache exceeds this size
+
+        Returns:
+            Number of cache files removed
+        """
+        if not self.enabled or not self.cache_dir.exists():
+            return 0
+
+        cache_files = list(self.cache_dir.rglob("*.json"))
+        removed_count = 0
+
+        # Remove by age
+        if max_age_days is not None:
+            now = datetime.now(timezone.utc)
+            for cache_file in cache_files:
+                try:
+                    with open(cache_file) as f:
+                        cached = CachedResult.from_dict(json.load(f))
+                    age_days = (now - cached.timestamp).days
+                    if age_days > max_age_days:
+                        cache_file.unlink()
+                        removed_count += 1
+                except (json.JSONDecodeError, KeyError, ValueError):
+                    # Remove corrupted files
+                    cache_file.unlink()
+                    removed_count += 1
+
+        # Remove by size (keep newest files)
+        if max_size_mb is not None:
+            cache_files = list(self.cache_dir.rglob("*.json"))
+            current_size_mb = sum(f.stat().st_size for f in cache_files) / (1024 * 1024)
+
+            if current_size_mb > max_size_mb:
+                # Sort by modification time (oldest first)
+                sorted_files = sorted(cache_files, key=lambda f: f.stat().st_mtime)
+
+                for cache_file in sorted_files:
+                    if current_size_mb <= max_size_mb:
+                        break
+                    file_size_mb = cache_file.stat().st_size / (1024 * 1024)
+                    cache_file.unlink()
+                    current_size_mb -= file_size_mb
+                    removed_count += 1
+
+        # Remove empty subdirectories
+        for subdir in self.cache_dir.iterdir():
+            if subdir.is_dir() and not list(subdir.iterdir()):
+                subdir.rmdir()
+
+        return removed_count
+
+
+def get_default_cache() -> ResultCache:
+    """Get default cache instance.
+
+    Returns:
+        ResultCache with default settings
+    """
+    return ResultCache()

--- a/src/mcpbr/cli.py
+++ b/src/mcpbr/cli.py
@@ -62,6 +62,7 @@ def main() -> None:
       providers  List available model providers
       harnesses  List available agent harnesses
       benchmarks List available benchmarks
+      cache      Manage result cache
       cleanup    Remove orphaned Docker containers
 
     \b
@@ -1087,6 +1088,171 @@ def validate(config_path: Path) -> None:
         console.print("[red bold]Configuration validation failed.[/red bold]")
         console.print("[dim]Fix the errors above and run validation again.[/dim]")
         sys.exit(1)
+
+
+@main.group(context_settings={"help_option_names": ["-h", "--help"]})
+def cache() -> None:
+    """Cache management commands.
+
+    Manage the benchmark result cache to avoid re-running identical evaluations.
+
+    \b
+    Examples:
+      mcpbr cache stats    # Show cache statistics
+      mcpbr cache clear    # Clear all cached results
+      mcpbr cache prune    # Remove old cache entries
+    """
+    pass
+
+
+@cache.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.option(
+    "--cache-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Cache directory (default: ~/.cache/mcpbr)",
+)
+def stats(cache_dir: Path | None) -> None:
+    """Show cache statistics.
+
+    Displays information about cached results including total entries,
+    disk usage, and oldest/newest cache entries.
+
+    \b
+    Examples:
+      mcpbr cache stats                        # Default cache directory
+      mcpbr cache stats --cache-dir ./cache    # Custom cache directory
+    """
+    from .cache import ResultCache
+
+    result_cache = ResultCache(cache_dir=cache_dir, enabled=True)
+    cache_stats = result_cache.get_stats()
+
+    console.print("[bold]Cache Statistics[/bold]\n")
+    console.print(f"  Cache directory: {cache_stats.cache_dir}")
+    console.print(f"  Total entries:   {cache_stats.total_entries}")
+    console.print(f"  Total size:      {cache_stats.format_size()}")
+
+    if cache_stats.oldest_entry:
+        console.print(
+            f"  Oldest entry:    {cache_stats.oldest_entry.strftime('%Y-%m-%d %H:%M:%S')}"
+        )
+    if cache_stats.newest_entry:
+        console.print(
+            f"  Newest entry:    {cache_stats.newest_entry.strftime('%Y-%m-%d %H:%M:%S')}"
+        )
+
+    if cache_stats.total_entries == 0:
+        console.print("\n[dim]Cache is empty[/dim]")
+
+
+@cache.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.option(
+    "--cache-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Cache directory (default: ~/.cache/mcpbr)",
+)
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    help="Skip confirmation prompt",
+)
+def clear(cache_dir: Path | None, force: bool) -> None:
+    """Clear all cached results.
+
+    Removes all entries from the cache. This operation cannot be undone.
+
+    \b
+    Examples:
+      mcpbr cache clear           # Clear with confirmation
+      mcpbr cache clear -f        # Clear without confirmation
+    """
+    from .cache import ResultCache
+
+    result_cache = ResultCache(cache_dir=cache_dir, enabled=True)
+    cache_stats = result_cache.get_stats()
+
+    if cache_stats.total_entries == 0:
+        console.print("[yellow]Cache is already empty[/yellow]")
+        return
+
+    console.print(f"[yellow]About to clear {cache_stats.total_entries} cached result(s)[/yellow]")
+    console.print(f"[yellow]Total size: {cache_stats.format_size()}[/yellow]")
+
+    if not force:
+        confirm = click.confirm("Are you sure you want to clear the cache?", default=False)
+        if not confirm:
+            console.print("[dim]Aborted[/dim]")
+            return
+
+    removed = result_cache.clear()
+    console.print(f"[green]Cleared {removed} cached result(s)[/green]")
+
+
+@cache.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.option(
+    "--cache-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Cache directory (default: ~/.cache/mcpbr)",
+)
+@click.option(
+    "--max-age-days",
+    type=int,
+    default=None,
+    help="Remove entries older than this many days",
+)
+@click.option(
+    "--max-size-mb",
+    type=int,
+    default=None,
+    help="Remove oldest entries if cache exceeds this size in MB",
+)
+def prune(cache_dir: Path | None, max_age_days: int | None, max_size_mb: int | None) -> None:
+    """Remove old cache entries based on age or size limits.
+
+    Prunes the cache by removing entries older than a specified age or
+    keeping only the most recent entries within a size limit.
+
+    \b
+    Examples:
+      mcpbr cache prune --max-age-days 30      # Remove entries older than 30 days
+      mcpbr cache prune --max-size-mb 100      # Keep only 100 MB of newest entries
+      mcpbr cache prune --max-age-days 7 --max-size-mb 50  # Combine both limits
+    """
+    from .cache import ResultCache
+
+    if max_age_days is None and max_size_mb is None:
+        console.print(
+            "[red]Error: Must specify at least one of --max-age-days or --max-size-mb[/red]"
+        )
+        sys.exit(1)
+
+    result_cache = ResultCache(cache_dir=cache_dir, enabled=True)
+    cache_stats_before = result_cache.get_stats()
+
+    if cache_stats_before.total_entries == 0:
+        console.print("[yellow]Cache is empty[/yellow]")
+        return
+
+    console.print(
+        f"[dim]Current cache: {cache_stats_before.total_entries} entries, "
+        f"{cache_stats_before.format_size()}[/dim]"
+    )
+
+    removed = result_cache.prune(max_age_days=max_age_days, max_size_mb=max_size_mb)
+
+    if removed > 0:
+        cache_stats_after = result_cache.get_stats()
+        console.print(f"[green]Removed {removed} cached result(s)[/green]")
+        console.print(
+            f"[dim]Remaining: {cache_stats_after.total_entries} entries, "
+            f"{cache_stats_after.format_size()}[/dim]"
+        )
+    else:
+        console.print("[dim]No entries removed[/dim]")
 
 
 if __name__ == "__main__":

--- a/src/mcpbr/config.py
+++ b/src/mcpbr/config.py
@@ -128,6 +128,16 @@ class HarnessConfig(BaseModel):
         description="Maximum budget in USD for the evaluation (halts when reached)",
     )
 
+    cache_enabled: bool = Field(
+        default=False,
+        description="Enable result caching to avoid re-running identical evaluations",
+    )
+
+    cache_dir: Path | None = Field(
+        default=None,
+        description="Directory to store cache files (default: ~/.cache/mcpbr)",
+    )
+
     @field_validator("provider")
     @classmethod
     def validate_provider(cls, v: str) -> str:

--- a/src/mcpbr/harness.py
+++ b/src/mcpbr/harness.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn, TextColumn
 
 from .benchmarks import Benchmark, create_benchmark
+from .cache import ResultCache
 from .config import HarnessConfig
 from .docker_env import DockerEnvironmentManager, TaskEnvironment
 from .evaluation import EvaluationResult
@@ -202,6 +203,7 @@ async def run_single_task(
     verbosity: int = 1,
     log_file: TextIO | None = None,
     log_dir: Path | None = None,
+    cache: ResultCache | None = None,
 ) -> TaskResult:
     """Run evaluation for a single task.
 
@@ -216,6 +218,7 @@ async def run_single_task(
         verbosity: Verbosity level (0=silent, 1=summary, 2=detailed).
         log_file: Optional file handle for writing raw JSON logs.
         log_dir: Optional directory for per-instance JSON log files.
+        cache: Optional result cache.
 
     Returns:
         TaskResult with results for both runs.
@@ -236,6 +239,7 @@ async def run_single_task(
                 verbose,
                 verbosity,
                 mcp_log_writer if mcp_log_writer else log_file,
+                cache,
             )
         finally:
             if mcp_log_writer:
@@ -254,6 +258,7 @@ async def run_single_task(
                 verbose,
                 verbosity,
                 baseline_log_writer if baseline_log_writer else log_file,
+                cache,
             )
         finally:
             if baseline_log_writer:
@@ -270,8 +275,32 @@ async def _run_mcp_evaluation(
     verbose: bool,
     verbosity: int = 1,
     log_file: TextIO | InstanceLogWriter | None = None,
+    cache: ResultCache | None = None,
 ) -> dict[str, Any]:
-    """Run MCP agent evaluation."""
+    """Run MCP agent evaluation with optional caching.
+
+    Args:
+        task: Task dictionary from benchmark.
+        config: Harness configuration.
+        docker_manager: Docker environment manager.
+        benchmark: Benchmark instance.
+        verbose: Enable verbose output.
+        verbosity: Verbosity level.
+        log_file: Optional log file writer.
+        cache: Optional result cache.
+
+    Returns:
+        Dictionary with evaluation results.
+    """
+    # Check cache first if enabled
+    if cache and cache.enabled:
+        prompt = config.agent_prompt if config.agent_prompt else benchmark.get_prompt_template()
+        cached_result = cache.get(task, config, prompt, is_mcp=True)
+        if cached_result is not None:
+            # Add cache hit marker to result
+            cached_result["cache_hit"] = True
+            return cached_result
+
     env: TaskEnvironment | None = None
     try:
         env = await benchmark.create_environment(task, docker_manager)
@@ -300,7 +329,14 @@ async def _run_mcp_evaluation(
         else:
             eval_result = None
 
-        return agent_result_to_dict(agent_result, eval_result, config.model)
+        result = agent_result_to_dict(agent_result, eval_result, config.model)
+
+        # Store in cache if enabled
+        if cache and cache.enabled:
+            prompt = config.agent_prompt if config.agent_prompt else benchmark.get_prompt_template()
+            cache.put(task, config, prompt, is_mcp=True, result=result)
+
+        return result
 
     except asyncio.TimeoutError:
         cost = calculate_cost(config.model, 0, 0)
@@ -337,8 +373,32 @@ async def _run_baseline_evaluation(
     verbose: bool,
     verbosity: int = 1,
     log_file: TextIO | InstanceLogWriter | None = None,
+    cache: ResultCache | None = None,
 ) -> dict[str, Any]:
-    """Run baseline agent evaluation (same harness as MCP, but without MCP server)."""
+    """Run baseline agent evaluation (same harness as MCP, but without MCP server).
+
+    Args:
+        task: Task dictionary from benchmark.
+        config: Harness configuration.
+        docker_manager: Docker environment manager.
+        benchmark: Benchmark instance.
+        verbose: Enable verbose output.
+        verbosity: Verbosity level.
+        log_file: Optional log file writer.
+        cache: Optional result cache.
+
+    Returns:
+        Dictionary with evaluation results.
+    """
+    # Check cache first if enabled
+    if cache and cache.enabled:
+        prompt = config.agent_prompt if config.agent_prompt else benchmark.get_prompt_template()
+        cached_result = cache.get(task, config, prompt, is_mcp=False)
+        if cached_result is not None:
+            # Add cache hit marker to result
+            cached_result["cache_hit"] = True
+            return cached_result
+
     env: TaskEnvironment | None = None
     try:
         env = await benchmark.create_environment(task, docker_manager)
@@ -367,7 +427,14 @@ async def _run_baseline_evaluation(
         else:
             eval_result = None
 
-        return agent_result_to_dict(agent_result, eval_result, config.model)
+        result = agent_result_to_dict(agent_result, eval_result, config.model)
+
+        # Store in cache if enabled
+        if cache and cache.enabled:
+            prompt = config.agent_prompt if config.agent_prompt else benchmark.get_prompt_template()
+            cache.put(task, config, prompt, is_mcp=False, result=result)
+
+        return result
 
     except asyncio.TimeoutError:
         cost = calculate_cost(config.model, 0, 0)
@@ -448,6 +515,12 @@ async def run_evaluation(
     console.print(f"[dim]Evaluating {len(tasks)} tasks[/dim]")
     console.print(f"[dim]Provider: {config.provider}, Harness: {config.agent_harness}[/dim]")
 
+    # Initialize cache if enabled
+    cache: ResultCache | None = None
+    if config.cache_enabled:
+        cache = ResultCache(cache_dir=config.cache_dir, enabled=True)
+        console.print(f"[dim]Cache enabled: {cache.cache_dir}[/dim]")
+
     docker_manager = DockerEnvironmentManager(use_prebuilt=config.use_prebuilt_images)
 
     results: list[TaskResult] = []
@@ -475,6 +548,7 @@ async def run_evaluation(
                 verbosity,
                 log_file,
                 log_dir,
+                cache,
             )
 
             # Update current cost

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,459 @@
+"""Tests for the result caching system."""
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from mcpbr.cache import CachedResult, ResultCache
+from mcpbr.config import HarnessConfig, MCPServerConfig
+
+
+@pytest.fixture
+def temp_cache_dir(tmp_path: Path) -> Path:
+    """Create a temporary cache directory."""
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    return cache_dir
+
+
+@pytest.fixture
+def sample_config() -> HarnessConfig:
+    """Create a sample configuration for testing."""
+    return HarnessConfig(
+        mcp_server=MCPServerConfig(
+            command="npx",
+            args=["-y", "@modelcontextprotocol/server-filesystem", "{workdir}"],
+        ),
+        model="claude-sonnet-4-5-20250929",
+        provider="anthropic",
+        benchmark="swe-bench",
+    )
+
+
+@pytest.fixture
+def sample_task() -> dict:
+    """Create a sample task for testing."""
+    return {
+        "instance_id": "test-task-1",
+        "problem_statement": "Fix the bug in the code",
+        "repo": "test/repo",
+    }
+
+
+@pytest.fixture
+def sample_result() -> dict:
+    """Create a sample result for testing."""
+    return {
+        "resolved": True,
+        "patch_applied": True,
+        "tokens": {"input": 1000, "output": 500},
+        "iterations": 5,
+        "tool_calls": 10,
+        "cost": 0.05,
+    }
+
+
+def test_cache_initialization(temp_cache_dir: Path):
+    """Test cache initialization."""
+    cache = ResultCache(cache_dir=temp_cache_dir, enabled=True)
+    assert cache.enabled
+    assert cache.cache_dir == temp_cache_dir
+    assert cache.cache_dir.exists()
+
+
+def test_cache_disabled():
+    """Test that disabled cache is a no-op."""
+    cache = ResultCache(enabled=False)
+    assert not cache.enabled
+
+    # All operations should be no-ops
+    task = {"instance_id": "test"}
+    config = HarnessConfig(
+        mcp_server=MCPServerConfig(command="test", args=[]),
+        model="test",
+        provider="anthropic",
+        benchmark="swe-bench",
+    )
+    result = {"resolved": True}
+
+    # Get should return None
+    assert cache.get(task, config, "test prompt", is_mcp=True) is None
+
+    # Put should not raise an error
+    cache.put(task, config, "test prompt", is_mcp=True, result=result)
+
+    # Stats should show empty cache
+    stats = cache.get_stats()
+    assert stats.total_entries == 0
+
+
+def test_cache_put_and_get(
+    temp_cache_dir: Path,
+    sample_config: HarnessConfig,
+    sample_task: dict,
+    sample_result: dict,
+):
+    """Test storing and retrieving results from cache."""
+    cache = ResultCache(cache_dir=temp_cache_dir, enabled=True)
+    prompt = "Fix the issue: {problem_statement}"
+
+    # Initially cache miss
+    assert cache.get(sample_task, sample_config, prompt, is_mcp=True) is None
+
+    # Store result
+    cache.put(sample_task, sample_config, prompt, is_mcp=True, result=sample_result)
+
+    # Now should be a cache hit
+    cached = cache.get(sample_task, sample_config, prompt, is_mcp=True)
+    assert cached is not None
+    assert cached["resolved"] == sample_result["resolved"]
+    assert cached["cost"] == sample_result["cost"]
+
+
+def test_cache_key_uniqueness(
+    temp_cache_dir: Path,
+    sample_config: HarnessConfig,
+    sample_task: dict,
+):
+    """Test that cache keys are unique for different configurations."""
+    cache = ResultCache(cache_dir=temp_cache_dir, enabled=True)
+    prompt = "Fix the issue"
+    result1 = {"resolved": True}
+    result2 = {"resolved": False}
+
+    # Store MCP result
+    cache.put(sample_task, sample_config, prompt, is_mcp=True, result=result1)
+
+    # Store baseline result (should have different key)
+    cache.put(sample_task, sample_config, prompt, is_mcp=False, result=result2)
+
+    # Both should be retrievable separately
+    mcp_cached = cache.get(sample_task, sample_config, prompt, is_mcp=True)
+    baseline_cached = cache.get(sample_task, sample_config, prompt, is_mcp=False)
+
+    assert mcp_cached["resolved"]
+    assert not baseline_cached["resolved"]
+
+
+def test_cache_key_depends_on_config(
+    temp_cache_dir: Path,
+    sample_config: HarnessConfig,
+    sample_task: dict,
+):
+    """Test that different configs produce different cache keys."""
+    cache = ResultCache(cache_dir=temp_cache_dir, enabled=True)
+    prompt = "Fix the issue"
+    result1 = {"resolved": True}
+    result2 = {"resolved": False}
+
+    # Store with first config
+    cache.put(sample_task, sample_config, prompt, is_mcp=True, result=result1)
+
+    # Modify config (different model)
+    config2 = sample_config.model_copy()
+    config2.model = "claude-opus-4-5-20251101"
+
+    # Store with second config
+    cache.put(sample_task, config2, prompt, is_mcp=True, result=result2)
+
+    # Should get different results
+    cached1 = cache.get(sample_task, sample_config, prompt, is_mcp=True)
+    cached2 = cache.get(sample_task, config2, prompt, is_mcp=True)
+
+    assert cached1["resolved"]
+    assert not cached2["resolved"]
+
+
+def test_cache_key_depends_on_prompt(
+    temp_cache_dir: Path,
+    sample_config: HarnessConfig,
+    sample_task: dict,
+):
+    """Test that different prompts produce different cache keys."""
+    cache = ResultCache(cache_dir=temp_cache_dir, enabled=True)
+    result1 = {"resolved": True}
+    result2 = {"resolved": False}
+
+    # Store with first prompt
+    cache.put(sample_task, sample_config, "Prompt 1", is_mcp=True, result=result1)
+
+    # Store with second prompt
+    cache.put(sample_task, sample_config, "Prompt 2", is_mcp=True, result=result2)
+
+    # Should get different results
+    cached1 = cache.get(sample_task, sample_config, "Prompt 1", is_mcp=True)
+    cached2 = cache.get(sample_task, sample_config, "Prompt 2", is_mcp=True)
+
+    assert cached1["resolved"]
+    assert not cached2["resolved"]
+
+
+def test_cache_key_depends_on_task(
+    temp_cache_dir: Path,
+    sample_config: HarnessConfig,
+):
+    """Test that different tasks produce different cache keys."""
+    cache = ResultCache(cache_dir=temp_cache_dir, enabled=True)
+    prompt = "Fix the issue"
+    result1 = {"resolved": True}
+    result2 = {"resolved": False}
+
+    task1 = {"instance_id": "task-1", "problem_statement": "Bug 1"}
+    task2 = {"instance_id": "task-2", "problem_statement": "Bug 2"}
+
+    # Store results for different tasks
+    cache.put(task1, sample_config, prompt, is_mcp=True, result=result1)
+    cache.put(task2, sample_config, prompt, is_mcp=True, result=result2)
+
+    # Should get different results
+    cached1 = cache.get(task1, sample_config, prompt, is_mcp=True)
+    cached2 = cache.get(task2, sample_config, prompt, is_mcp=True)
+
+    assert cached1["resolved"]
+    assert not cached2["resolved"]
+
+
+def test_cache_invalidate(
+    temp_cache_dir: Path,
+    sample_config: HarnessConfig,
+    sample_task: dict,
+    sample_result: dict,
+):
+    """Test cache invalidation."""
+    cache = ResultCache(cache_dir=temp_cache_dir, enabled=True)
+    prompt = "Fix the issue"
+
+    # Store result
+    cache.put(sample_task, sample_config, prompt, is_mcp=True, result=sample_result)
+
+    # Verify it's cached
+    assert cache.get(sample_task, sample_config, prompt, is_mcp=True) is not None
+
+    # Invalidate
+    removed = cache.invalidate(sample_task, sample_config, prompt, is_mcp=True)
+    assert removed
+
+    # Should be a cache miss now
+    assert cache.get(sample_task, sample_config, prompt, is_mcp=True) is None
+
+    # Invalidating again should return False
+    removed = cache.invalidate(sample_task, sample_config, prompt, is_mcp=True)
+    assert not removed
+
+
+def test_cache_clear(
+    temp_cache_dir: Path,
+    sample_config: HarnessConfig,
+    sample_task: dict,
+):
+    """Test clearing all cache entries."""
+    cache = ResultCache(cache_dir=temp_cache_dir, enabled=True)
+    prompt = "Fix the issue"
+
+    # Store multiple results
+    for i in range(5):
+        task = {"instance_id": f"task-{i}", "problem_statement": f"Bug {i}"}
+        result = {"resolved": i % 2 == 0}
+        cache.put(task, sample_config, prompt, is_mcp=True, result=result)
+
+    # Verify they're all cached
+    stats = cache.get_stats()
+    assert stats.total_entries == 5
+
+    # Clear cache
+    removed = cache.clear()
+    assert removed == 5
+
+    # Cache should be empty
+    stats = cache.get_stats()
+    assert stats.total_entries == 0
+
+
+def test_cache_stats(
+    temp_cache_dir: Path,
+    sample_config: HarnessConfig,
+):
+    """Test cache statistics."""
+    cache = ResultCache(cache_dir=temp_cache_dir, enabled=True)
+    prompt = "Fix the issue"
+
+    # Empty cache
+    stats = cache.get_stats()
+    assert stats.total_entries == 0
+    assert stats.total_size_bytes == 0
+    assert stats.oldest_entry is None
+    assert stats.newest_entry is None
+
+    # Add some entries
+    for i in range(3):
+        task = {"instance_id": f"task-{i}", "problem_statement": f"Bug {i}"}
+        result = {"resolved": True}
+        cache.put(task, sample_config, prompt, is_mcp=True, result=result)
+
+    # Check stats
+    stats = cache.get_stats()
+    assert stats.total_entries == 3
+    assert stats.total_size_bytes > 0
+    assert stats.oldest_entry is not None
+    assert stats.newest_entry is not None
+    assert stats.oldest_entry <= stats.newest_entry
+
+
+def test_cache_prune_by_age(
+    temp_cache_dir: Path,
+    sample_config: HarnessConfig,
+):
+    """Test pruning cache entries by age."""
+    cache = ResultCache(cache_dir=temp_cache_dir, enabled=True)
+    prompt = "Fix the issue"
+
+    # Create some cache entries with different timestamps
+    for i in range(3):
+        task = {"instance_id": f"task-{i}", "problem_statement": f"Bug {i}"}
+        result = {"resolved": True}
+        cache.put(task, sample_config, prompt, is_mcp=True, result=result)
+
+    # Manually modify timestamps of cache files to simulate old entries
+    cache_files = list(temp_cache_dir.rglob("*.json"))
+    assert len(cache_files) == 3
+
+    # Make first file "old" by modifying its timestamp in the JSON
+    with open(cache_files[0]) as f:
+        data = json.load(f)
+    old_timestamp = datetime.now(timezone.utc) - timedelta(days=31)
+    data["timestamp"] = old_timestamp.isoformat()
+    with open(cache_files[0], "w") as f:
+        json.dump(data, f)
+
+    # Prune entries older than 30 days
+    removed = cache.prune(max_age_days=30)
+    assert removed == 1
+
+    # Should have 2 entries left
+    stats = cache.get_stats()
+    assert stats.total_entries == 2
+
+
+def test_cache_prune_by_size(
+    temp_cache_dir: Path,
+    sample_config: HarnessConfig,
+):
+    """Test pruning cache entries by size."""
+    cache = ResultCache(cache_dir=temp_cache_dir, enabled=True)
+    prompt = "Fix the issue"
+
+    # Add several entries
+    for i in range(5):
+        task = {"instance_id": f"task-{i}", "problem_statement": f"Bug {i}"}
+        result = {"resolved": True, "large_data": "x" * 1000}  # Make entries larger
+        cache.put(task, sample_config, prompt, is_mcp=True, result=result)
+
+    # Check current size
+    stats = cache.get_stats()
+    initial_size_mb = stats.total_size_bytes / (1024 * 1024)
+
+    # Prune to very small size (will remove most entries)
+    removed = cache.prune(max_size_mb=0.001)
+    assert removed > 0
+
+    # Should have fewer entries
+    stats = cache.get_stats()
+    final_size_mb = stats.total_size_bytes / (1024 * 1024)
+    assert final_size_mb < initial_size_mb
+
+
+def test_cached_result_serialization():
+    """Test CachedResult serialization and deserialization."""
+    cached = CachedResult(
+        instance_id="test-task",
+        cache_key="abc123",
+        result={"resolved": True, "cost": 0.05},
+        timestamp=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        config_hash="def456",
+    )
+
+    # Convert to dict
+    data = cached.to_dict()
+    assert data["instance_id"] == "test-task"
+    assert data["cache_key"] == "abc123"
+    assert data["result"]["resolved"]
+    assert "timestamp" in data
+
+    # Convert back from dict
+    restored = CachedResult.from_dict(data)
+    assert restored.instance_id == cached.instance_id
+    assert restored.cache_key == cached.cache_key
+    assert restored.result == cached.result
+    assert restored.timestamp == cached.timestamp
+    assert restored.config_hash == cached.config_hash
+
+
+def test_cache_corrupted_file_handling(
+    temp_cache_dir: Path,
+    sample_config: HarnessConfig,
+    sample_task: dict,
+):
+    """Test that corrupted cache files are handled gracefully."""
+    cache = ResultCache(cache_dir=temp_cache_dir, enabled=True)
+    prompt = "Fix the issue"
+    result = {"resolved": True}
+
+    # Store a result
+    cache.put(sample_task, sample_config, prompt, is_mcp=True, result=result)
+
+    # Corrupt the cache file
+    cache_files = list(temp_cache_dir.rglob("*.json"))
+    assert len(cache_files) == 1
+    with open(cache_files[0], "w") as f:
+        f.write("corrupted json {{{")
+
+    # Get should return None and remove corrupted file
+    cached = cache.get(sample_task, sample_config, prompt, is_mcp=True)
+    assert cached is None
+    assert not cache_files[0].exists()
+
+
+def test_cache_subdirectory_structure(
+    temp_cache_dir: Path,
+    sample_config: HarnessConfig,
+):
+    """Test that cache uses subdirectories to avoid too many files."""
+    cache = ResultCache(cache_dir=temp_cache_dir, enabled=True)
+    prompt = "Fix the issue"
+
+    # Add many entries
+    for i in range(10):
+        task = {"instance_id": f"task-{i}", "problem_statement": f"Bug {i}"}
+        result = {"resolved": True}
+        cache.put(task, sample_config, prompt, is_mcp=True, result=result)
+
+    # Check that subdirectories were created
+    subdirs = [d for d in temp_cache_dir.iterdir() if d.is_dir()]
+    assert len(subdirs) > 0
+
+    # Each subdirectory should contain cache files
+    for subdir in subdirs:
+        files = list(subdir.glob("*.json"))
+        assert len(files) > 0
+
+
+def test_cache_format_size():
+    """Test size formatting in CacheStats."""
+    from mcpbr.cache import CacheStats
+
+    stats = CacheStats(
+        total_entries=10,
+        total_size_bytes=1024,
+        oldest_entry=None,
+        newest_entry=None,
+        cache_dir=Path("/tmp/cache"),
+    )
+    assert "KB" in stats.format_size()
+
+    stats.total_size_bytes = 1024 * 1024
+    assert "MB" in stats.format_size()
+
+    stats.total_size_bytes = 1024 * 1024 * 1024
+    assert "GB" in stats.format_size()

--- a/uv.lock
+++ b/uv.lock
@@ -1038,7 +1038,7 @@ wheels = [
 
 [[package]]
 name = "mcpbr"
-version = "0.3.7"
+version = "0.3.8"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Implements a comprehensive result caching system to avoid re-running identical evaluations, significantly reducing evaluation time and costs for repeated runs.

This PR closes #30.

## Features

- **Content-based cache keys**: Uses SHA256 hash of task, config, and prompt to ensure cache hits only for truly identical evaluations
- **File-based storage**: Cache stored in `~/.cache/mcpbr` by default with configurable directory
- **Separate MCP/baseline caching**: MCP and baseline runs have separate cache entries
- **Cache management CLI**: New `mcpbr cache` command group with `stats`, `clear`, and `prune` subcommands
- **Automatic integration**: Cache lookup and storage integrated into evaluation harness
- **Opt-in by design**: Caching disabled by default via `cache_enabled` config option

## Implementation Details

### Cache Key Components
Cache keys are computed from:
- Task `instance_id` and `problem_statement`
- Model, provider, and benchmark type
- Agent prompt template
- Max iterations and timeout settings
- MCP server configuration (for MCP runs only)
- CyberGym level (for CyberGym benchmark)

This ensures cache hits only occur when evaluating the exact same task with the exact same configuration.

### Cache Storage
- Results stored as JSON files in subdirectories (first 2 chars of hash)
- Each entry includes timestamp and config hash metadata
- Corrupted cache files automatically detected and removed

### Configuration
```yaml
cache_enabled: true  # Enable caching (default: false)
cache_dir: /path/to/cache  # Optional custom cache directory
```

### CLI Commands
```bash
# View cache statistics
mcpbr cache stats

# Clear all cached results
mcpbr cache clear

# Prune old entries
mcpbr cache prune --max-age-days 30
mcpbr cache prune --max-size-mb 100
```

## Testing

- Added 16 comprehensive unit tests covering all cache operations
- Tests validate cache key uniqueness, storage/retrieval, invalidation, and pruning
- All 334 existing tests pass with new changes
- Code passes ruff linting and formatting

## Performance Benefits

- Eliminates duplicate agent runs for identical tasks
- Preserves token usage and cost information from original runs
- Enables rapid experimentation with different task subsets
- Cache hits include marker (`cache_hit: true`) in results

## Breaking Changes

None. Caching is opt-in and disabled by default.

## Test Plan

- [x] Unit tests for all cache operations pass
- [x] Existing test suite passes (334 tests)
- [x] Linting and formatting pass
- [x] Cache key uniqueness validated for different configurations
- [x] Cache corruption handling tested
- [x] CLI commands work as expected

Generated with Claude Sonnet 4.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a result caching system for benchmark evaluations with configurable cache directory and enable/disable toggle
  * Introduced cache management commands: `cache stats`, `cache clear`, and `cache prune` for managing cached results
  * Added configuration options to control caching behavior
  * Removed incremental save feature

* **Tests**
  * Added comprehensive test suite covering cache operations, edge cases, and error handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->