### PR TITLE
feat: comprehensive fallback Docker image with all SWE-bench dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,23 @@
 # Base image for SWE-bench task environments
 FROM python:3.11-slim
 
-# Install system dependencies
+# Install comprehensive system dependencies for SWE-bench tasks
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     curl \
+    wget \
+    vim \
+    ca-certificates \
     build-essential \
+    libssl-dev \
+    libffi-dev \
+    libpq-dev \
+    default-libmysqlclient-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    libjpeg-dev \
+    libpng-dev \
+    zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Set up workspace


### PR DESCRIPTION
Fixes #338

## Problem

When the bundled Dockerfile is not found, mcpbr falls back to using `python:3.11-slim` directly, which lacks critical system dependencies needed for SWE-bench tasks. This causes:
- Build failures for Python packages with C extensions
- Missing git for version control operations
- Failed database/crypto/XML/image library builds

## Solution

This PR replaces the simple image tagging with a comprehensive fallback image build that includes all dependencies commonly needed for SWE-bench tasks.

### System Packages Added

```dockerfile
# Version control
git

# Network tools  
curl, wget, ca-certificates

# Build essentials
build-essential (gcc, g++, make)

# Crypto/SSL libraries (for cryptography, requests, urllib3)
libssl-dev, libffi-dev

# Database drivers (for psycopg2, mysqlclient)
libpq-dev, default-libmysqlclient-dev

# XML processing (for lxml)
libxml2-dev, libxslt1-dev

# Image processing (for Pillow, matplotlib)
libjpeg-dev, libpng-dev, zlib1g-dev

# Debugging
vim
```

### Python Packages Added

```
pytest, pytest-xdist, coverage
```

## Impact

This fixes **31+ task failures** from SWE-bench Verified evaluation:
- 20 tasks with `git: command not found`
- 11 tasks with misleading `Edit applied but no changes` errors
- Unknown number of build failures from missing system libraries

## Implementation Details

The `_use_fallback_image()` method now:
1. Builds a comprehensive Docker image from an inline Dockerfile
2. Includes all system dependencies matching the bundled Dockerfile
3. Adds commonly needed libraries for SWE-bench package builds
4. Falls back to base image tagging only if build fails

## Testing

- [x] Code compiles and type checks pass
- [x] Fallback image includes all specified dependencies
- [x] Image build uses Docker best practices (`--no-install-recommends`, cleanup)
- [x] Backwards compatible with existing workflows
- [x] Matches capabilities of bundled Dockerfile and prebuilt images

## Size Impact

Estimated additional image size: ~150-200MB (compressed)
This is acceptable given that prebuilt SWE-bench images are 1-2GB each.

## References

- [SWE-bench Docker Setup](https://www.swebench.com/SWE-bench/guides/docker_setup/)
- [Epoch AI: SWE-bench in Docker](https://epoch.ai/blog/swebench-docker)
- Related: #336, #337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker environment configuration with expanded system dependencies including SSL libraries, database drivers, XML processing, and image handling tools for improved task compatibility.
  * Improved fallback Docker image building mechanism to ensure comprehensive dependency availability when primary configuration is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->