### PR TITLE
feat: Add runtime tracking for task evaluation (#325)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = [
-    "pytest>=7.0.0",
-    "pytest-asyncio>=0.21.0",
-    "ruff>=0.1.0",
-    "pre-commit>=3.0.0",
-]
 docs = [
     "mkdocs>=1.5.0",
     "mkdocs-material>=9.5.0",
@@ -92,4 +86,7 @@ markers = [
 [dependency-groups]
 dev = [
     "pytest>=9.0.2",
+    "pytest-asyncio>=0.21.0",
+    "ruff>=0.1.0",
+    "pre-commit>=3.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,3 +88,8 @@ testpaths = ["tests"]
 markers = [
     "integration: marks tests as integration tests (deselect with '-m not integration')",
 ]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+dev = [
+    "pytest>=9.0.2",
+    "pytest-asyncio>=0.21.0",
+    "ruff>=0.1.0",
+    "pre-commit>=3.0.0",
+]
 docs = [
     "mkdocs>=1.5.0",
     "mkdocs-material>=9.5.0",
@@ -81,12 +87,4 @@ asyncio_mode = "auto"
 testpaths = ["tests"]
 markers = [
     "integration: marks tests as integration tests (deselect with '-m not integration')",
-]
-
-[dependency-groups]
-dev = [
-    "pytest>=9.0.2",
-    "pytest-asyncio>=0.21.0",
-    "ruff>=0.1.0",
-    "pre-commit>=3.0.0",
 ]

--- a/src/mcpbr/harness.py
+++ b/src/mcpbr/harness.py
@@ -1,6 +1,7 @@
 """Main evaluation harness orchestrating parallel task execution."""
 
 import asyncio
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -334,8 +335,6 @@ async def _run_mcp_evaluation(
             cached_result["cache_hit"] = True
             return cached_result
 
-    import time
-
     start_time = time.time()
     env: TaskEnvironment | None = None
     try:
@@ -445,8 +444,6 @@ async def _run_baseline_evaluation(
             # Add cache hit marker to result
             cached_result["cache_hit"] = True
             return cached_result
-
-    import time
 
     start_time = time.time()
     env: TaskEnvironment | None = None

--- a/tests/test_runtime_tracking.py
+++ b/tests/test_runtime_tracking.py
@@ -1,0 +1,428 @@
+"""Tests for runtime tracking feature."""
+
+import pytest
+
+from mcpbr.harness import EvaluationResults, TaskResult
+from mcpbr.reporting import format_runtime
+from mcpbr.statistics import RuntimeStatistics, calculate_comprehensive_statistics
+
+
+class TestFormatRuntime:
+    """Tests for runtime formatting helper."""
+
+    def test_format_seconds(self) -> None:
+        """Test formatting times under 60 seconds."""
+        assert format_runtime(0) == "0s"
+        assert format_runtime(15) == "15s"
+        assert format_runtime(59) == "59s"
+        assert format_runtime(59.9) == "59s"
+
+    def test_format_minutes(self) -> None:
+        """Test formatting times in minutes."""
+        assert format_runtime(60) == "1m 0s"
+        assert format_runtime(90) == "1m 30s"
+        assert format_runtime(125) == "2m 5s"
+        assert format_runtime(3599) == "59m 59s"
+
+    def test_format_hours(self) -> None:
+        """Test formatting times in hours."""
+        assert format_runtime(3600) == "1h 0m 0s"
+        assert format_runtime(3661) == "1h 1m 1s"
+        assert format_runtime(7200) == "2h 0m 0s"
+        assert format_runtime(4523) == "1h 15m 23s"
+
+
+class TestRuntimeStatistics:
+    """Tests for RuntimeStatistics dataclass."""
+
+    def test_basic_runtime_stats(self) -> None:
+        """Test basic runtime statistics calculation."""
+        results = EvaluationResults(
+            metadata={},
+            summary={},
+            tasks=[
+                TaskResult(
+                    instance_id="task-1",
+                    mcp={"runtime_seconds": 120.5, "resolved": True},
+                ),
+                TaskResult(
+                    instance_id="task-2",
+                    mcp={"runtime_seconds": 85.2, "resolved": False},
+                ),
+                TaskResult(
+                    instance_id="task-3",
+                    mcp={"runtime_seconds": 200.0, "resolved": True},
+                ),
+            ],
+        )
+
+        stats = calculate_comprehensive_statistics(results)
+
+        assert stats.mcp_runtime.total_runtime == pytest.approx(405.7, rel=1e-4)
+        assert stats.mcp_runtime.avg_runtime_per_task == pytest.approx(405.7 / 3, rel=1e-4)
+        assert stats.mcp_runtime.max_runtime == 200.0
+        assert stats.mcp_runtime.min_runtime == 85.2
+        # Only resolved tasks: 120.5 + 200.0 = 320.5, divided by 2 = 160.25
+        assert stats.mcp_runtime.runtime_per_resolved == pytest.approx(160.25, rel=1e-4)
+
+    def test_runtime_stats_no_resolved(self) -> None:
+        """Test runtime statistics when no tasks are resolved."""
+        results = EvaluationResults(
+            metadata={},
+            summary={},
+            tasks=[
+                TaskResult(
+                    instance_id="task-1",
+                    mcp={"runtime_seconds": 100.0, "resolved": False},
+                ),
+            ],
+        )
+
+        stats = calculate_comprehensive_statistics(results)
+
+        assert stats.mcp_runtime.runtime_per_resolved is None
+
+    def test_runtime_stats_per_task(self) -> None:
+        """Test per-task runtime tracking."""
+        results = EvaluationResults(
+            metadata={},
+            summary={},
+            tasks=[
+                TaskResult(
+                    instance_id="task-1",
+                    mcp={"runtime_seconds": 150.5, "resolved": True},
+                ),
+                TaskResult(
+                    instance_id="task-2",
+                    mcp={"runtime_seconds": 75.0, "resolved": False},
+                ),
+            ],
+        )
+
+        stats = calculate_comprehensive_statistics(results)
+
+        assert "task-1" in stats.mcp_runtime.per_task
+        assert "task-2" in stats.mcp_runtime.per_task
+        assert stats.mcp_runtime.per_task["task-1"] == 150.5
+        assert stats.mcp_runtime.per_task["task-2"] == 75.0
+
+    def test_runtime_stats_serialization(self) -> None:
+        """Test runtime statistics serialization to dict."""
+        stats = RuntimeStatistics(
+            total_runtime=500.567,
+            avg_runtime_per_task=100.1134,
+            runtime_per_resolved=250.2835,
+            min_runtime=50.123,
+            max_runtime=200.456,
+        )
+
+        data = stats.to_dict()
+
+        assert data["total_runtime"] == pytest.approx(500.57, rel=1e-4)
+        assert data["avg_runtime_per_task"] == pytest.approx(100.11, rel=1e-4)
+        assert data["runtime_per_resolved"] == pytest.approx(250.28, rel=1e-4)
+        assert data["min_runtime"] == pytest.approx(50.12, rel=1e-4)
+        assert data["max_runtime"] == pytest.approx(200.46, rel=1e-4)
+
+    def test_runtime_stats_empty_tasks(self) -> None:
+        """Test runtime statistics with empty task list."""
+        results = EvaluationResults(metadata={}, summary={}, tasks=[])
+
+        stats = calculate_comprehensive_statistics(results)
+
+        assert stats.mcp_runtime.total_runtime == 0.0
+        assert stats.mcp_runtime.avg_runtime_per_task == 0.0
+        assert stats.mcp_runtime.runtime_per_resolved is None
+        assert stats.mcp_runtime.min_runtime == 0.0
+        assert stats.mcp_runtime.max_runtime == 0.0
+
+    def test_runtime_stats_missing_field(self) -> None:
+        """Test handling of missing runtime_seconds field."""
+        results = EvaluationResults(
+            metadata={},
+            summary={},
+            tasks=[
+                TaskResult(
+                    instance_id="task-1",
+                    mcp={"resolved": True},  # No runtime_seconds field
+                ),
+            ],
+        )
+
+        stats = calculate_comprehensive_statistics(results)
+
+        # Should default to 0.0
+        assert stats.mcp_runtime.total_runtime == 0.0
+        assert stats.mcp_runtime.per_task["task-1"] == 0.0
+
+    def test_runtime_stats_baseline_comparison(self) -> None:
+        """Test runtime statistics for both MCP and baseline."""
+        results = EvaluationResults(
+            metadata={},
+            summary={},
+            tasks=[
+                TaskResult(
+                    instance_id="task-1",
+                    mcp={"runtime_seconds": 150.0, "resolved": True},
+                    baseline={"runtime_seconds": 120.0, "resolved": False},
+                ),
+                TaskResult(
+                    instance_id="task-2",
+                    mcp={"runtime_seconds": 100.0, "resolved": False},
+                    baseline={"runtime_seconds": 80.0, "resolved": True},
+                ),
+            ],
+        )
+
+        stats = calculate_comprehensive_statistics(results)
+
+        # MCP stats
+        assert stats.mcp_runtime.total_runtime == 250.0
+        assert stats.mcp_runtime.avg_runtime_per_task == 125.0
+        assert stats.mcp_runtime.runtime_per_resolved == 150.0  # Only task-1 resolved
+
+        # Baseline stats
+        assert stats.baseline_runtime.total_runtime == 200.0
+        assert stats.baseline_runtime.avg_runtime_per_task == 100.0
+        assert stats.baseline_runtime.runtime_per_resolved == 80.0  # Only task-2 resolved
+
+    def test_runtime_stats_single_task(self) -> None:
+        """Test runtime statistics with a single task."""
+        results = EvaluationResults(
+            metadata={},
+            summary={},
+            tasks=[
+                TaskResult(
+                    instance_id="task-1",
+                    mcp={"runtime_seconds": 275.5, "resolved": True},
+                ),
+            ],
+        )
+
+        stats = calculate_comprehensive_statistics(results)
+
+        assert stats.mcp_runtime.total_runtime == 275.5
+        assert stats.mcp_runtime.avg_runtime_per_task == 275.5
+        assert stats.mcp_runtime.min_runtime == 275.5
+        assert stats.mcp_runtime.max_runtime == 275.5
+        assert stats.mcp_runtime.runtime_per_resolved == 275.5
+
+    def test_runtime_stats_zero_runtime(self) -> None:
+        """Test handling of zero runtime."""
+        results = EvaluationResults(
+            metadata={},
+            summary={},
+            tasks=[
+                TaskResult(
+                    instance_id="task-1",
+                    mcp={"runtime_seconds": 0.0, "resolved": False},
+                ),
+            ],
+        )
+
+        stats = calculate_comprehensive_statistics(results)
+
+        assert stats.mcp_runtime.total_runtime == 0.0
+        assert stats.mcp_runtime.min_runtime == 0.0
+
+
+class TestRuntimeIntegration:
+    """Tests for runtime tracking integration."""
+
+    def test_comprehensive_stats_includes_runtime(self) -> None:
+        """Test that comprehensive statistics includes runtime data."""
+        results = EvaluationResults(
+            metadata={},
+            summary={},
+            tasks=[
+                TaskResult(
+                    instance_id="task-1",
+                    mcp={
+                        "tokens": {"input": 100, "output": 500},
+                        "cost": 0.01,
+                        "iterations": 5,
+                        "runtime_seconds": 120.0,
+                        "resolved": True,
+                    },
+                ),
+            ],
+        )
+
+        stats = calculate_comprehensive_statistics(results)
+        data = stats.to_dict()
+
+        # Verify runtime is included in serialization
+        assert "mcp_runtime" in data
+        assert "baseline_runtime" in data
+        assert "total_runtime" in data["mcp_runtime"]
+        assert data["mcp_runtime"]["total_runtime"] == 120.0
+
+    def test_runtime_with_errors(self) -> None:
+        """Test runtime tracking with task errors."""
+        results = EvaluationResults(
+            metadata={},
+            summary={},
+            tasks=[
+                TaskResult(
+                    instance_id="task-1",
+                    mcp={
+                        "runtime_seconds": 100.0,
+                        "error": "Timeout exceeded",
+                        "resolved": False,
+                    },
+                ),
+                TaskResult(
+                    instance_id="task-2",
+                    mcp={
+                        "runtime_seconds": 50.0,
+                        "error": "Connection failed",
+                        "resolved": False,
+                    },
+                ),
+            ],
+        )
+
+        stats = calculate_comprehensive_statistics(results)
+
+        # Runtime should still be tracked even with errors
+        assert stats.mcp_runtime.total_runtime == 150.0
+        assert stats.mcp_runtime.avg_runtime_per_task == 75.0
+
+    def test_runtime_with_mixed_results(self) -> None:
+        """Test runtime tracking with mixed success/failure results."""
+        results = EvaluationResults(
+            metadata={},
+            summary={},
+            tasks=[
+                TaskResult(
+                    instance_id="task-1",
+                    mcp={
+                        "runtime_seconds": 200.0,
+                        "resolved": True,
+                        "patch_applied": True,
+                    },
+                ),
+                TaskResult(
+                    instance_id="task-2",
+                    mcp={
+                        "runtime_seconds": 100.0,
+                        "resolved": False,
+                        "patch_applied": False,
+                    },
+                ),
+                TaskResult(
+                    instance_id="task-3",
+                    mcp={
+                        "runtime_seconds": 150.0,
+                        "resolved": True,
+                        "patch_applied": True,
+                    },
+                ),
+            ],
+        )
+
+        stats = calculate_comprehensive_statistics(results)
+
+        assert stats.mcp_runtime.total_runtime == 450.0
+        assert stats.mcp_runtime.avg_runtime_per_task == 150.0
+        # 2 tasks resolved: 200.0 + 150.0 = 350.0, divided by 2 = 175.0
+        assert stats.mcp_runtime.runtime_per_resolved == 175.0
+
+    def test_runtime_baseline_only(self) -> None:
+        """Test runtime statistics with baseline only (no MCP data)."""
+        results = EvaluationResults(
+            metadata={},
+            summary={},
+            tasks=[
+                TaskResult(
+                    instance_id="task-1",
+                    baseline={
+                        "runtime_seconds": 100.0,
+                        "resolved": True,
+                    },
+                ),
+            ],
+        )
+
+        stats = calculate_comprehensive_statistics(results)
+
+        # MCP should be empty
+        assert stats.mcp_runtime.total_runtime == 0.0
+        # Baseline should have data
+        assert stats.baseline_runtime.total_runtime == 100.0
+
+    def test_runtime_with_cache_hit(self) -> None:
+        """Test that runtime can be tracked even with cache hits."""
+        results = EvaluationResults(
+            metadata={},
+            summary={},
+            tasks=[
+                TaskResult(
+                    instance_id="task-1",
+                    mcp={
+                        "runtime_seconds": 50.0,
+                        "cache_hit": True,
+                        "resolved": True,
+                    },
+                ),
+                TaskResult(
+                    instance_id="task-2",
+                    mcp={
+                        "runtime_seconds": 150.0,
+                        "cache_hit": False,
+                        "resolved": True,
+                    },
+                ),
+            ],
+        )
+
+        stats = calculate_comprehensive_statistics(results)
+
+        # Both should be counted regardless of cache status
+        assert stats.mcp_runtime.total_runtime == 200.0
+        assert stats.mcp_runtime.avg_runtime_per_task == 100.0
+
+    def test_large_runtime_values(self) -> None:
+        """Test handling of large runtime values."""
+        results = EvaluationResults(
+            metadata={},
+            summary={},
+            tasks=[
+                TaskResult(
+                    instance_id="task-1",
+                    mcp={"runtime_seconds": 10800.0, "resolved": True},  # 3 hours
+                ),
+                TaskResult(
+                    instance_id="task-2",
+                    mcp={"runtime_seconds": 7200.0, "resolved": True},  # 2 hours
+                ),
+            ],
+        )
+
+        stats = calculate_comprehensive_statistics(results)
+
+        assert stats.mcp_runtime.total_runtime == 18000.0
+        assert stats.mcp_runtime.max_runtime == 10800.0
+        assert stats.mcp_runtime.min_runtime == 7200.0
+
+    def test_fractional_runtime_values(self) -> None:
+        """Test handling of fractional runtime values."""
+        results = EvaluationResults(
+            metadata={},
+            summary={},
+            tasks=[
+                TaskResult(
+                    instance_id="task-1",
+                    mcp={"runtime_seconds": 123.456, "resolved": True},
+                ),
+                TaskResult(
+                    instance_id="task-2",
+                    mcp={"runtime_seconds": 78.912, "resolved": False},
+                ),
+            ],
+        )
+
+        stats = calculate_comprehensive_statistics(results)
+
+        assert stats.mcp_runtime.total_runtime == pytest.approx(202.368, rel=1e-4)
+        assert stats.mcp_runtime.avg_runtime_per_task == pytest.approx(101.184, rel=1e-4)

--- a/uv.lock
+++ b/uv.lock
@@ -1065,7 +1065,7 @@ wheels = [
 
 [[package]]
 name = "mcpbr"
-version = "0.3.28"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -1094,6 +1094,11 @@ docs = [
     { name = "mkdocstrings", extra = ["python"] },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.40.0" },
@@ -1116,6 +1121,9 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
 ]
 provides-extras = ["dev", "docs"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.2" }]
 
 [[package]]
 name = "mdurl"


### PR DESCRIPTION
## Summary
Implements runtime tracking feature to measure wall-clock execution time for each task evaluation. This addresses issue #325 by tracking start and end times for both MCP and baseline evaluations.

## Changes
- **Runtime Capture**: Added `runtime_seconds` field to task results, captured using `time.time()` at start and end of each evaluation
- **RuntimeStatistics Class**: New statistics class in `statistics.py` with comprehensive runtime metrics:
  - `total_runtime`: Total time across all tasks (seconds)
  - `avg_runtime_per_task`: Average time per task
  - `runtime_per_resolved`: Average time for successfully resolved tasks
  - `min_runtime`/`max_runtime`: Minimum and maximum task runtimes
  - `per_task`: Detailed per-task runtime breakdown
- **Display Formatting**: Added `format_runtime()` helper for human-readable time formats (e.g., "45m 23s", "1h 5m 30s")
- **Console Output**: Updated `print_comprehensive_statistics()` to display runtime comparison table
- **Markdown Reports**: Updated `save_markdown_report()` to include runtime statistics section
- **Tests**: Added comprehensive test suite (`test_runtime_tracking.py`) with 19 tests covering:
  - Time formatting
  - Runtime calculations
  - Edge cases (empty tasks, missing fields, zero runtime)
  - Integration scenarios

## Example Output
```
Runtime Statistics
┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━┓
┃ Metric              ┃ MCP Agent ┃ Baseline ┃
┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━┩
│ Total Runtime       │ 45m 23s   │ 38m 12s  │
│ Avg Runtime/Task    │ 4m 32s    │ 3m 49s   │
│ Runtime/Resolved    │ 15m 8s    │ 19m 6s   │
│ Min Runtime         │ 1m 20s    │ 1m 5s    │
│ Max Runtime         │ 10m 0s    │ 10m 0s   │
└─────────────────────┴───────────┴──────────┘
```

## Test Results
All tests pass:
- ✅ 19 new runtime tracking tests
- ✅ 35 existing statistics tests
- ✅ 31 existing reporting tests
- ✅ Total: 85 tests passing

## Technical Details
- Runtime tracking happens at the evaluation function level in `harness.py`
- Time is captured even for timeout and error cases
- Runtime data is serialized with 2 decimal places for consistent output
- `runtime_per_resolved` only considers tasks that were successfully resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime tracking captures wall‑clock time across all evaluation outcomes and is included in reports with human‑readable formatting.
  * Reports and summaries now show comprehensive runtime metrics: total, average per task, per‑task runtimes, min/max, and runtime per resolved task (when available).

* **Tests**
  * Added extensive tests covering runtime formatting, statistics calculation, serialization, and integration scenarios.

* **Chores**
  * Updated development pytest requirement to >=9.0.2.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->