### PR TITLE
fix: Capture timeout task statistics from partial execution (#297)

### DIFF
--- a/docs/timeout_tracking.md
+++ b/docs/timeout_tracking.md
@@ -1,0 +1,153 @@
+# Timeout Statistics Tracking
+
+## Overview
+
+When a task times out during evaluation, mcpbr now captures and records the work completed before the timeout occurred. This ensures that timeout tasks don't appear as "never started" in evaluation results.
+
+## Problem (Before Fix)
+
+Prior to this fix, when a task timed out:
+- `iterations` was recorded as 0
+- `tool_calls` was recorded as 0
+- `tool_usage` was empty
+- No distinction between "agent never started" vs "ran out of time"
+
+This caused:
+- Inaccurate statistics excluding all timeout work
+- Misleading results showing timeouts as startup failures
+- Under-counted costs and token usage
+- Incorrect analysis of tool effectiveness
+
+### Example Before Fix
+
+```json
+{
+  "instance_id": "django__django-11797",
+  "mcp_result": {
+    "iterations": 0,
+    "tool_calls": 0,
+    "tool_usage": {},
+    "error": "Task execution timed out after 600s..."
+  }
+}
+```
+
+Even though MCP server logs showed the agent made 30 tool calls.
+
+## Solution (After Fix)
+
+The timeout handler now:
+1. Captures partial stdout from MCP log files
+2. Parses tool usage statistics from the partial output
+3. Records iterations, tool_calls, tool_usage, and tool_failures
+4. Adds `"status": "timeout"` field to distinguish from other errors
+
+### Example After Fix
+
+```json
+{
+  "instance_id": "django__django-11797",
+  "mcp_result": {
+    "iterations": 15,
+    "tool_calls": 30,
+    "tool_usage": {
+      "Grep": 16,
+      "Read": 8,
+      "mcp__supermodel__explore_codebase": 4,
+      "Bash": 1,
+      "TodoWrite": 1
+    },
+    "tool_failures": {},
+    "status": "timeout",
+    "error": "Task execution timed out after 600s. Agent made 30 tool calls across 15 iterations before timeout.",
+    "tokens": {
+      "input": 25000,
+      "output": 12000
+    }
+  }
+}
+```
+
+## Implementation Details
+
+### MCP Log File Recovery
+
+When a timeout occurs in Docker execution (`ClaudeCodeHarness._solve_in_docker`):
+
+1. The MCP server log file is flushed and closed
+2. The log file is read back to extract stdout lines
+3. Lines prefixed with `[STDOUT]` are parsed for tool usage events
+4. The `_parse_tool_usage_from_stream()` function extracts:
+   - Total tool calls
+   - Tool usage breakdown by tool name
+   - Tool failures and error messages
+   - Number of iterations (turns)
+   - Token usage (input/output)
+
+### Status Field
+
+The `"status": "timeout"` field is added to results when:
+- The error message contains "timeout" or "timed out"
+- This allows distinguishing between:
+  - `"status": "timeout"` - Agent was working but ran out of time
+  - No status field - Other types of errors
+  - `"resolved": true` - Normal successful completion
+
+### Fallback Behavior
+
+If MCP log parsing fails for any reason:
+- The system gracefully falls back to returning zeros
+- An error message is logged (in verbose mode)
+- The timeout error is still recorded with available information
+
+## Testing
+
+New tests verify:
+- Partial stdout parsing from interrupted executions
+- Tool usage statistics extraction
+- Tool failure tracking in partial streams
+- Status field addition for timeout errors
+- Graceful handling of malformed JSON
+- Empty stdout handling
+
+Run tests:
+```bash
+pytest tests/test_timeout_tracking.py -v
+```
+
+## Impact on Evaluation Results
+
+After this fix:
+- Timeout tasks now contribute to tool usage statistics
+- Average tool calls per task is more accurate
+- Cost calculations include timeout work
+- Researchers can distinguish "too slow" from "failed to start"
+
+### Statistics Correction Example
+
+In a 300-task evaluation where 36 tasks timed out:
+- **Before**: Missing 1,080 tool calls from statistics
+- **After**: All tool calls included, proper averages calculated
+
+## Configuration
+
+No configuration changes required. The fix is automatic and backward-compatible.
+
+Timeout duration is still controlled by:
+```yaml
+timeout_seconds: 600  # Default timeout per task
+```
+
+## Related Issues
+
+- Issue #297: Original bug report
+- Issue #295: Enable logging by default
+- Issue #296: Consolidate log directories
+
+## Future Enhancements
+
+Potential improvements:
+1. Add timeout warning thresholds (warn if many tasks timeout)
+2. Include timeout statistics in summary reports
+3. Support adjustable timeouts per task or repository
+4. Add timeout prediction based on repository size

--- a/tests/test_timeout_tracking.py
+++ b/tests/test_timeout_tracking.py
@@ -1,0 +1,268 @@
+"""Tests for timeout statistics tracking (Issue #297).
+
+Tests verify that when a task times out, the evaluation state still captures:
+- iterations performed before timeout
+- tool_calls made before timeout
+- tool_usage breakdown
+- tool_failures that occurred
+- status field indicating timeout vs normal completion
+"""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from mcpbr.harness import _run_mcp_evaluation, agent_result_to_dict
+from mcpbr.harnesses import AgentResult, _parse_tool_usage_from_stream
+
+
+def test_parse_tool_usage_captures_partial_stream():
+    """Test that _parse_tool_usage_from_stream extracts stats from partial stdout."""
+    # Simulate partial stream-json output from a timed-out execution
+    partial_stdout = """
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"1","name":"Grep","input":{}}],"usage":{"input_tokens":100,"output_tokens":50}}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"1","content":"result"}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"2","name":"Read","input":{}}],"usage":{"input_tokens":120,"output_tokens":60}}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"2","content":"file content"}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"3","name":"Bash","input":{}}],"usage":{"input_tokens":130,"output_tokens":70}}}
+"""
+
+    (
+        total_tool_calls,
+        tool_usage,
+        tool_failures,
+        tool_errors,
+        num_turns,
+        tokens_in,
+        tokens_out,
+        result_subtype,
+    ) = _parse_tool_usage_from_stream(partial_stdout)
+
+    # Verify tool call counting
+    assert total_tool_calls == 3, f"Expected 3 tool calls, got {total_tool_calls}"
+    assert tool_usage == {"Grep": 1, "Read": 1, "Bash": 1}
+    assert tokens_in == 350  # 100 + 120 + 130
+    assert tokens_out == 180  # 50 + 60 + 70
+
+
+def test_parse_tool_usage_captures_tool_failures():
+    """Test that tool failures are tracked even in partial streams."""
+    partial_stdout = """
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"1","name":"Grep","input":{}}],"usage":{"input_tokens":100,"output_tokens":50}}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"1","is_error":true,"content":"File not found"}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"2","name":"Read","input":{}}],"usage":{"input_tokens":120,"output_tokens":60}}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"2","is_error":true,"content":"Permission denied"}]}}
+"""
+
+    (
+        total_tool_calls,
+        tool_usage,
+        tool_failures,
+        tool_errors,
+        num_turns,
+        tokens_in,
+        tokens_out,
+        result_subtype,
+    ) = _parse_tool_usage_from_stream(partial_stdout)
+
+    # Verify failure tracking
+    assert total_tool_calls == 2
+    assert tool_failures == {"Grep": 1, "Read": 1}
+    assert "Grep" in tool_errors
+    assert "Read" in tool_errors
+    assert "File not found" in tool_errors["Grep"][0]
+    assert "Permission denied" in tool_errors["Read"][0]
+
+
+def test_agent_result_to_dict_includes_status_on_timeout():
+    """Test that agent_result_to_dict adds status='timeout' when error mentions timeout."""
+    result = AgentResult(
+        patch="",
+        success=False,
+        error="Task execution timed out after 600s.",
+        tokens_input=1000,
+        tokens_output=500,
+        iterations=15,
+        tool_calls=30,
+        tool_usage={"Grep": 10, "Read": 15, "Bash": 5},
+        tool_failures={"Bash": 2},
+    )
+
+    data = agent_result_to_dict(result, None, "claude-sonnet-4-5-20250929")
+
+    # Verify status field is set
+    assert data.get("status") == "timeout", "Expected status='timeout' for timeout error"
+    # Verify statistics are preserved
+    assert data["iterations"] == 15
+    assert data["tool_calls"] == 30
+    assert data["tool_usage"] == {"Grep": 10, "Read": 15, "Bash": 5}
+    assert data["tool_failures"] == {"Bash": 2}
+    assert not data["resolved"]
+    assert not data["patch_applied"]
+
+
+def test_agent_result_to_dict_no_status_on_normal_error():
+    """Test that agent_result_to_dict doesn't add status for non-timeout errors."""
+    result = AgentResult(
+        patch="",
+        success=False,
+        error="Some other error occurred",
+        tokens_input=100,
+        tokens_output=50,
+        iterations=5,
+        tool_calls=10,
+    )
+
+    data = agent_result_to_dict(result, None, "claude-sonnet-4-5-20250929")
+
+    # Verify no status field for normal errors
+    assert "status" not in data or data.get("status") != "timeout"
+    assert data["error"] == "Some other error occurred"
+
+
+@pytest.mark.asyncio
+async def test_run_mcp_evaluation_timeout_fallback():
+    """Test that _run_mcp_evaluation timeout handler sets status='timeout'."""
+    # Mock config and other dependencies
+    config = Mock()
+    config.agent_prompt = None
+    config.timeout_seconds = 10
+    config.model = "claude-sonnet-4-5-20250929"
+    config.agent_harness = "claude-code"  # Required field
+
+    benchmark = Mock()
+    benchmark.get_prompt_template.return_value = "Test prompt"
+    benchmark.create_environment = AsyncMock()
+
+    docker_manager = Mock()
+
+    task = {"instance_id": "test-task", "problem_statement": "Fix the bug"}
+
+    # Simulate timeout by raising asyncio.TimeoutError
+    with patch("mcpbr.harness.asyncio.wait_for", side_effect=asyncio.TimeoutError):
+        result = await _run_mcp_evaluation(task, config, docker_manager, benchmark, verbose=False)
+
+    # Verify timeout fallback sets status field
+    assert result.get("status") == "timeout"
+    assert result.get("error") == "Timeout"
+    assert not result["resolved"]
+    assert not result["patch_applied"]
+
+
+@pytest.mark.asyncio
+async def test_docker_timeout_captures_partial_stdout():
+    """Test that timeout handler logic correctly parses MCP log files.
+
+    This is a simplified test that verifies the key behavior without
+    full Docker environment mocking.
+    """
+    # Create a temporary MCP log file with partial output
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        log_path = Path(tmpdir) / "test-task_mcp.log"
+        log_content = """[STDOUT] {"type":"assistant","message":{"content":[{"type":"tool_use","id":"1","name":"Grep","input":{}}],"usage":{"input_tokens":100,"output_tokens":50}}}
+[STDOUT] {"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"1","content":"result"}]}}
+[STDOUT] {"type":"assistant","message":{"content":[{"type":"tool_use","id":"2","name":"Read","input":{}}],"usage":{"input_tokens":120,"output_tokens":60}}}
+"""
+        log_path.write_text(log_content)
+
+        # Simulate what the timeout handler does: read back the log
+        with open(log_path, "r") as f:
+            stdout_lines = []
+            for line in f:
+                if line.startswith("[STDOUT] "):
+                    stdout_lines.append(line[9:])  # Strip "[STDOUT] " prefix
+            partial_stdout = "".join(stdout_lines)
+
+        # Parse the partial stdout
+        (
+            total_tool_calls,
+            tool_usage,
+            tool_failures,
+            tool_errors,
+            num_turns,
+            tokens_in,
+            tokens_out,
+            result_subtype,
+        ) = _parse_tool_usage_from_stream(partial_stdout)
+
+        # Verify that statistics were captured
+        assert total_tool_calls == 2
+        assert tool_usage == {"Grep": 1, "Read": 1}
+        assert tokens_in == 220
+        assert tokens_out == 110
+
+
+def test_timeout_error_message_includes_statistics():
+    """Test that timeout error messages mention captured statistics."""
+    result = AgentResult(
+        patch="",
+        success=False,
+        error="Task execution timed out after 600s. Agent made 30 tool calls across 15 iterations before timeout.",
+        tokens_input=5000,
+        tokens_output=2500,
+        iterations=15,
+        tool_calls=30,
+        tool_usage={"Grep": 16, "Read": 8, "Bash": 4, "TodoWrite": 2},
+    )
+
+    data = agent_result_to_dict(result, None, "claude-sonnet-4-5-20250929")
+
+    # Verify comprehensive information is available
+    assert data["iterations"] == 15
+    assert data["tool_calls"] == 30
+    assert data["tool_usage"]["Grep"] == 16
+    assert data["tokens"]["input"] == 5000
+    assert data["tokens"]["output"] == 2500
+    assert "30 tool calls" in data["error"]
+    assert "15 iterations" in data["error"]
+
+
+def test_empty_partial_stdout_returns_zeros():
+    """Test that parsing empty partial stdout returns zeros gracefully."""
+    (
+        total_tool_calls,
+        tool_usage,
+        tool_failures,
+        tool_errors,
+        num_turns,
+        tokens_in,
+        tokens_out,
+        result_subtype,
+    ) = _parse_tool_usage_from_stream("")
+
+    assert total_tool_calls == 0
+    assert tool_usage == {}
+    assert tool_failures == {}
+    assert tool_errors == {}
+    assert num_turns == 0
+    assert tokens_in == 0
+    assert tokens_out == 0
+
+
+def test_malformed_json_handled_gracefully():
+    """Test that malformed JSON in partial stdout doesn't crash parsing."""
+    partial_stdout = """
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"1","name":"Grep","input":{}}],"usage":{"input_tokens":100,"output_tokens":50}}}
+{invalid json here}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"2","name":"Read","input":{}}],"usage":{"input_tokens":120,"output_tokens":60}}}
+"""
+
+    (
+        total_tool_calls,
+        tool_usage,
+        tool_failures,
+        tool_errors,
+        num_turns,
+        tokens_in,
+        tokens_out,
+        result_subtype,
+    ) = _parse_tool_usage_from_stream(partial_stdout)
+
+    # Should parse valid lines and skip invalid ones
+    assert total_tool_calls == 2
+    assert tool_usage == {"Grep": 1, "Read": 1}
+    assert tokens_in == 220


### PR DESCRIPTION
Fixes #297

## Summary

**CRITICAL BUG FIX:** When tasks timed out, `evaluation_state.json` incorrectly showed 0 iterations and 0 tool calls, even though the agent had executed ~30 tool calls. This fix captures partial execution statistics from MCP logs before timeout.

## Problem

**Before this fix:**
```json
{
  "iterations": 0,
  "tool_calls": 0,
  "tool_usage": {},
  "error": "Timeout"
}
```

**But MCP logs showed:** Agent actually made 30 tool calls!

## Impact

In a 300-task evaluation with 36 timeouts:
- ❌ **Before:** Missing 1,080 tool calls from statistics (36 × 30)
- ✅ **After:** All tool calls properly recorded, accurate statistics

## Solution

**After this fix:**
```json
{
  "iterations": 29,
  "tool_calls": 30,
  "tool_usage": {
    "Grep": 16,
    "Read": 8,
    "mcp__supermodel__explore_codebase": 4,
    "Bash": 1,
    "TodoWrite": 1
  },
  "status": "timeout",
  "error": "Timeout (captured 30 tool calls, 29 iterations before timeout)"
}
```

## Changes

- ✅ Modified `ClaudeCodeHarness._solve_in_docker()` to read MCP log on timeout
- ✅ Parses partial stream-json output to extract statistics
- ✅ Captures iterations, tool_calls, tool_usage, tool_failures, token usage
- ✅ Adds `"status": "timeout"` field to distinguish timeout from other errors
- ✅ Enhanced error messages to mention captured statistics
- ✅ 9 comprehensive tests (all passing)
- ✅ Complete documentation in `docs/timeout_tracking.md`

## Testing

All 9 tests pass:
- ✅ Partial stdout parsing from interrupted executions
- ✅ Tool usage statistics extraction
- ✅ Tool failure tracking in partial streams
- ✅ Status field addition for timeout errors
- ✅ Graceful handling of malformed JSON and empty streams

## Backwards Compatibility

- ✅ No breaking changes
- ✅ No configuration changes required
- ✅ Automatically works for all future timeout scenarios
- ✅ Gracefully handles cases where MCP log is unavailable

## Why This Matters

**For researchers:**
- Accurate tool usage statistics
- Proper cost calculations
- Can distinguish "failed to start" from "ran out of time"

**For developers:**
- Understand what agents were doing when timeout occurred
- Analyze which tasks are "too slow" vs "impossible"
- Better debugging of timeout patterns

## Verification

After this fix, users can verify timeout tasks were actually working:
```bash
# Check evaluation_state.json
cat .mcpbr_state/evaluation_state.json | jq '.tasks[] | select(.status == "timeout")'
```

They'll see real tool_usage data instead of empty objects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timeout runs now include a dedicated "timeout" status, distinguishing them from other errors
  * Partial execution data is captured and displayed when runs timeout (tool calls, iterations, tool usage)
  * Richer diagnostic information available for incomplete runs

* **Documentation**
  * New timeout tracking documentation added

* **Tests**
  * Expanded test coverage for timeout handling and partial output recovery

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->