### PR TITLE
feat: validate output files after evaluation

### DIFF
--- a/src/mcpbr/cli.py
+++ b/src/mcpbr/cli.py
@@ -17,6 +17,7 @@ from .harness import run_evaluation
 from .harnesses import list_available_harnesses
 from .junit_reporter import save_junit_xml
 from .models import list_supported_models
+from .output_validator import validate_output_file
 from .regression import (
     detect_regressions,
     format_regression_report,
@@ -665,9 +666,25 @@ To archive:
         save_json_results(results, output_path)
         console.print(f"\n[green]Results saved to {output_path}[/green]")
 
+        # Validate output file
+        valid, msg = validate_output_file(output_path)
+        if not valid:
+            console.print(f"[red]✗ {msg}[/red]")
+            console.print("[yellow]Check logs for errors during evaluation[/yellow]")
+            sys.exit(4)
+        console.print(f"[green]✓ Output validated: {msg}[/green]")
+
     if yaml_output:
         save_yaml_results(results, yaml_output)
         console.print(f"[green]YAML results saved to {yaml_output}[/green]")
+
+        # Validate YAML output file
+        valid, msg = validate_output_file(yaml_output)
+        if not valid:
+            console.print(f"[red]✗ {msg}[/red]")
+            console.print("[yellow]Check logs for errors during evaluation[/yellow]")
+            sys.exit(4)
+        console.print(f"[green]✓ Output validated: {msg}[/green]")
 
     if report_path:
         save_markdown_report(results, report_path)

--- a/src/mcpbr/output_validator.py
+++ b/src/mcpbr/output_validator.py
@@ -1,0 +1,58 @@
+"""Output file validation utilities."""
+
+import json
+from pathlib import Path
+
+import yaml
+
+
+def validate_output_file(output_path: Path) -> tuple[bool, str]:
+    """Validate output file was created and is valid JSON or YAML.
+
+    Args:
+        output_path: Path to the output file to validate.
+
+    Returns:
+        Tuple of (is_valid, message) where message describes the validation result.
+    """
+    # Check file exists
+    if not output_path.exists():
+        return False, f"Output file not created: {output_path}"
+
+    # Check file is not empty
+    if output_path.stat().st_size == 0:
+        return False, f"Output file is empty: {output_path}"
+
+    # Determine file type by extension
+    file_ext = output_path.suffix.lower()
+
+    # Validate structure based on file type
+    try:
+        with open(output_path) as f:
+            if file_ext in (".yaml", ".yml"):
+                data = yaml.safe_load(f)
+                file_type = "YAML"
+            else:
+                # Default to JSON
+                data = json.load(f)
+                file_type = "JSON"
+
+        # Validate required structure
+        if not isinstance(data, dict):
+            return False, f"Output must be a {file_type} object"
+
+        if "tasks" not in data:
+            return False, "Output missing 'tasks' field"
+
+        if not isinstance(data["tasks"], list):
+            return False, "'tasks' field must be a list"
+
+        task_count = len(data["tasks"])
+        return True, f"Valid {file_type} with {task_count} task(s)"
+
+    except json.JSONDecodeError as e:
+        return False, f"Invalid JSON: {e}"
+    except yaml.YAMLError as e:
+        return False, f"Invalid YAML: {e}"
+    except Exception as e:
+        return False, f"Validation error: {e}"

--- a/tests/test_output_validator.py
+++ b/tests/test_output_validator.py
@@ -1,0 +1,189 @@
+"""Tests for output file validation."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import yaml
+
+from mcpbr.output_validator import validate_output_file
+
+
+class TestOutputValidator:
+    """Tests for output file validation."""
+
+    def test_validate_valid_json_file(self) -> None:
+        """Test validation of a valid JSON output file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "results.json"
+            data = {
+                "metadata": {"timestamp": "2026-01-20T12:00:00Z"},
+                "summary": {"mcp": {"resolved": 1, "total": 2}},
+                "tasks": [
+                    {"instance_id": "task-1", "mcp": {"resolved": True}},
+                    {"instance_id": "task-2", "mcp": {"resolved": False}},
+                ],
+            }
+            output_path.write_text(json.dumps(data))
+
+            valid, msg = validate_output_file(output_path)
+
+            assert valid is True
+            assert "Valid JSON with 2 task(s)" in msg
+
+    def test_validate_valid_yaml_file(self) -> None:
+        """Test validation of a valid YAML output file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "results.yaml"
+            data = {
+                "metadata": {"timestamp": "2026-01-20T12:00:00Z"},
+                "summary": {"mcp": {"resolved": 1, "total": 2}},
+                "tasks": [
+                    {"instance_id": "task-1", "mcp": {"resolved": True}},
+                    {"instance_id": "task-2", "mcp": {"resolved": False}},
+                ],
+            }
+            with open(output_path, "w") as f:
+                yaml.dump(data, f)
+
+            valid, msg = validate_output_file(output_path)
+
+            assert valid is True
+            assert "Valid YAML with 2 task(s)" in msg
+
+    def test_validate_missing_file(self) -> None:
+        """Test validation when output file doesn't exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "nonexistent.json"
+
+            valid, msg = validate_output_file(output_path)
+
+            assert valid is False
+            assert "Output file not created" in msg
+            assert str(output_path) in msg
+
+    def test_validate_empty_file(self) -> None:
+        """Test validation of an empty output file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "empty.json"
+            output_path.write_text("")
+
+            valid, msg = validate_output_file(output_path)
+
+            assert valid is False
+            assert "Output file is empty" in msg
+
+    def test_validate_invalid_json(self) -> None:
+        """Test validation of a file with invalid JSON."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "invalid.json"
+            output_path.write_text("{ invalid json }")
+
+            valid, msg = validate_output_file(output_path)
+
+            assert valid is False
+            assert "Invalid JSON" in msg
+
+    def test_validate_invalid_yaml(self) -> None:
+        """Test validation of a file with invalid YAML."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "invalid.yaml"
+            output_path.write_text("invalid: yaml: content: [")
+
+            valid, msg = validate_output_file(output_path)
+
+            assert valid is False
+            assert "Invalid YAML" in msg
+
+    def test_validate_json_not_object(self) -> None:
+        """Test validation when JSON is not an object."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "array.json"
+            output_path.write_text("[1, 2, 3]")
+
+            valid, msg = validate_output_file(output_path)
+
+            assert valid is False
+            assert "Output must be a JSON object" in msg
+
+    def test_validate_missing_tasks_field(self) -> None:
+        """Test validation when 'tasks' field is missing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "no_tasks.json"
+            data = {"metadata": {"timestamp": "2026-01-20"}}
+            output_path.write_text(json.dumps(data))
+
+            valid, msg = validate_output_file(output_path)
+
+            assert valid is False
+            assert "Output missing 'tasks' field" in msg
+
+    def test_validate_tasks_not_list(self) -> None:
+        """Test validation when 'tasks' is not a list."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "tasks_not_list.json"
+            data = {"tasks": "not a list"}
+            output_path.write_text(json.dumps(data))
+
+            valid, msg = validate_output_file(output_path)
+
+            assert valid is False
+            assert "'tasks' field must be a list" in msg
+
+    def test_validate_empty_tasks_list(self) -> None:
+        """Test validation with an empty tasks list."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "empty_tasks.json"
+            data = {"tasks": []}
+            output_path.write_text(json.dumps(data))
+
+            valid, msg = validate_output_file(output_path)
+
+            assert valid is True
+            assert "Valid JSON with 0 task(s)" in msg
+
+    def test_validate_single_task(self) -> None:
+        """Test validation with a single task."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "single_task.json"
+            data = {"tasks": [{"instance_id": "task-1", "mcp": {"resolved": True}}]}
+            output_path.write_text(json.dumps(data))
+
+            valid, msg = validate_output_file(output_path)
+
+            assert valid is True
+            assert "Valid JSON with 1 task(s)" in msg
+
+    def test_validate_yaml_with_yml_extension(self) -> None:
+        """Test that .yml extension is recognized as YAML."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "results.yml"
+            data = {"tasks": [{"instance_id": "task-1"}]}
+            with open(output_path, "w") as f:
+                yaml.dump(data, f)
+
+            valid, msg = validate_output_file(output_path)
+
+            assert valid is True
+            assert "Valid YAML" in msg
+
+    def test_validate_handles_exceptions(self) -> None:
+        """Test that unexpected exceptions are handled gracefully."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "results.json"
+            # Create a file with valid JSON but with permission issues
+            output_path.write_text(json.dumps({"tasks": []}))
+
+            # Make file unreadable (only works on Unix-like systems)
+            import sys
+
+            if sys.platform != "win32":
+                output_path.chmod(0o000)
+
+                valid, msg = validate_output_file(output_path)
+
+                assert valid is False
+                assert "Validation error" in msg
+
+                # Restore permissions for cleanup
+                output_path.chmod(0o644)


### PR DESCRIPTION
## Summary

- Implements output file validation after saving evaluation results
- Validates JSON and YAML output files for structure and content
- Exits with code 4 on validation failure

## Changes

- **New module**: `src/mcpbr/output_validator.py` with `validate_output_file()` function
- **CLI integration**: Added validation after `save_json_results()` and `save_yaml_results()`
- **Tests**: Comprehensive test coverage in `tests/test_output_validator.py`
- **Exit code**: Exit with code 4 when output validation fails

## Validation Checks

The validator performs the following checks:
1. File exists
2. File is not empty
3. Content is valid JSON or YAML (based on extension)
4. Structure contains required `tasks` field
5. `tasks` field is a list

## Benefits

- **Fail fast**: Know immediately if output is broken
- **Better debugging**: Clear messages about what's wrong
- **Reliable scripts**: Automation scripts can trust output exists and is valid
- **Clear feedback**: Users see validation messages:
  - ✓ Output validated: Valid JSON with 2 task(s)
  - ✗ Output file not created: /path/to/file.json

## Testing

All tests pass:
- 13 new tests for output validation
- Tests cover valid/invalid JSON, YAML, missing files, empty files, etc.
- Existing tests continue to pass

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Output files are now validated after generation. Validation checks that files are properly formatted and contain required task data. Failed validation exits with error code 4.

* **Tests**
  * Added comprehensive test suite for output file validation covering valid/invalid JSON and YAML formats, missing fields, and error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->