### PR TITLE
ci: Add npm publishing to CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,42 @@ jobs:
         run: |
           pip install twine
           twine check dist/*
+
+  npm-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Verify CLI package structure
+        run: |
+          test -f package.json || (echo "Error: Root package.json not found" && exit 1)
+          test -f bin/mcpbr.js || (echo "Error: CLI binary not found" && exit 1)
+          echo "CLI package structure verified"
+
+      - name: Run CLI package scripts
+        run: |
+          npm test
+          echo "CLI package tests passed"
+
+      - name: Verify plugin package structure
+        run: |
+          test -f .claude-plugin/package.json || (echo "Error: Plugin package.json not found" && exit 1)
+          test -f .claude-plugin/plugin.json || (echo "Error: plugin.json not found" && exit 1)
+          test -d .claude-plugin/skills || (echo "Error: skills directory not found" && exit 1)
+          echo "Plugin package structure verified"
+
+      - name: Check CLI package with npm pack
+        run: |
+          npm pack --dry-run
+          echo "CLI package check passed"
+
+      - name: Check plugin package with npm pack
+        run: |
+          cd .claude-plugin
+          npm pack --dry-run
+          echo "Plugin package check passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,14 @@ jobs:
           python -m build
           pip install dist/*.whl
 
+      - name: Verify mcpbr Python package installation
+        run: |
+          python --version
+          python3 --version
+          pip list | grep mcpbr
+          python -m mcpbr --version
+          python3 -m mcpbr --version
+
       - name: Verify CLI package structure
         run: |
           test -f package.json || (echo "Error: Root package.json not found" && exit 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,11 +118,8 @@ jobs:
 
       - name: Verify mcpbr Python package installation
         run: |
-          python --version
-          python3 --version
-          pip list | grep mcpbr
           python -m mcpbr --version
-          python3 -m mcpbr --version
+          echo "mcpbr Python package installed successfully"
 
       - name: Verify CLI package structure
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
           test -f bin/mcpbr.js || (echo "Error: CLI binary not found" && exit 1)
           echo "CLI package structure verified"
 
+      - name: Install CLI package dependencies
+        run: npm install
+
       - name: Run CLI package scripts
         run: |
           npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,10 +96,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+
+      - name: Install Python build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build and install mcpbr Python package
+        run: |
+          python -m build
+          pip install dist/*.whl
 
       - name: Verify CLI package structure
         run: |
@@ -109,6 +124,11 @@ jobs:
 
       - name: Install CLI package dependencies
         run: npm install
+
+      - name: Test CLI package
+        run: |
+          npm test
+          echo "CLI package test passed"
 
       - name: Verify plugin package structure
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,11 +110,6 @@ jobs:
       - name: Install CLI package dependencies
         run: npm install
 
-      - name: Run CLI package scripts
-        run: |
-          npm test
-          echo "CLI package tests passed"
-
       - name: Verify plugin package structure
         run: |
           test -f .claude-plugin/package.json || (echo "Error: Plugin package.json not found" && exit 1)

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -27,19 +27,45 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Publishing version: $VERSION"
 
-      - name: Update package.json version
+      - name: Update CLI package version
         run: |
-          # Update version in package.json to match release tag
+          # Update version in root package.json to match release tag
           npm version ${{ steps.get_version.outputs.version }} --no-git-tag-version
+          echo "CLI package version updated"
 
-      - name: Verify package contents
+      - name: Update plugin package version
         run: |
-          # Check that required files exist
-          test -f .claude-plugin/plugin.json || (echo "Error: plugin.json not found" && exit 1)
-          test -d skills || (echo "Error: skills directory not found" && exit 1)
-          echo "Package contents verified"
+          # Update version in .claude-plugin/package.json to match release tag
+          cd .claude-plugin
+          npm version ${{ steps.get_version.outputs.version }} --no-git-tag-version
+          echo "Plugin package version updated"
 
-      - name: Publish to npm
-        run: npm publish
+      - name: Verify CLI package contents
+        run: |
+          # Check that required files exist for CLI package
+          test -f package.json || (echo "Error: Root package.json not found" && exit 1)
+          test -f bin/mcpbr.js || (echo "Error: CLI binary not found" && exit 1)
+          echo "CLI package contents verified"
+
+      - name: Verify plugin package contents
+        run: |
+          # Check that required files exist for plugin package
+          test -f .claude-plugin/package.json || (echo "Error: Plugin package.json not found" && exit 1)
+          test -f .claude-plugin/plugin.json || (echo "Error: plugin.json not found" && exit 1)
+          test -d .claude-plugin/skills || (echo "Error: skills directory not found" && exit 1)
+          echo "Plugin package contents verified"
+
+      - name: Publish CLI package to npm
+        run: |
+          npm publish --access public
+          echo "CLI package published successfully"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish plugin package to npm
+        run: |
+          cd .claude-plugin
+          npm publish --access public
+          echo "Plugin package published successfully"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,45 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Extract version from release tag
+        id: get_version
+        run: |
+          # Remove 'v' prefix if present (e.g., v0.3.17 -> 0.3.17)
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Publishing version: $VERSION"
+
+      - name: Update package.json version
+        run: |
+          # Update version in package.json to match release tag
+          npm version ${{ steps.get_version.outputs.version }} --no-git-tag-version
+
+      - name: Verify package contents
+        run: |
+          # Check that required files exist
+          test -f .claude-plugin/plugin.json || (echo "Error: plugin.json not found" && exit 1)
+          test -d skills || (echo "Error: skills directory not found" && exit 1)
+          echo "Package contents verified"
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ make build
 
 #### Version Management
 
-The project uses a centralized version in `pyproject.toml` that is automatically synced to other files (like `.claude-plugin/plugin.json`).
+The project uses a centralized version in `pyproject.toml` that is automatically synced to other files (like `.claude-plugin/plugin.json` and `package.json`).
 
 **Automated syncing:**
 - The version sync runs automatically during `make build`
@@ -142,6 +142,24 @@ The project uses a centralized version in `pyproject.toml` that is automatically
 make sync-version
 # or
 python3 scripts/sync_version.py
+```
+
+#### npm Package Commands
+
+The Claude Code plugin is published to npm as `claude-code-plugin-mcpbr`. Use these commands for npm package management:
+
+```bash
+# Prepare npm package (syncs version from pyproject.toml)
+make npm-build
+
+# Test npm package contents locally
+make npm-test
+
+# Create a tarball for local testing
+make npm-pack
+
+# Publish to npm (requires NPM_TOKEN environment variable)
+make npm-publish
 ```
 
 #### Pre-commit Hooks (Optional)
@@ -206,6 +224,71 @@ mcpbr/
 3. Update `VALID_HARNESSES` in `config.py`
 4. Add tests
 5. Update documentation
+
+## Release Process
+
+### Publishing a New Release
+
+When a new GitHub release is published, the following happens automatically:
+
+1. **PyPI Publishing** (`.github/workflows/publish.yml`)
+   - Builds Python package
+   - Publishes to PyPI using trusted publishing
+
+2. **npm Publishing** (`.github/workflows/publish-npm.yml`)
+   - Syncs version from release tag to `package.json`
+   - Verifies package contents
+   - Publishes to npm as `claude-code-plugin-mcpbr`
+
+### Prerequisites for Automated Publishing
+
+**PyPI:**
+- Uses GitHub's trusted publishing (no token needed)
+- Configured in PyPI project settings
+
+**npm:**
+- Requires `NPM_TOKEN` secret in GitHub repository settings
+- Token must have publish permissions for `claude-code-plugin-mcpbr`
+- **Note:** Repository maintainers must add this secret manually
+
+### Creating a Release
+
+1. Update version in `pyproject.toml`
+2. Run `make sync-version` to sync to plugin.json and package.json
+3. Commit and push changes
+4. Create a new GitHub release with tag `vX.Y.Z` (e.g., `v0.3.18`)
+5. Both PyPI and npm packages will be published automatically
+
+### Testing Before Release
+
+**Python package:**
+```bash
+make build
+pip install dist/mcpbr-*.whl  # Test locally
+```
+
+**npm package:**
+```bash
+make npm-pack  # Creates a tarball
+npm install ./claude-code-plugin-mcpbr-*.tgz  # Test locally
+```
+
+### Manual Publishing (if needed)
+
+**PyPI:**
+```bash
+make build
+pip install twine
+twine upload dist/*
+```
+
+**npm:**
+```bash
+export NPM_TOKEN=your-npm-token
+make npm-publish
+# or
+npm publish
+```
 
 ## Questions?
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install test test-all lint format sync-version clean build
+.PHONY: help install test test-all lint format sync-version clean build npm-build npm-test npm-publish npm-pack
 
 help:
 	@echo "Available commands:"
@@ -9,6 +9,12 @@ help:
 	@echo "  make sync-version  - Sync version across project files"
 	@echo "  make clean         - Remove build artifacts"
 	@echo "  make build         - Build distribution packages"
+	@echo ""
+	@echo "npm commands:"
+	@echo "  make npm-build     - Prepare npm package (sync version)"
+	@echo "  make npm-test      - Test npm package locally"
+	@echo "  make npm-pack      - Create npm package tarball"
+	@echo "  make npm-publish   - Publish to npm (requires NPM_TOKEN)"
 
 install:
 	pip install -e ".[dev]"
@@ -38,3 +44,24 @@ clean:
 
 build: sync-version
 	python -m build
+
+npm-build: sync-version
+	@echo "npm package prepared (version synced)"
+
+npm-test: npm-build
+	@echo "Testing npm package contents..."
+	@test -f package.json || (echo "Error: package.json not found" && exit 1)
+	@test -f .claude-plugin/plugin.json || (echo "Error: plugin.json not found" && exit 1)
+	@test -d skills || (echo "Error: skills directory not found" && exit 1)
+	@echo "npm package contents verified"
+
+npm-pack: npm-build
+	npm pack
+
+npm-publish: npm-build
+	@if [ -z "$$NPM_TOKEN" ]; then \
+		echo "Error: NPM_TOKEN environment variable not set"; \
+		echo "Set it with: export NPM_TOKEN=your-token"; \
+		exit 1; \
+	fi
+	npm publish

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -4,6 +4,7 @@ Sync version across all project files.
 
 This script reads the version from pyproject.toml and updates it in:
 - .claude-plugin/plugin.json
+- package.json (if it exists)
 
 Usage:
     python scripts/sync_version.py
@@ -55,11 +56,31 @@ def update_plugin_json(plugin_json_path: Path, version: str) -> None:
     print(f"Updated {plugin_json_path}: {old_version} -> {version}")
 
 
+def update_package_json(package_json_path: Path, version: str) -> None:
+    """Update version in package.json."""
+    if not package_json_path.exists():
+        print(f"Info: {package_json_path} does not exist. Skipping npm package sync.")
+        return
+
+    with open(package_json_path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    old_version = data.get("version", "unknown")
+    data["version"] = version
+
+    with open(package_json_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")  # Add trailing newline
+
+    print(f"Updated {package_json_path}: {old_version} -> {version}")
+
+
 def main() -> None:
     """Main entry point."""
     project_root = Path(__file__).parent.parent
     pyproject_path = project_root / "pyproject.toml"
     plugin_json_path = project_root / ".claude-plugin" / "plugin.json"
+    package_json_path = project_root / "package.json"
 
     if not pyproject_path.exists():
         print(f"Error: {pyproject_path} not found", file=sys.stderr)
@@ -71,6 +92,9 @@ def main() -> None:
 
     # Update plugin.json
     update_plugin_json(plugin_json_path, version)
+
+    # Update package.json (if it exists)
+    update_package_json(package_json_path, version)
 
     print("\nVersion sync complete!")
 

--- a/src/mcpbr/__main__.py
+++ b/src/mcpbr/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for running mcpbr as a module with python -m mcpbr."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/mcpbr/cli.py
+++ b/src/mcpbr/cli.py
@@ -37,8 +37,8 @@ class DefaultToRunGroup(click.Group):
         if args and args[0] not in self.commands and not args[0].startswith("-"):
             return super().parse_args(ctx, args)
 
-        # Don't default to 'run' if asking for help at the group level
-        if args and args[0] in ("--help", "-h"):
+        # Don't default to 'run' if asking for help or version at the group level
+        if args and args[0] in ("--help", "-h", "--version"):
             return super().parse_args(ctx, args)
 
         if not args or args[0].startswith("-"):


### PR DESCRIPTION
## Summary

Implements issue #272 by adding automated npm package publishing for the Claude Code plugin.

## Changes

### npm Package Structure
- **`package.json`**: npm package manifest for `claude-code-plugin-mcpbr`
  - Includes `.claude-plugin/` directory with plugin.json
  - Includes `skills/` directory with all skill definitions
  - Version synced automatically from `pyproject.toml`

### GitHub Actions Workflow
- **`.github/workflows/publish-npm.yml`**: Automated npm publishing
  - Triggers on GitHub release (same as PyPI publishing)
  - Extracts version from release tag (e.g., `v0.3.18` → `0.3.18`)
  - Updates `package.json` version to match release
  - Verifies package contents before publishing
  - Publishes to npm registry

### Version Synchronization
- **`scripts/sync_version.py`**: Extended to sync `package.json`
  - Now syncs: `pyproject.toml` → `plugin.json` + `package.json`
  - Gracefully handles missing `package.json` (for backwards compatibility)
  - Integrated with existing pre-commit hooks and CI checks

### Makefile Targets
- **`make npm-build`**: Prepare npm package (sync version)
- **`make npm-test`**: Verify package contents locally
- **`make npm-pack`**: Create tarball for local testing
- **`make npm-publish`**: Manual publish (requires `NPM_TOKEN` env var)

### Documentation
- **`CONTRIBUTING.md`**: New sections covering:
  - npm package commands
  - Release process (PyPI + npm)
  - Testing before release
  - Manual publishing instructions

### .gitignore
- Updated to allow `package.json` (previously excluded by `*.json` rule)

## Release Process

When a new GitHub release is published:

1. **PyPI workflow** publishes Python package (existing)
2. **npm workflow** publishes Claude Code plugin package (new)
3. Both packages stay in sync with the same version number

## Testing

```bash
# Test version sync
python3 scripts/sync_version.py

# Test npm package locally
make npm-test

# Create tarball for manual testing
make npm-pack
npm install ./claude-code-plugin-mcpbr-*.tgz
```

## Required Setup

**Action Required:** Repository maintainers must add the `NPM_TOKEN` secret to GitHub repository settings:

1. Generate npm access token with publish permissions
2. Add to repository settings: Settings → Secrets and variables → Actions → New repository secret
3. Name: `NPM_TOKEN`
4. Value: Your npm token

Without this secret, the npm publishing workflow will fail (PyPI publishing will still work).

## Benefits

- Claude Code plugin available via npm: `npm install claude-code-plugin-mcpbr`
- Automated publishing keeps npm and PyPI in sync
- Version management across all package formats
- Easy local testing and development workflow

## Related

Closes #272

Generated with [Claude Code](https://claude.com/claude-code)