### PR TITLE
feat: Task Result Caching (closes #115)

### DIFF
--- a/src/mcpbr/cache.py
+++ b/src/mcpbr/cache.py
@@ -1,0 +1,428 @@
+"""Task result caching system for mcpbr.
+
+Implements intelligent result caching with content-based hashing,
+cache invalidation, TTL management, and size limits.
+"""
+
+import hashlib
+import json
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class CacheEntry:
+    """A single cache entry with metadata."""
+
+    key: str
+    result: dict[str, Any]
+    timestamp: float
+    version: str
+    task_hash: str
+    config_hash: str
+
+
+@dataclass
+class CacheStats:
+    """Statistics about cache usage."""
+
+    hits: int = 0
+    misses: int = 0
+    total_entries: int = 0
+    cache_size_bytes: int = 0
+
+    @property
+    def hit_rate(self) -> float:
+        """Calculate cache hit rate."""
+        total = self.hits + self.misses
+        return self.hits / total if total > 0 else 0.0
+
+
+class TaskResultCache:
+    """Cache for task evaluation results.
+
+    Features:
+    - Content-based cache keys using task and config hashing
+    - Configurable TTL (time-to-live) for cache entries
+    - Cache size limits with LRU eviction
+    - Cache statistics tracking
+    - Atomic cache operations
+    """
+
+    def __init__(
+        self,
+        cache_dir: Path | None = None,
+        ttl_seconds: int | None = 86400,  # 24 hours default
+        max_size_mb: int = 1000,  # 1GB default
+        version: str = "0.3.8",
+    ):
+        """Initialize the cache.
+
+        Args:
+            cache_dir: Directory to store cache files. Defaults to ~/.mcpbr/cache
+            ttl_seconds: Time-to-live for cache entries in seconds. None = no expiration
+            max_size_mb: Maximum cache size in megabytes
+            version: mcpbr version for cache invalidation
+        """
+        if cache_dir is None:
+            cache_dir = Path.home() / ".mcpbr" / "cache"
+        self.cache_dir = cache_dir
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+        self.ttl_seconds = ttl_seconds
+        self.max_size_bytes = max_size_mb * 1024 * 1024
+        self.version = version
+
+        self.stats = CacheStats()
+        self._load_stats()
+
+    def _compute_task_hash(self, task: dict[str, Any]) -> str:
+        """Compute hash of task definition.
+
+        Args:
+            task: Task dictionary
+
+        Returns:
+            SHA256 hash of task content
+        """
+        # Extract relevant fields for hashing
+        # Exclude metadata that doesn't affect the task itself
+        task_content = {
+            "instance_id": task.get("instance_id"),
+            "problem_statement": task.get("problem_statement"),
+            "repo": task.get("repo"),
+            "base_commit": task.get("base_commit"),
+            "patch": task.get("patch"),
+            "test_patch": task.get("test_patch"),
+            "FAIL_TO_PASS": task.get("FAIL_TO_PASS"),
+            "PASS_TO_PASS": task.get("PASS_TO_PASS"),
+        }
+
+        # Sort keys for consistent hashing
+        content_str = json.dumps(task_content, sort_keys=True)
+        return hashlib.sha256(content_str.encode()).hexdigest()
+
+    def _compute_config_hash(self, config: dict[str, Any]) -> str:
+        """Compute hash of relevant configuration.
+
+        Args:
+            config: Configuration dictionary
+
+        Returns:
+            SHA256 hash of config content
+        """
+        # Only include config fields that affect task execution
+        config_content = {
+            "model": config.get("model"),
+            "provider": config.get("provider"),
+            "agent_harness": config.get("agent_harness"),
+            "benchmark": config.get("benchmark"),
+            "max_iterations": config.get("max_iterations"),
+            "timeout_seconds": config.get("timeout_seconds"),
+            "agent_prompt": config.get("agent_prompt"),
+            "mcp_server": config.get("mcp_server"),
+        }
+
+        content_str = json.dumps(config_content, sort_keys=True)
+        return hashlib.sha256(content_str.encode()).hexdigest()
+
+    def _compute_cache_key(self, task_hash: str, config_hash: str, run_type: str) -> str:
+        """Compute final cache key.
+
+        Args:
+            task_hash: Hash of task content
+            config_hash: Hash of configuration
+            run_type: Type of run (mcp or baseline)
+
+        Returns:
+            Cache key string
+        """
+        key_content = f"{self.version}:{task_hash}:{config_hash}:{run_type}"
+        return hashlib.sha256(key_content.encode()).hexdigest()
+
+    def _get_cache_path(self, key: str) -> Path:
+        """Get file path for a cache entry.
+
+        Args:
+            key: Cache key
+
+        Returns:
+            Path to cache file
+        """
+        # Use first 2 characters for subdirectory to avoid too many files in one dir
+        subdir = key[:2]
+        cache_subdir = self.cache_dir / subdir
+        cache_subdir.mkdir(exist_ok=True)
+        return cache_subdir / f"{key}.json"
+
+    def get(
+        self,
+        task: dict[str, Any],
+        config: dict[str, Any],
+        run_type: str,
+    ) -> dict[str, Any] | None:
+        """Get cached result for a task.
+
+        Args:
+            task: Task dictionary
+            config: Configuration dictionary
+            run_type: Type of run (mcp or baseline)
+
+        Returns:
+            Cached result or None if not found or expired
+        """
+        task_hash = self._compute_task_hash(task)
+        config_hash = self._compute_config_hash(config)
+        key = self._compute_cache_key(task_hash, config_hash, run_type)
+
+        cache_path = self._get_cache_path(key)
+
+        if not cache_path.exists():
+            self.stats.misses += 1
+            self._save_stats()
+            return None
+
+        try:
+            with open(cache_path) as f:
+                entry_data = json.load(f)
+                entry = CacheEntry(**entry_data)
+
+            # Check version match
+            if entry.version != self.version:
+                self.stats.misses += 1
+                self._save_stats()
+                cache_path.unlink()
+                return None
+
+            # Check TTL
+            if self.ttl_seconds is not None:
+                age = time.time() - entry.timestamp
+                if age > self.ttl_seconds:
+                    self.stats.misses += 1
+                    self._save_stats()
+                    cache_path.unlink()
+                    return None
+
+            # Cache hit
+            self.stats.hits += 1
+            self._save_stats()
+            return entry.result
+
+        except (json.JSONDecodeError, KeyError, TypeError):
+            # Corrupted cache entry
+            self.stats.misses += 1
+            self._save_stats()
+            if cache_path.exists():
+                cache_path.unlink()
+            return None
+
+    def put(
+        self,
+        task: dict[str, Any],
+        config: dict[str, Any],
+        run_type: str,
+        result: dict[str, Any],
+    ) -> None:
+        """Store result in cache.
+
+        Args:
+            task: Task dictionary
+            config: Configuration dictionary
+            run_type: Type of run (mcp or baseline)
+            result: Result to cache
+        """
+        task_hash = self._compute_task_hash(task)
+        config_hash = self._compute_config_hash(config)
+        key = self._compute_cache_key(task_hash, config_hash, run_type)
+
+        entry = CacheEntry(
+            key=key,
+            result=result,
+            timestamp=time.time(),
+            version=self.version,
+            task_hash=task_hash,
+            config_hash=config_hash,
+        )
+
+        cache_path = self._get_cache_path(key)
+
+        # Write atomically using temp file
+        temp_path = cache_path.with_suffix(".tmp")
+        try:
+            with open(temp_path, "w") as f:
+                json.dump(asdict(entry), f)
+            temp_path.replace(cache_path)
+
+            # Update stats
+            self.stats.total_entries = self._count_entries()
+            self.stats.cache_size_bytes = self._calculate_cache_size()
+            self._save_stats()
+
+            # Enforce size limit
+            self._enforce_size_limit()
+
+        except Exception:
+            if temp_path.exists():
+                temp_path.unlink()
+            raise
+
+    def clear(self) -> int:
+        """Clear all cache entries.
+
+        Returns:
+            Number of entries removed
+        """
+        count = 0
+        for subdir in self.cache_dir.iterdir():
+            if subdir.is_dir():
+                for cache_file in subdir.glob("*.json"):
+                    cache_file.unlink()
+                    count += 1
+                # Remove empty subdirectories
+                try:
+                    subdir.rmdir()
+                except OSError:
+                    pass
+
+        # Reset stats
+        self.stats.total_entries = 0
+        self.stats.cache_size_bytes = 0
+        self._save_stats()
+
+        return count
+
+    def _count_entries(self) -> int:
+        """Count total cache entries."""
+        count = 0
+        for subdir in self.cache_dir.iterdir():
+            if subdir.is_dir():
+                count += len(list(subdir.glob("*.json")))
+        return count
+
+    def _calculate_cache_size(self) -> int:
+        """Calculate total cache size in bytes."""
+        total_size = 0
+        for subdir in self.cache_dir.iterdir():
+            if subdir.is_dir():
+                for cache_file in subdir.glob("*.json"):
+                    try:
+                        total_size += cache_file.stat().st_size
+                    except OSError:
+                        pass
+        return total_size
+
+    def _enforce_size_limit(self) -> None:
+        """Enforce cache size limit using LRU eviction."""
+        if self.stats.cache_size_bytes <= self.max_size_bytes:
+            return
+
+        # Get all cache entries with their access times
+        entries: list[tuple[Path, float]] = []
+        for subdir in self.cache_dir.iterdir():
+            if subdir.is_dir():
+                for cache_file in subdir.glob("*.json"):
+                    try:
+                        # Use modification time as proxy for last access
+                        mtime = cache_file.stat().st_mtime
+                        entries.append((cache_file, mtime))
+                    except OSError:
+                        pass
+
+        # Sort by access time (oldest first)
+        entries.sort(key=lambda x: x[1])
+
+        # Remove oldest entries until under size limit
+        for cache_file, _ in entries:
+            if self.stats.cache_size_bytes <= self.max_size_bytes:
+                break
+
+            try:
+                size = cache_file.stat().st_size
+                cache_file.unlink()
+                self.stats.cache_size_bytes -= size
+                self.stats.total_entries -= 1
+            except OSError:
+                pass
+
+        self._save_stats()
+
+    def _get_stats_path(self) -> Path:
+        """Get path to stats file."""
+        return self.cache_dir / "stats.json"
+
+    def _load_stats(self) -> None:
+        """Load stats from disk."""
+        stats_path = self._get_stats_path()
+        if stats_path.exists():
+            try:
+                with open(stats_path) as f:
+                    data = json.load(f)
+                    self.stats = CacheStats(**data)
+            except (json.JSONDecodeError, KeyError, TypeError):
+                # Corrupted stats, start fresh
+                self.stats = CacheStats()
+
+        # Update counts from actual cache
+        self.stats.total_entries = self._count_entries()
+        self.stats.cache_size_bytes = self._calculate_cache_size()
+
+    def _save_stats(self) -> None:
+        """Save stats to disk."""
+        stats_path = self._get_stats_path()
+        try:
+            with open(stats_path, "w") as f:
+                json.dump(asdict(self.stats), f)
+        except Exception:
+            # Don't fail if we can't save stats
+            pass
+
+    def get_stats(self) -> CacheStats:
+        """Get current cache statistics.
+
+        Returns:
+            CacheStats object with current statistics
+        """
+        # Refresh stats
+        self.stats.total_entries = self._count_entries()
+        self.stats.cache_size_bytes = self._calculate_cache_size()
+        return self.stats
+
+    def invalidate_version(self, version: str) -> int:
+        """Invalidate all cache entries for a specific version.
+
+        Args:
+            version: Version to invalidate
+
+        Returns:
+            Number of entries removed
+        """
+        count = 0
+        for subdir in self.cache_dir.iterdir():
+            if subdir.is_dir():
+                for cache_file in subdir.glob("*.json"):
+                    try:
+                        with open(cache_file) as f:
+                            entry_data = json.load(f)
+                            if entry_data.get("version") == version:
+                                cache_file.unlink()
+                                count += 1
+                    except (json.JSONDecodeError, KeyError, OSError):
+                        pass
+
+        # Update stats
+        self.stats.total_entries = self._count_entries()
+        self.stats.cache_size_bytes = self._calculate_cache_size()
+        self._save_stats()
+
+        return count
+
+
+def get_default_cache() -> TaskResultCache:
+    """Get default cache instance.
+
+    Returns:
+        TaskResultCache with default settings
+    """
+    return TaskResultCache()

--- a/src/mcpbr/reporting.py
+++ b/src/mcpbr/reporting.py
@@ -213,6 +213,25 @@ def print_summary(results: "EvaluationResults", console: Console) -> None:
 
     console.print(cost_table)
 
+    # Print cache statistics if available
+    cache_stats = results.metadata.get("cache")
+    if cache_stats and cache_stats.get("enabled"):
+        console.print()
+        console.print("[bold]Cache Statistics[/bold]")
+        console.print()
+
+        cache_table = Table(title="Result Caching")
+        cache_table.add_column("Metric", style="cyan")
+        cache_table.add_column("Value", style="green")
+
+        cache_table.add_row("Cache Hits", str(cache_stats.get("hits", 0)))
+        cache_table.add_row("Cache Misses", str(cache_stats.get("misses", 0)))
+        cache_table.add_row("Hit Rate", f"{cache_stats.get('hit_rate', 0.0):.1%}")
+        cache_table.add_row("Total Entries", str(cache_stats.get("total_entries", 0)))
+        cache_table.add_row("Cache Size", f"{cache_stats.get('cache_size_mb', 0.0):.2f} MB")
+
+        console.print(cache_table)
+
     # Print cost comparison
     cost_comparison = results.summary.get("cost_comparison", {})
     total_diff = cost_comparison.get("total_difference")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,430 @@
+"""Tests for task result caching."""
+
+import json
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+from mcpbr.cache import CacheEntry, CacheStats, TaskResultCache, get_default_cache
+
+
+class TestCacheEntry:
+    """Tests for CacheEntry dataclass."""
+
+    def test_creation(self) -> None:
+        """Test creating a cache entry."""
+        entry = CacheEntry(
+            key="test_key",
+            result={"resolved": True, "cost": 0.5},
+            timestamp=time.time(),
+            version="0.3.8",
+            task_hash="abc123",
+            config_hash="def456",
+        )
+        assert entry.key == "test_key"
+        assert entry.result["resolved"] is True
+        assert entry.version == "0.3.8"
+
+
+class TestCacheStats:
+    """Tests for CacheStats dataclass."""
+
+    def test_hit_rate_calculation(self) -> None:
+        """Test hit rate calculation."""
+        stats = CacheStats(hits=7, misses=3)
+        assert stats.hit_rate == 0.7
+
+    def test_hit_rate_zero_total(self) -> None:
+        """Test hit rate when no hits or misses."""
+        stats = CacheStats(hits=0, misses=0)
+        assert stats.hit_rate == 0.0
+
+    def test_hit_rate_all_hits(self) -> None:
+        """Test hit rate with all hits."""
+        stats = CacheStats(hits=10, misses=0)
+        assert stats.hit_rate == 1.0
+
+
+class TestTaskResultCache:
+    """Tests for TaskResultCache."""
+
+    @pytest.fixture
+    def temp_cache_dir(self) -> Path:
+        """Create a temporary cache directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    @pytest.fixture
+    def cache(self, temp_cache_dir: Path) -> TaskResultCache:
+        """Create a cache instance with temporary directory."""
+        return TaskResultCache(
+            cache_dir=temp_cache_dir,
+            ttl_seconds=3600,
+            max_size_mb=10,
+            version="0.3.8",
+        )
+
+    def test_initialization(self, temp_cache_dir: Path) -> None:
+        """Test cache initialization."""
+        cache = TaskResultCache(cache_dir=temp_cache_dir)
+        assert cache.cache_dir == temp_cache_dir
+        assert cache.cache_dir.exists()
+        assert cache.ttl_seconds == 86400  # default
+        assert cache.version == "0.3.8"
+
+    def test_compute_task_hash(self, cache: TaskResultCache) -> None:
+        """Test task hashing."""
+        task1 = {
+            "instance_id": "test-1",
+            "problem_statement": "Fix bug",
+            "repo": "test/repo",
+            "base_commit": "abc123",
+        }
+        task2 = {
+            "instance_id": "test-1",
+            "problem_statement": "Fix bug",
+            "repo": "test/repo",
+            "base_commit": "abc123",
+            "extra_field": "ignored",  # Should be ignored
+        }
+        task3 = {
+            "instance_id": "test-2",
+            "problem_statement": "Fix bug",
+            "repo": "test/repo",
+            "base_commit": "abc123",
+        }
+
+        hash1 = cache._compute_task_hash(task1)
+        hash2 = cache._compute_task_hash(task2)
+        hash3 = cache._compute_task_hash(task3)
+
+        # Same relevant content = same hash
+        assert hash1 == hash2
+        # Different task = different hash
+        assert hash1 != hash3
+
+    def test_compute_config_hash(self, cache: TaskResultCache) -> None:
+        """Test config hashing."""
+        config1 = {
+            "model": "claude-sonnet-4-5",
+            "provider": "anthropic",
+            "agent_harness": "claude-code",
+            "max_iterations": 10,
+        }
+        config2 = {
+            "model": "claude-sonnet-4-5",
+            "provider": "anthropic",
+            "agent_harness": "claude-code",
+            "max_iterations": 10,
+            "sample_size": 5,  # Should be ignored
+        }
+        config3 = {
+            "model": "claude-opus-4-5",  # Different model
+            "provider": "anthropic",
+            "agent_harness": "claude-code",
+            "max_iterations": 10,
+        }
+
+        hash1 = cache._compute_config_hash(config1)
+        hash2 = cache._compute_config_hash(config2)
+        hash3 = cache._compute_config_hash(config3)
+
+        # Same relevant config = same hash
+        assert hash1 == hash2
+        # Different model = different hash
+        assert hash1 != hash3
+
+    def test_put_and_get(self, cache: TaskResultCache) -> None:
+        """Test storing and retrieving cache entries."""
+        task = {"instance_id": "test-1", "problem_statement": "Fix bug"}
+        config = {"model": "claude-sonnet-4-5", "provider": "anthropic"}
+        result = {"resolved": True, "cost": 0.5, "tokens": {"input": 100, "output": 50}}
+
+        # Store result
+        cache.put(task, config, "mcp", result)
+
+        # Retrieve result
+        cached = cache.get(task, config, "mcp")
+        assert cached is not None
+        assert cached["resolved"] is True
+        assert cached["cost"] == 0.5
+
+        # Stats should show 1 hit
+        assert cache.stats.hits == 1
+        assert cache.stats.misses == 0
+
+    def test_get_miss(self, cache: TaskResultCache) -> None:
+        """Test cache miss."""
+        task = {"instance_id": "test-1", "problem_statement": "Fix bug"}
+        config = {"model": "claude-sonnet-4-5", "provider": "anthropic"}
+
+        # Try to get non-existent entry
+        cached = cache.get(task, config, "mcp")
+        assert cached is None
+
+        # Stats should show 1 miss
+        assert cache.stats.hits == 0
+        assert cache.stats.misses == 1
+
+    def test_cache_different_run_types(self, cache: TaskResultCache) -> None:
+        """Test caching different run types (mcp vs baseline)."""
+        task = {"instance_id": "test-1", "problem_statement": "Fix bug"}
+        config = {"model": "claude-sonnet-4-5", "provider": "anthropic"}
+
+        mcp_result = {"resolved": True, "cost": 0.5}
+        baseline_result = {"resolved": False, "cost": 0.3}
+
+        # Store both
+        cache.put(task, config, "mcp", mcp_result)
+        cache.put(task, config, "baseline", baseline_result)
+
+        # Retrieve both
+        cached_mcp = cache.get(task, config, "mcp")
+        cached_baseline = cache.get(task, config, "baseline")
+
+        assert cached_mcp["resolved"] is True
+        assert cached_baseline["resolved"] is False
+
+    def test_cache_expiration(self, temp_cache_dir: Path) -> None:
+        """Test TTL-based cache expiration."""
+        # Create cache with very short TTL
+        cache = TaskResultCache(
+            cache_dir=temp_cache_dir,
+            ttl_seconds=1,
+            version="0.3.8",
+        )
+
+        task = {"instance_id": "test-1", "problem_statement": "Fix bug"}
+        config = {"model": "claude-sonnet-4-5", "provider": "anthropic"}
+        result = {"resolved": True}
+
+        # Store result
+        cache.put(task, config, "mcp", result)
+
+        # Should be cached immediately
+        cached = cache.get(task, config, "mcp")
+        assert cached is not None
+
+        # Wait for TTL to expire
+        time.sleep(1.5)
+
+        # Should be expired
+        cached = cache.get(task, config, "mcp")
+        assert cached is None
+
+    def test_cache_no_ttl(self, temp_cache_dir: Path) -> None:
+        """Test cache with no expiration."""
+        cache = TaskResultCache(
+            cache_dir=temp_cache_dir,
+            ttl_seconds=None,  # No expiration
+            version="0.3.8",
+        )
+
+        task = {"instance_id": "test-1", "problem_statement": "Fix bug"}
+        config = {"model": "claude-sonnet-4-5", "provider": "anthropic"}
+        result = {"resolved": True}
+
+        # Store result
+        cache.put(task, config, "mcp", result)
+
+        # Wait a bit (entry would expire with TTL)
+        time.sleep(0.5)
+
+        # Should still be cached
+        cached = cache.get(task, config, "mcp")
+        assert cached is not None
+
+    def test_version_invalidation(self, cache: TaskResultCache) -> None:
+        """Test version-based cache invalidation."""
+        task = {"instance_id": "test-1", "problem_statement": "Fix bug"}
+        config = {"model": "claude-sonnet-4-5", "provider": "anthropic"}
+        result = {"resolved": True}
+
+        # Store with current version
+        cache.put(task, config, "mcp", result)
+
+        # Should be cached
+        cached = cache.get(task, config, "mcp")
+        assert cached is not None
+
+        # Create new cache with different version
+        new_cache = TaskResultCache(
+            cache_dir=cache.cache_dir,
+            version="0.4.0",  # Different version
+        )
+
+        # Should not find cached entry (version mismatch)
+        cached = new_cache.get(task, config, "mcp")
+        assert cached is None
+
+    def test_clear_cache(self, cache: TaskResultCache) -> None:
+        """Test clearing all cache entries."""
+        task1 = {"instance_id": "test-1", "problem_statement": "Fix bug"}
+        task2 = {"instance_id": "test-2", "problem_statement": "Fix bug"}
+        config = {"model": "claude-sonnet-4-5", "provider": "anthropic"}
+        result = {"resolved": True}
+
+        # Store multiple entries
+        cache.put(task1, config, "mcp", result)
+        cache.put(task2, config, "mcp", result)
+
+        # Stats should show 2 entries
+        stats = cache.get_stats()
+        assert stats.total_entries == 2
+
+        # Clear cache
+        count = cache.clear()
+        assert count == 2
+
+        # Stats should show 0 entries
+        stats = cache.get_stats()
+        assert stats.total_entries == 0
+
+    def test_cache_size_management(self, temp_cache_dir: Path) -> None:
+        """Test cache size limit enforcement."""
+        # Create cache with very small size limit (1 KB)
+        cache = TaskResultCache(
+            cache_dir=temp_cache_dir,
+            max_size_mb=0.001,  # 1 KB
+            version="0.3.8",
+        )
+
+        config = {"model": "claude-sonnet-4-5", "provider": "anthropic"}
+        # Create large result (> 1 KB)
+        large_result = {"resolved": True, "data": "x" * 2000}
+
+        # Store multiple entries to exceed size limit
+        for i in range(5):
+            task = {"instance_id": f"test-{i}", "problem_statement": "Fix bug"}
+            cache.put(task, config, "mcp", large_result)
+
+        # Cache should have evicted some entries
+        stats = cache.get_stats()
+        assert stats.total_entries < 5
+        assert stats.cache_size_bytes <= cache.max_size_bytes
+
+    def test_corrupted_cache_entry(self, cache: TaskResultCache) -> None:
+        """Test handling of corrupted cache entries."""
+        task = {"instance_id": "test-1", "problem_statement": "Fix bug"}
+        config = {"model": "claude-sonnet-4-5", "provider": "anthropic"}
+        result = {"resolved": True}
+
+        # Store valid entry
+        cache.put(task, config, "mcp", result)
+
+        # Get cache file path
+        task_hash = cache._compute_task_hash(task)
+        config_hash = cache._compute_config_hash(config)
+        key = cache._compute_cache_key(task_hash, config_hash, "mcp")
+        cache_path = cache._get_cache_path(key)
+
+        # Corrupt the file
+        cache_path.write_text("invalid json{")
+
+        # Should handle corruption gracefully
+        cached = cache.get(task, config, "mcp")
+        assert cached is None
+
+        # File should be removed
+        assert not cache_path.exists()
+
+    def test_get_default_cache(self) -> None:
+        """Test getting default cache instance."""
+        cache = get_default_cache()
+        assert isinstance(cache, TaskResultCache)
+        assert cache.cache_dir == Path.home() / ".mcpbr" / "cache"
+
+    def test_invalidate_version(self, cache: TaskResultCache) -> None:
+        """Test invalidating cache entries by version."""
+        task1 = {"instance_id": "test-1", "problem_statement": "Fix bug"}
+        task2 = {"instance_id": "test-2", "problem_statement": "Fix bug"}
+        config = {"model": "claude-sonnet-4-5", "provider": "anthropic"}
+        result = {"resolved": True}
+
+        # Store entries
+        cache.put(task1, config, "mcp", result)
+        cache.put(task2, config, "mcp", result)
+
+        # Invalidate current version
+        count = cache.invalidate_version("0.3.8")
+        assert count == 2
+
+        # Entries should be gone
+        stats = cache.get_stats()
+        assert stats.total_entries == 0
+
+    def test_cache_stats_persistence(self, cache: TaskResultCache) -> None:
+        """Test that cache stats are persisted across instances."""
+        task = {"instance_id": "test-1", "problem_statement": "Fix bug"}
+        config = {"model": "claude-sonnet-4-5", "provider": "anthropic"}
+        result = {"resolved": True}
+
+        # Store entry and get it (1 miss, 1 hit)
+        cache.put(task, config, "mcp", result)
+        cache.get(task, config, "mcp")
+
+        # Create new cache instance with same directory
+        new_cache = TaskResultCache(
+            cache_dir=cache.cache_dir,
+            version="0.3.8",
+        )
+
+        # Stats should be loaded
+        stats = new_cache.get_stats()
+        assert stats.hits >= 1
+        assert stats.total_entries == 1
+
+    def test_cache_subdirectory_structure(self, cache: TaskResultCache) -> None:
+        """Test that cache uses subdirectories to avoid too many files."""
+        task = {"instance_id": "test-1", "problem_statement": "Fix bug"}
+        config = {"model": "claude-sonnet-4-5", "provider": "anthropic"}
+        result = {"resolved": True}
+
+        cache.put(task, config, "mcp", result)
+
+        # Should create subdirectory based on first 2 chars of key
+        task_hash = cache._compute_task_hash(task)
+        config_hash = cache._compute_config_hash(config)
+        key = cache._compute_cache_key(task_hash, config_hash, "mcp")
+
+        subdir = cache.cache_dir / key[:2]
+        assert subdir.exists()
+        assert subdir.is_dir()
+
+        # Cache file should be in subdirectory
+        cache_file = subdir / f"{key}.json"
+        assert cache_file.exists()
+
+    def test_task_hash_stability(self, cache: TaskResultCache) -> None:
+        """Test that task hashes are stable across runs."""
+        task = {
+            "instance_id": "test-1",
+            "problem_statement": "Fix bug",
+            "repo": "test/repo",
+            "base_commit": "abc123",
+        }
+
+        hash1 = cache._compute_task_hash(task)
+        hash2 = cache._compute_task_hash(task)
+
+        # Same task should produce same hash
+        assert hash1 == hash2
+
+        # Hash should be deterministic
+        expected_input = {
+            "instance_id": "test-1",
+            "problem_statement": "Fix bug",
+            "repo": "test/repo",
+            "base_commit": "abc123",
+            "patch": None,
+            "test_patch": None,
+            "FAIL_TO_PASS": None,
+            "PASS_TO_PASS": None,
+        }
+        content_str = json.dumps(expected_input, sort_keys=True)
+        import hashlib
+
+        expected_hash = hashlib.sha256(content_str.encode()).hexdigest()
+        assert hash1 == expected_hash

--- a/uv.lock
+++ b/uv.lock
@@ -1038,7 +1038,7 @@ wheels = [
 
 [[package]]
 name = "mcpbr"
-version = "0.3.7"
+version = "0.3.8"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
Implements intelligent result caching to avoid re-executing unchanged tasks during iterative development. When re-running evaluations with the same configuration, tasks that haven't changed now use cached results, saving significant time and API credits.

## Changes

### Core Cache System (`src/mcpbr/cache.py`)
- Content-based cache keys using SHA256 hashing of task definition and configuration
- Configurable TTL (time-to-live) with default 24 hours expiration
- Cache size limits with LRU eviction (default 1GB, configurable)
- Version-based cache invalidation for compatibility across mcpbr versions
- Atomic cache operations with subdirectory structure (avoids filesystem limits)
- Persistent cache statistics tracking (hits, misses, hit rate)

### CLI Additions (`src/mcpbr/cli.py`)
- `--no-cache` flag to disable result caching (force fresh evaluation)
- `--cache-ttl SECONDS` to configure TTL (0 = no expiration)
- `--cache-size MB` to set maximum cache size in megabytes
- `mcpbr cache clear` command to clear all cached results
- `mcpbr cache stats` command to display cache statistics

### Evaluation Integration (`src/mcpbr/harness.py`)
- Automatic cache check before running each task
- Automatic cache store after completing each task
- Separate caching for MCP and baseline runs
- Cache statistics included in evaluation results metadata
- Verbose mode shows cache hits for transparency

### Reporting (`src/mcpbr/reporting.py`)
- Cache statistics table shown in evaluation summary
- Cache metadata included in JSON/YAML output files

### Testing (`tests/test_cache.py`)
- Comprehensive test suite with 21 tests covering:
  - Cache key generation and stability
  - Cache hit/miss scenarios
  - TTL-based expiration
  - Version-based invalidation
  - Size management and LRU eviction
  - Corrupted entry handling
  - Subdirectory structure
  - Statistics persistence

## Cache Storage
Cache is stored in `~/.mcpbr/cache` by default with the following structure:
```
~/.mcpbr/cache/
├── ab/
│   ├── abc123...456.json  # Cache entries
│   └── abc789...012.json
├── cd/
│   └── cde345...678.json
└── stats.json  # Cache statistics
```

## Cache Key Components
Cache keys are computed from:
- Task definition (instance_id, problem_statement, repo, base_commit, patches, tests)
- Model and provider configuration
- Agent harness type
- Max iterations and timeout settings
- Agent prompt template
- MCP server configuration
- mcpbr version
- Run type (mcp vs baseline)

## Usage Examples

### Basic usage (caching enabled by default)
```bash
mcpbr run -c config.yaml
```

### Disable caching
```bash
mcpbr run -c config.yaml --no-cache
```

### Configure cache TTL and size
```bash
mcpbr run -c config.yaml --cache-ttl 3600 --cache-size 500
```

### Manage cache
```bash
mcpbr cache stats   # View statistics
mcpbr cache clear   # Clear all entries
```

## Test Plan
- [x] All 21 cache tests pass
- [x] Existing tests continue to pass (no regressions)
- [x] Linting and formatting checks pass
- [x] Cache correctly stores and retrieves results
- [x] Cache expires based on TTL
- [x] Cache invalidates on version change
- [x] Size limits are enforced with LRU eviction
- [x] Statistics are tracked and persisted
- [x] CLI commands work as expected

## Related Issues
Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)