### PR TITLE
fix: prevent ZeroDivisionError in cost comparison when running --mcp-only

### DIFF
--- a/src/mcpbr/reporting.py
+++ b/src/mcpbr/reporting.py
@@ -504,16 +504,27 @@ def print_summary(results: "EvaluationResults", console: Console) -> None:
 
     if total_diff is not None:
         console.print()
-        if total_diff > 0:
-            console.print(
-                f"[bold]MCP Additional Cost:[/bold] {format_cost(total_diff)} "
-                f"({abs(total_diff) / baseline.get('total_cost', 1) * 100:+.1f}%)"
-            )
+        baseline_cost = baseline.get("total_cost", 0)
+        if baseline_cost > 0:
+            pct = abs(total_diff) / baseline_cost * 100
+            if total_diff > 0:
+                console.print(
+                    f"[bold]MCP Additional Cost:[/bold] {format_cost(total_diff)} ({pct:+.1f}%)"
+                )
+            else:
+                console.print(
+                    f"[bold]MCP Cost Savings:[/bold] {format_cost(abs(total_diff))} ({pct:.1f}%)"
+                )
         else:
-            console.print(
-                f"[bold]MCP Cost Savings:[/bold] {format_cost(abs(total_diff))} "
-                f"({abs(total_diff) / baseline.get('total_cost', 1) * 100:.1f}%)"
-            )
+            # No baseline cost available (e.g., --mcp-only mode)
+            if total_diff > 0:
+                console.print(
+                    f"[bold]MCP Additional Cost:[/bold] {format_cost(total_diff)} (N/A - no baseline)"
+                )
+            else:
+                console.print(
+                    f"[bold]MCP Cost Savings:[/bold] {format_cost(abs(total_diff))} (N/A - no baseline)"
+                )
 
     if cost_per_additional is not None:
         console.print(
@@ -791,16 +802,23 @@ def save_markdown_report(results: "EvaluationResults", output_path: Path) -> Non
     cost_per_additional = cost_comparison.get("cost_per_additional_resolution")
 
     if total_diff is not None:
-        if total_diff > 0:
-            lines.append(
-                f"**MCP Additional Cost:** {format_cost(total_diff)} "
-                f"({abs(total_diff) / baseline.get('total_cost', 1) * 100:+.1f}%)"
-            )
+        baseline_cost = baseline.get("total_cost", 0)
+        if baseline_cost > 0:
+            pct = abs(total_diff) / baseline_cost * 100
+            if total_diff > 0:
+                lines.append(f"**MCP Additional Cost:** {format_cost(total_diff)} ({pct:+.1f}%)")
+            else:
+                lines.append(f"**MCP Cost Savings:** {format_cost(abs(total_diff))} ({pct:.1f}%)")
         else:
-            lines.append(
-                f"**MCP Cost Savings:** {format_cost(abs(total_diff))} "
-                f"({abs(total_diff) / baseline.get('total_cost', 1) * 100:.1f}%)"
-            )
+            # No baseline cost available (e.g., --mcp-only mode)
+            if total_diff > 0:
+                lines.append(
+                    f"**MCP Additional Cost:** {format_cost(total_diff)} (N/A - no baseline)"
+                )
+            else:
+                lines.append(
+                    f"**MCP Cost Savings:** {format_cost(abs(total_diff))} (N/A - no baseline)"
+                )
 
     if cost_per_additional is not None:
         lines.append(f"**Cost per Additional Resolution:** {format_cost(cost_per_additional)}")


### PR DESCRIPTION
## Summary

Fixes #315 - Prevents ZeroDivisionError when running with `--mcp-only` flag by checking if baseline cost data exists before attempting percentage calculation.

## Problem

When running with `--mcp-only`, mcpbr crashed with `ZeroDivisionError` when trying to print cost comparison:
```
ZeroDivisionError: division by zero
  File "reporting.py", line 312, in print_summary
    f"({abs(total_diff) / baseline.get('total_cost', 1) * 100:+.1f}%)"
```

This was a critical issue because users lost evaluation results when this crash occurred (crash happened before output file was saved).

## Solution

Added baseline cost validation before calculating percentage:
- Check if `baseline.get('total_cost', 0) > 0` before division
- Display "(N/A - no baseline)" instead of percentage when baseline data is unavailable
- Applied fix to both `print_summary()` and `save_markdown_report()` functions

## Changes

- `src/mcpbr/reporting.py`: Added baseline cost validation in two locations (lines 507-525, 807-827)
- `tests/test_reporting.py`: Added comprehensive test suite for `--mcp-only` mode with 4 new tests

## Test Plan

- [x] Added test for markdown report with zero baseline cost
- [x] Added test for markdown report with missing baseline cost  
- [x] Added test for console output with zero baseline cost
- [x] Added test for console output with missing baseline cost
- [x] All new tests pass
- [x] All existing reporting tests pass (31 total)
- [x] No regressions in other test modules

Example output with fix:
```
MCP Additional Cost: $0.05 (N/A - no baseline)
```

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cost comparison reporting to accurately calculate and display MCP savings or additional costs with correct percentages when baseline data is available
  * Improved handling of missing baseline data with clear messaging in MCP-only scenarios

* **Tests**
  * Added comprehensive test coverage for MCP-only mode, zero baseline costs, and related edge cases

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->