### PR TITLE
feat: Consolidate all logs into single directory (#296)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,8 @@ reports/
 .swebench-mcp/
 .logs/
 logs/
+.mcpbr_run_*/
+.mcpbr_state/
 
 # npm
 node_modules/

--- a/README.md
+++ b/README.md
@@ -773,6 +773,36 @@ Results saved to results.json
 }
 ```
 
+### Output Directory Structure
+
+By default, mcpbr consolidates all outputs into a single timestamped directory:
+
+```text
+.mcpbr_run_20260126_133000/
+├── config.yaml                # Copy of configuration used
+├── evaluation_state.json      # Task results and state
+├── logs/                      # Detailed MCP server logs
+│   ├── task_1_mcp.log
+│   ├── task_2_mcp.log
+│   └── ...
+└── README.txt                 # Auto-generated explanation
+```
+
+This makes it easy to:
+- **Archive results**: `tar -czf results.tar.gz .mcpbr_run_*`
+- **Clean up**: `rm -rf .mcpbr_run_*`
+- **Share**: Just zip one directory
+
+You can customize the output directory:
+
+```bash
+# Custom output directory
+mcpbr run -c config.yaml --output-dir ./my-results
+
+# Or in config.yaml
+output_dir: "./my-results"
+```
+
 ### Markdown Report (`--report`)
 
 Generates a human-readable report with:

--- a/README.md
+++ b/README.md
@@ -803,6 +803,8 @@ mcpbr run -c config.yaml --output-dir ./my-results
 output_dir: "./my-results"
 ```
 
+**Note:** The `--output-dir` CLI flag takes precedence over the `output_dir` config setting. This ensures that the README.txt file in the output directory reflects the final effective configuration values after all CLI overrides are applied.
+
 ### Markdown Report (`--report`)
 
 Generates a human-readable report with:

--- a/src/mcpbr/config.py
+++ b/src/mcpbr/config.py
@@ -146,6 +146,11 @@ class HarnessConfig(BaseModel):
         description="Directory to store cache files (default: ~/.cache/mcpbr)",
     )
 
+    output_dir: str | None = Field(
+        default=None,
+        description="Directory for all evaluation outputs (logs, state, results). Default: .mcpbr_run_TIMESTAMP",
+    )
+
     @field_validator("provider")
     @classmethod
     def validate_provider(cls, v: str) -> str:

--- a/src/mcpbr/harness.py
+++ b/src/mcpbr/harness.py
@@ -142,6 +142,7 @@ def _create_mcp_agent(
     benchmark: Benchmark,
     verbosity: int = 1,
     log_file: TextIO | InstanceLogWriter | None = None,
+    mcp_logs_dir: Path | None = None,
 ) -> AgentHarness:
     """Create the agent harness based on config.
 
@@ -150,6 +151,7 @@ def _create_mcp_agent(
         benchmark: Benchmark instance for getting default prompt.
         verbosity: Verbosity level (0=silent, 1=summary, 2=detailed).
         log_file: Optional file handle for writing raw JSON logs.
+        mcp_logs_dir: Directory for MCP server logs.
 
     Returns:
         Configured AgentHarness.
@@ -165,6 +167,7 @@ def _create_mcp_agent(
         max_iterations=config.max_iterations,
         verbosity=verbosity,
         log_file=log_file,
+        mcp_logs_dir=mcp_logs_dir,
     )
 
 
@@ -211,6 +214,7 @@ async def run_single_task(
     log_file: TextIO | None = None,
     log_dir: Path | None = None,
     cache: ResultCache | None = None,
+    mcp_logs_dir: Path | None = None,
 ) -> TaskResult:
     """Run evaluation for a single task.
 
@@ -226,6 +230,7 @@ async def run_single_task(
         log_file: Optional file handle for writing raw JSON logs.
         log_dir: Optional directory for per-instance JSON log files.
         cache: Optional result cache.
+        mcp_logs_dir: Directory for MCP server logs.
 
     Returns:
         TaskResult with results for both runs.
@@ -247,6 +252,7 @@ async def run_single_task(
                 verbosity,
                 mcp_log_writer if mcp_log_writer else log_file,
                 cache,
+                mcp_logs_dir,
             )
         finally:
             if mcp_log_writer:
@@ -283,6 +289,7 @@ async def _run_mcp_evaluation(
     verbosity: int = 1,
     log_file: TextIO | InstanceLogWriter | None = None,
     cache: ResultCache | None = None,
+    mcp_logs_dir: Path | None = None,
 ) -> dict[str, Any]:
     """Run MCP agent evaluation with optional caching.
 
@@ -295,6 +302,7 @@ async def _run_mcp_evaluation(
         verbosity: Verbosity level.
         log_file: Optional log file writer.
         cache: Optional result cache.
+        mcp_logs_dir: Directory for MCP server logs.
 
     Returns:
         Dictionary with evaluation results.
@@ -312,7 +320,7 @@ async def _run_mcp_evaluation(
     try:
         env = await benchmark.create_environment(task, docker_manager)
 
-        agent = _create_mcp_agent(config, benchmark, verbosity, log_file)
+        agent = _create_mcp_agent(config, benchmark, verbosity, log_file, mcp_logs_dir)
 
         instance_id = task.get(
             "instance_id", f"{task.get('project', 'unknown')}_{task.get('bug_id', 'unknown')}"
@@ -558,6 +566,7 @@ async def run_evaluation(
     state_tracker: Any | None = None,
     from_task: str | None = None,
     incremental_save_path: Path | None = None,
+    mcp_logs_dir: Path | None = None,
 ) -> EvaluationResults:
     """Run the full evaluation.
 
@@ -573,6 +582,7 @@ async def run_evaluation(
         state_tracker: Optional state tracker for incremental evaluation.
         from_task: Optional task ID to resume from.
         incremental_save_path: Optional path to save results incrementally for crash recovery.
+        mcp_logs_dir: Directory for MCP server logs.
 
     Returns:
         EvaluationResults with all results.
@@ -722,6 +732,7 @@ async def run_evaluation(
                 log_file,
                 log_dir,
                 cache,
+                mcp_logs_dir,
             )
 
             # Update current cost

--- a/src/mcpbr/harnesses.py
+++ b/src/mcpbr/harnesses.py
@@ -452,6 +452,7 @@ class ClaudeCodeHarness:
         max_iterations: int = 10,
         verbosity: int = 1,
         log_file: TextIO | InstanceLogWriter | None = None,
+        mcp_logs_dir: Path | None = None,
     ) -> None:
         """Initialize Claude Code harness.
 
@@ -462,6 +463,7 @@ class ClaudeCodeHarness:
             max_iterations: Maximum number of agentic turns.
             verbosity: Verbosity level (0=silent, 1=summary, 2=detailed).
             log_file: Optional file handle for writing raw JSON logs.
+            mcp_logs_dir: Directory for MCP server logs. Default: ~/.mcpbr_state/logs
         """
         self.model = model
         self.mcp_server = mcp_server
@@ -471,6 +473,7 @@ class ClaudeCodeHarness:
         self.max_iterations = max_iterations
         self.verbosity = verbosity
         self.log_file = log_file
+        self.mcp_logs_dir = mcp_logs_dir
         self._console = Console()
 
     async def solve(
@@ -825,8 +828,11 @@ class ClaudeCodeHarness:
             if self.mcp_server:
                 from pathlib import Path
 
-                # Create logs directory in .mcpbr_state
-                state_dir = Path.home() / ".mcpbr_state" / "logs"
+                # Determine logs directory: use mcp_logs_dir if provided, otherwise fall back to home directory
+                if self.mcp_logs_dir:
+                    state_dir = self.mcp_logs_dir / "logs"
+                else:
+                    state_dir = Path.home() / ".mcpbr_state" / "logs"
                 state_dir.mkdir(parents=True, exist_ok=True)
                 # Sanitize instance_id to prevent path traversal
                 safe_instance_id = instance_id.replace("/", "_").replace("\\", "_")
@@ -1075,6 +1081,7 @@ def create_harness(
     max_iterations: int = 10,
     verbosity: int = 1,
     log_file: TextIO | InstanceLogWriter | None = None,
+    mcp_logs_dir: Path | None = None,
 ) -> AgentHarness:
     """Factory function to create an agent harness.
 
@@ -1086,6 +1093,7 @@ def create_harness(
         max_iterations: Maximum agent iterations (used by claude-code harness).
         verbosity: Verbosity level for logging (0=silent, 1=summary, 2=detailed).
         log_file: Optional file handle for writing raw JSON logs.
+        mcp_logs_dir: Directory for MCP server logs.
 
     Returns:
         AgentHarness instance.
@@ -1107,6 +1115,7 @@ def create_harness(
         max_iterations=max_iterations,
         verbosity=verbosity,
         log_file=log_file,
+        mcp_logs_dir=mcp_logs_dir,
     )
 
 


### PR DESCRIPTION
Fixes #296

## Summary

Consolidates all evaluation outputs into a single timestamped directory, making it easy to collect, archive, and share results.

## Changes

- ✅ Timestamped output directories: `.mcpbr_run_20260126_133000/`
- ✅ Added `--output-dir` CLI flag and `output_dir` config option
- ✅ All outputs consolidated: config.yaml, evaluation_state.json, logs/, README.txt
- ✅ Auto-generated README.txt in each run directory explaining contents
- ✅ Updated .gitignore for new directory pattern
- ✅ Full documentation in README

## Directory Structure

```
.mcpbr_run_20260126_133000/
├── config.yaml                 # Copy of config used
├── evaluation_state.json       # Results
├── logs/                       # Per-task execution logs
│   ├── task_1_mcp.log
│   └── task_2_mcp.log
└── README.txt                  # Auto-generated explanation
```

## Benefits

**Before:**
```bash
# Logs scattered across 3+ locations:
./benchmark.log
./.mcpbr_state/evaluation_state.json
~/.mcpbr_state/logs/*.log  # In HOME directory!
```

**After:**
```bash
# Everything in one place:
.mcpbr_run_20260126_133000/

# Easy to archive:
tar -czf results.tar.gz .mcpbr_run_*

# Easy to cleanup:
rm -rf .mcpbr_run_*
```

## Usage

**Default (timestamped):**
```bash
mcpbr run -c config.yaml
# Creates: .mcpbr_run_20260126_133000/
```

**Custom location:**
```bash
mcpbr run -c config.yaml --output-dir ./my-results
# Creates: ./my-results/
```

**Via config:**
```yaml
output_dir: "./my-results"
```

## Backwards Compatibility

- ✅ Fully backwards compatible
- ✅ MCP logs fall back to `~/.mcpbr_state/logs/` if output_dir not set
- ✅ No breaking changes
- ✅ No configuration changes required for existing users

## Impact

Makes evaluation results easy to:
- Archive and share (single zip file)
- Cleanup (single rm command)
- Organize (timestamped, non-overlapping)
- Understand (auto-generated README)

Perfect for CI/CD workflows and research collaboration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI option to specify a custom output directory for evaluation results; defaults to a timestamped run directory when unset.
  * Evaluation runs now place logs, state, config, and a README into a dedicated output folder.

* **Documentation**
  * Added an "Output Directory Structure" section describing layout, customization via CLI/config, and usage guidance.

* **Chores**
  * Updated ignore rules to exclude run and state directories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->