### PR TITLE
feat: Add comprehensive pre-flight validation summary

### DIFF
--- a/src/mcpbr/preflight.py
+++ b/src/mcpbr/preflight.py
@@ -1,0 +1,244 @@
+"""Comprehensive pre-flight validation for mcpbr evaluations."""
+
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+import docker
+from rich.console import Console
+from rich.table import Table
+
+from .config import HarnessConfig
+
+console = Console()
+
+
+@dataclass
+class PreflightCheck:
+    """Result of a single pre-flight check."""
+
+    name: str
+    status: str  # "✓", "✗", or "⚠"
+    details: str
+    critical: bool = True  # If True, failure prevents execution
+
+
+def run_comprehensive_preflight(
+    config: HarnessConfig, config_path: Path
+) -> tuple[list[PreflightCheck], list[str]]:
+    """Run all pre-flight checks and return results.
+
+    Args:
+        config: Harness configuration.
+        config_path: Path to configuration file.
+
+    Returns:
+        Tuple of (checks: list of PreflightCheck, failures: list of error messages).
+    """
+    checks: list[PreflightCheck] = []
+    failures: list[str] = []
+
+    # 1. Docker check
+    try:
+        client = docker.from_env()
+        client.ping()
+        info = client.info()
+        version = info.get("ServerVersion", "unknown")
+        checks.append(
+            PreflightCheck(
+                name="Docker",
+                status="✓",
+                details=f"v{version} running",
+                critical=True,
+            )
+        )
+    except docker.errors.DockerException:
+        checks.append(
+            PreflightCheck(
+                name="Docker",
+                status="✗",
+                details="Not running",
+                critical=True,
+            )
+        )
+        failures.append("Docker is not running. Please start Docker Desktop and try again.")
+    except Exception as e:
+        checks.append(
+            PreflightCheck(
+                name="Docker",
+                status="✗",
+                details=f"Error: {str(e)[:40]}",
+                critical=True,
+            )
+        )
+        failures.append(f"Docker check failed: {e}")
+
+    # 2. API key check
+    api_key = os.getenv("ANTHROPIC_API_KEY")
+    if api_key:
+        # Mask the key for display
+        masked = f"{api_key[:8]}...{api_key[-4:]}" if len(api_key) > 12 else "***"
+        checks.append(
+            PreflightCheck(
+                name="ANTHROPIC_API_KEY",
+                status="✓",
+                details=f"Set ({masked})",
+                critical=True,
+            )
+        )
+    else:
+        checks.append(
+            PreflightCheck(
+                name="ANTHROPIC_API_KEY",
+                status="✗",
+                details="Not set",
+                critical=True,
+            )
+        )
+        failures.append(
+            "ANTHROPIC_API_KEY environment variable not set. "
+            "Please set it before running: export ANTHROPIC_API_KEY=your-key"
+        )
+
+    # 3. MCP server check
+    if config.mcp_server and config.mcp_server.command:
+        command_path = shutil.which(config.mcp_server.command)
+        if command_path:
+            checks.append(
+                PreflightCheck(
+                    name="MCP Server",
+                    status="✓",
+                    details=f"{config.mcp_server.command} found",
+                    critical=True,
+                )
+            )
+        else:
+            checks.append(
+                PreflightCheck(
+                    name="MCP Server",
+                    status="✗",
+                    details=f"{config.mcp_server.command} not found",
+                    critical=True,
+                )
+            )
+            failures.append(
+                f"MCP server command '{config.mcp_server.command}' not found in PATH. "
+                "Please install it or check your PATH."
+            )
+    else:
+        checks.append(
+            PreflightCheck(
+                name="MCP Server",
+                status="✗",
+                details="Not configured",
+                critical=True,
+            )
+        )
+        failures.append("MCP server not configured in config file")
+
+    # 4. Config file check (already loaded, so just mark as valid)
+    checks.append(
+        PreflightCheck(
+            name="Config File",
+            status="✓",
+            details=f"{config_path.name}",
+            critical=True,
+        )
+    )
+
+    # 5. Dataset access check (optional - HuggingFace)
+    try:
+        # Try importing huggingface_hub to check if available
+        import huggingface_hub  # noqa: F401
+
+        checks.append(
+            PreflightCheck(
+                name="Dataset Access",
+                status="✓",
+                details="HuggingFace available",
+                critical=False,
+            )
+        )
+    except ImportError:
+        checks.append(
+            PreflightCheck(
+                name="Dataset Access",
+                status="⚠",
+                details="HuggingFace not installed",
+                critical=False,
+            )
+        )
+        # Not a failure, just a warning
+
+    # 6. Disk space check
+    try:
+        stat = shutil.disk_usage("/")
+        free_gb = stat.free // (1024**3)
+        if free_gb > 10:
+            checks.append(
+                PreflightCheck(
+                    name="Disk Space",
+                    status="✓",
+                    details=f"{free_gb} GB free",
+                    critical=False,
+                )
+            )
+        else:
+            checks.append(
+                PreflightCheck(
+                    name="Disk Space",
+                    status="⚠",
+                    details=f"Only {free_gb} GB free",
+                    critical=False,
+                )
+            )
+            # Warning, not a critical failure
+    except Exception:
+        checks.append(
+            PreflightCheck(
+                name="Disk Space",
+                status="⚠",
+                details="Could not check",
+                critical=False,
+            )
+        )
+
+    return checks, failures
+
+
+def display_preflight_results(checks: list[PreflightCheck], failures: list[str]) -> None:
+    """Display pre-flight check results in a formatted table.
+
+    Args:
+        checks: List of pre-flight check results.
+        failures: List of failure messages.
+    """
+    table = Table(title="Pre-flight Validation", show_header=True, header_style="bold")
+    table.add_column("Check", style="cyan", no_wrap=True)
+    table.add_column("Status", justify="center", width=8)
+    table.add_column("Details")
+
+    for check in checks:
+        # Color the row based on status
+        if check.status == "✓":
+            style = "green"
+        elif check.status == "✗":
+            style = "red"
+        else:  # "⚠"
+            style = "yellow"
+
+        table.add_row(check.name, check.status, check.details, style=style)
+
+    console.print()
+    console.print(table)
+    console.print()
+
+    if failures:
+        console.print("[red bold]✗ Pre-flight failed[/red bold]")
+        for failure in failures:
+            console.print(f"[red]  • {failure}[/red]")
+        console.print()
+    else:
+        console.print("[green bold]✓ All checks passed, starting evaluation...[/green bold]")
+        console.print()

--- a/tests/test_default_logging.py
+++ b/tests/test_default_logging.py
@@ -169,7 +169,14 @@ sample_size: 1
 
             result = runner.invoke(
                 main,
-                ["run", "-c", str(test_config_path), "--skip-health-check", "--disable-logs"],
+                [
+                    "run",
+                    "-c",
+                    str(test_config_path),
+                    "--skip-health-check",
+                    "--skip-preflight",
+                    "--disable-logs",
+                ],
             )
 
             # Check that the command executed (exit code 0)
@@ -211,7 +218,9 @@ disable_logs: true
             }
             mock_run.return_value = mock_results
 
-            result = runner.invoke(main, ["run", "-c", str(config_path), "--skip-health-check"])
+            result = runner.invoke(
+                main, ["run", "-c", str(config_path), "--skip-health-check", "--skip-preflight"]
+            )
 
             # Check that the command executed
             assert result.exit_code == 0
@@ -259,6 +268,7 @@ disable_logs: true
                     "-c",
                     str(test_config_path),
                     "--skip-health-check",
+                    "--skip-preflight",
                     "--log-dir",
                     str(custom_log_dir),
                 ],
@@ -310,6 +320,7 @@ disable_logs: true
                     "-c",
                     str(test_config_path),
                     "--skip-health-check",
+                    "--skip-preflight",
                     "--log-file",
                     str(custom_log_file),
                 ],

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,259 @@
+"""Tests for comprehensive pre-flight validation."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcpbr.config import HarnessConfig, MCPServerConfig
+from mcpbr.preflight import run_comprehensive_preflight
+
+
+@pytest.fixture
+def mock_config():
+    """Create a mock configuration for testing."""
+    config = HarnessConfig(
+        provider="anthropic",
+        agent_harness="claude-code",
+        model="claude-sonnet-4-5-20250514",
+        benchmark="swe-bench-verified",
+        sample_size=10,
+        timeout_seconds=300,
+        max_iterations=10,
+        max_concurrent=4,
+        use_prebuilt_images=True,
+        mcp_server=MCPServerConfig(
+            command="npx",
+            args=["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+        ),
+    )
+    return config
+
+
+@pytest.fixture
+def config_path(tmp_path):
+    """Create a temporary config file."""
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("provider: anthropic\n")
+    return config_file
+
+
+def test_preflight_all_checks_pass(mock_config, config_path):
+    """Test pre-flight when all checks pass."""
+    with (
+        patch("mcpbr.preflight.docker.from_env") as mock_docker,
+        patch("mcpbr.preflight.shutil.which") as mock_which,
+        patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-ant-test1234567890"}),
+    ):
+        # Mock Docker
+        mock_client = MagicMock()
+        mock_client.ping.return_value = True
+        mock_client.info.return_value = {"ServerVersion": "24.0.7"}
+        mock_docker.return_value = mock_client
+
+        # Mock which (MCP server command exists)
+        mock_which.return_value = "/usr/bin/npx"
+
+        checks, failures = run_comprehensive_preflight(mock_config, config_path)
+
+        # Should have no failures
+        assert len(failures) == 0
+
+        # Check that we have all expected checks
+        check_names = [check.name for check in checks]
+        assert "Docker" in check_names
+        assert "ANTHROPIC_API_KEY" in check_names
+        assert "MCP Server" in check_names
+        assert "Config File" in check_names
+        assert "Dataset Access" in check_names
+        assert "Disk Space" in check_names
+
+        # Verify Docker check passed
+        docker_check = next(c for c in checks if c.name == "Docker")
+        assert docker_check.status == "✓"
+        assert "24.0.7" in docker_check.details
+
+
+def test_preflight_docker_not_running(mock_config, config_path):
+    """Test pre-flight when Docker is not running."""
+    import docker.errors
+
+    with (
+        patch("mcpbr.preflight.docker.from_env") as mock_docker,
+        patch("mcpbr.preflight.shutil.which") as mock_which,
+        patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-ant-test1234567890"}),
+    ):
+        # Mock Docker to raise exception
+        mock_docker.side_effect = docker.errors.DockerException("Connection refused")
+
+        # Mock which (MCP server command exists)
+        mock_which.return_value = "/usr/bin/npx"
+
+        checks, failures = run_comprehensive_preflight(mock_config, config_path)
+
+        # Should have failures
+        assert len(failures) > 0
+        assert any("Docker" in failure for failure in failures)
+
+        # Verify Docker check failed
+        docker_check = next(c for c in checks if c.name == "Docker")
+        assert docker_check.status == "✗"
+
+
+def test_preflight_api_key_missing(mock_config, config_path):
+    """Test pre-flight when API key is not set."""
+    with (
+        patch("mcpbr.preflight.docker.from_env") as mock_docker,
+        patch("mcpbr.preflight.shutil.which") as mock_which,
+        patch.dict(os.environ, {}, clear=True),
+    ):
+        # Mock Docker
+        mock_client = MagicMock()
+        mock_client.ping.return_value = True
+        mock_client.info.return_value = {"ServerVersion": "24.0.7"}
+        mock_docker.return_value = mock_client
+
+        # Mock which
+        mock_which.return_value = "/usr/bin/npx"
+
+        checks, failures = run_comprehensive_preflight(mock_config, config_path)
+
+        # Should have failures
+        assert len(failures) > 0
+        assert any("ANTHROPIC_API_KEY" in failure for failure in failures)
+
+        # Verify API key check failed
+        api_key_check = next(c for c in checks if c.name == "ANTHROPIC_API_KEY")
+        assert api_key_check.status == "✗"
+        assert "Not set" in api_key_check.details
+
+
+def test_preflight_mcp_server_not_found(mock_config, config_path):
+    """Test pre-flight when MCP server command is not found."""
+    with (
+        patch("mcpbr.preflight.docker.from_env") as mock_docker,
+        patch("mcpbr.preflight.shutil.which") as mock_which,
+        patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-ant-test1234567890"}),
+    ):
+        # Mock Docker
+        mock_client = MagicMock()
+        mock_client.ping.return_value = True
+        mock_client.info.return_value = {"ServerVersion": "24.0.7"}
+        mock_docker.return_value = mock_client
+
+        # Mock which (command not found)
+        mock_which.return_value = None
+
+        checks, failures = run_comprehensive_preflight(mock_config, config_path)
+
+        # Should have failures
+        assert len(failures) > 0
+        assert any("not found in PATH" in failure for failure in failures)
+
+        # Verify MCP server check failed
+        mcp_check = next(c for c in checks if c.name == "MCP Server")
+        assert mcp_check.status == "✗"
+        assert "not found" in mcp_check.details
+
+
+def test_preflight_api_key_masking(mock_config, config_path):
+    """Test that API key is properly masked in output."""
+    with (
+        patch("mcpbr.preflight.docker.from_env") as mock_docker,
+        patch("mcpbr.preflight.shutil.which") as mock_which,
+        patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-ant-api03-1234567890abcdefXYZ"}),
+    ):
+        # Mock Docker
+        mock_client = MagicMock()
+        mock_client.ping.return_value = True
+        mock_client.info.return_value = {"ServerVersion": "24.0.7"}
+        mock_docker.return_value = mock_client
+
+        # Mock which
+        mock_which.return_value = "/usr/bin/npx"
+
+        checks, failures = run_comprehensive_preflight(mock_config, config_path)
+
+        # Verify API key check shows masked key
+        api_key_check = next(c for c in checks if c.name == "ANTHROPIC_API_KEY")
+        assert api_key_check.status == "✓"
+        assert "sk-ant-a" in api_key_check.details  # Shows first part (first 8 chars)
+        assert "fXYZ" in api_key_check.details  # Shows last part (last 4 chars)
+        assert "..." in api_key_check.details  # Has masking
+        # Should not show full key
+        assert "1234567890abcdef" not in api_key_check.details
+
+
+def test_preflight_disk_space_warning(mock_config, config_path):
+    """Test pre-flight disk space warning."""
+    with (
+        patch("mcpbr.preflight.docker.from_env") as mock_docker,
+        patch("mcpbr.preflight.shutil.which") as mock_which,
+        patch("mcpbr.preflight.shutil.disk_usage") as mock_disk,
+        patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-ant-test1234567890"}),
+    ):
+        # Mock Docker
+        mock_client = MagicMock()
+        mock_client.ping.return_value = True
+        mock_client.info.return_value = {"ServerVersion": "24.0.7"}
+        mock_docker.return_value = mock_client
+
+        # Mock which
+        mock_which.return_value = "/usr/bin/npx"
+
+        # Mock disk usage (low space)
+        mock_stat = MagicMock()
+        mock_stat.free = 5 * 1024**3  # 5 GB
+        mock_disk.return_value = mock_stat
+
+        checks, failures = run_comprehensive_preflight(mock_config, config_path)
+
+        # Should not have critical failures (disk space is warning only)
+        assert len(failures) == 0
+
+        # Verify disk space check shows warning
+        disk_check = next(c for c in checks if c.name == "Disk Space")
+        assert disk_check.status == "⚠"
+        assert "5 GB" in disk_check.details
+        assert not disk_check.critical
+
+
+def test_preflight_mcp_server_no_command(config_path):
+    """Test pre-flight when MCP server has no command."""
+    # Config with MCP server but empty command
+    config = HarnessConfig(
+        provider="anthropic",
+        agent_harness="claude-code",
+        model="claude-sonnet-4-5-20250514",
+        benchmark="swe-bench-verified",
+        sample_size=10,
+        timeout_seconds=300,
+        max_iterations=10,
+        max_concurrent=4,
+        use_prebuilt_images=True,
+        mcp_server=MCPServerConfig(
+            command="",  # Empty command
+            args=[],
+        ),
+    )
+
+    with (
+        patch("mcpbr.preflight.docker.from_env") as mock_docker,
+        patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-ant-test1234567890"}),
+    ):
+        # Mock Docker
+        mock_client = MagicMock()
+        mock_client.ping.return_value = True
+        mock_client.info.return_value = {"ServerVersion": "24.0.7"}
+        mock_docker.return_value = mock_client
+
+        checks, failures = run_comprehensive_preflight(config, config_path)
+
+        # Should have failures
+        assert len(failures) > 0
+        assert any("not configured" in failure for failure in failures)
+
+        # Verify MCP server check failed
+        mcp_check = next(c for c in checks if c.name == "MCP Server")
+        assert mcp_check.status == "✗"
+        assert "Not configured" in mcp_check.details


### PR DESCRIPTION
## Summary
- Implements comprehensive pre-flight validation with clear table display
- Checks Docker, API key, MCP server, config, dataset access, and disk space
- Displays results in formatted Rich table with status indicators (✓/✗/⚠)
- Adds --skip-preflight CLI flag for bypassing validation

## Changes
- Added new `preflight.py` module with comprehensive pre-flight checks
- Updated CLI to use comprehensive validation instead of MCP-only check
- Added --skip-preflight option to allow bypassing validation
- Comprehensive test suite with 7 test cases covering all scenarios

## Pre-flight Checks
| Check | Critical? | Details |
|-------|-----------|---------|
| Docker | Yes | Daemon status and version |
| ANTHROPIC_API_KEY | Yes | Environment variable set (masked) |
| MCP Server | Yes | Command availability in PATH |
| Config File | Yes | Valid YAML configuration |
| Dataset Access | No | HuggingFace availability (warning) |
| Disk Space | No | Available space (warning if < 10GB) |

## Test plan
- [x] All new tests pass (7/7)
- [x] Existing tests pass
- [x] Pre-commit hooks pass
- [x] Test with Docker running: shows green check
- [x] Test with missing API key: shows red check and exits
- [x] Test with missing MCP server: shows red check and exits
- [x] Test --skip-preflight flag: bypasses validation

## Example Output
```
Pre-flight Validation
┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Check               ┃ Status ┃ Details                ┃
┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
│ Docker              │   ✓    │ v24.0.7 running        │
│ ANTHROPIC_API_KEY   │   ✓    │ Set (sk-ant-...2xY8)   │
│ MCP Server          │   ✓    │ npx found              │
│ Config File         │   ✓    │ config.yaml            │
│ Dataset Access      │   ✓    │ HuggingFace available  │
│ Disk Space          │   ✓    │ 157 GB free            │
└─────────────────────┴────────┴────────────────────────┘

✓ All checks passed, starting evaluation...
```

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)