### PR TITLE
fix: improve error messages for common failure modes

### DIFF
--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -1,7 +1,5 @@
 """Tests for error message accuracy and helpfulness."""
 
-import pytest
-
 from mcpbr.harnesses import _generate_no_patch_error_message
 
 

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -1,0 +1,172 @@
+"""Tests for error message accuracy and helpfulness."""
+
+import pytest
+
+from mcpbr.harnesses import _generate_no_patch_error_message
+
+
+class TestErrorMessageAccuracy:
+    """Tests that error messages accurately reflect what actually happened."""
+
+    def test_git_missing_error(self) -> None:
+        """Test detection of missing git command."""
+        # Simulate git command not found in stderr
+        git_stderr = "sh: git: command not found"
+        git_status = ""
+        tool_usage = {"Read": 3, "Bash": 2}
+
+        error_msg = _generate_no_patch_error_message(
+            git_status=git_status,
+            git_stderr=git_stderr,
+            buggy_line="",
+            tool_usage=tool_usage,
+        )
+
+        assert "git command not found" in error_msg
+        assert "ensure git is installed" in error_msg
+        # Should not claim edits were applied
+        assert "Edit applied" not in error_msg
+
+    def test_no_edits_made_error(self) -> None:
+        """Test error when agent never tried to edit files and no buggy line."""
+        # No Edit/Write tools in tool_usage, no buggy line
+        git_status = ""
+        git_stderr = ""
+        tool_usage = {"Read": 5, "Bash": 3, "Grep": 2}
+
+        error_msg = _generate_no_patch_error_message(
+            git_status=git_status,
+            git_stderr=git_stderr,
+            buggy_line="",  # No buggy line present
+            tool_usage=tool_usage,
+        )
+
+        assert "No patches applied" in error_msg
+        assert "completed without making changes" in error_msg
+        # Should mention what tools were actually used
+        assert "Read" in error_msg or "Tools used" in error_msg
+        # Should not claim edits were applied
+        assert "Edit applied" not in error_msg
+
+    def test_edit_failed_no_changes_error(self) -> None:
+        """Test error when Edit/Write tools were used but no git changes detected."""
+        # Edit tool was called but git shows no changes
+        git_status = ""
+        git_stderr = ""
+        tool_usage = {"Read": 3, "Edit": 2, "Bash": 1}
+
+        error_msg = _generate_no_patch_error_message(
+            git_status=git_status,
+            git_stderr=git_stderr,
+            buggy_line="",
+            tool_usage=tool_usage,
+        )
+
+        # Should indicate Edit was used
+        assert "Edit" in error_msg or "Write" in error_msg
+        assert "no changes detected" in error_msg
+        # Can use the original message since it's now accurate
+        assert "file may be unchanged" in error_msg or "file unchanged" in error_msg
+
+    def test_write_tool_detected(self) -> None:
+        """Test that Write tool is also detected as an edit attempt."""
+        git_status = ""
+        git_stderr = ""
+        tool_usage = {"Read": 2, "Write": 3}
+
+        error_msg = _generate_no_patch_error_message(
+            git_status=git_status,
+            git_stderr=git_stderr,
+            buggy_line="",
+            tool_usage=tool_usage,
+        )
+
+        # Should recognize Write as an edit tool
+        assert "Write" in error_msg or "Edit" in error_msg
+        assert "no changes detected" in error_msg
+
+    def test_git_status_shows_changes_but_no_patch(self) -> None:
+        """Test when git status shows changes but patch generation fails."""
+        git_status = "M file.py\n?? temp.txt"
+        git_stderr = ""
+        tool_usage = {"Edit": 2}
+
+        error_msg = _generate_no_patch_error_message(
+            git_status=git_status,
+            git_stderr=git_stderr,
+            buggy_line="",
+            tool_usage=tool_usage,
+        )
+
+        assert "Files changed but no valid patch" in error_msg
+        assert "M file.py" in error_msg
+
+    def test_buggy_line_still_present(self) -> None:
+        """Test when the buggy line is still detected after execution."""
+        git_status = ""
+        git_stderr = ""
+        tool_usage = {"Read": 3, "Edit": 1}
+        buggy_line = "cright = 1"
+
+        error_msg = _generate_no_patch_error_message(
+            git_status=git_status,
+            git_stderr=git_stderr,
+            buggy_line=buggy_line,
+            tool_usage=tool_usage,
+        )
+
+        assert "Buggy line still present" in error_msg
+        assert "cright = 1" in error_msg
+
+    def test_tool_usage_context_included(self) -> None:
+        """Test that tool usage context is included for debugging."""
+        git_status = ""
+        git_stderr = ""
+        tool_usage = {"Read": 5, "Bash": 3, "Grep": 2, "Glob": 1}
+
+        error_msg = _generate_no_patch_error_message(
+            git_status=git_status,
+            git_stderr=git_stderr,
+            buggy_line="bug",
+            tool_usage=tool_usage,
+        )
+
+        # Error message should include some tool usage info for debugging
+        # At minimum should mention tools were used
+        assert error_msg is not None
+        assert len(error_msg) > 0
+
+    def test_empty_tool_usage(self) -> None:
+        """Test handling when tool_usage is empty (agent made no tool calls)."""
+        git_status = ""
+        git_stderr = ""
+        tool_usage = {}
+
+        error_msg = _generate_no_patch_error_message(
+            git_status=git_status,
+            git_stderr=git_stderr,
+            buggy_line="bug",
+            tool_usage=tool_usage,
+        )
+
+        # Should indicate no tools were used
+        assert "No patches applied" in error_msg or "Buggy line still present" in error_msg
+
+    def test_max_iterations_no_changes(self) -> None:
+        """Test error message when agent hits max iterations without making changes."""
+        # This is a common case that was previously misdiagnosed
+        git_status = ""
+        git_stderr = ""
+        tool_usage = {"Read": 10, "Bash": 5, "Grep": 3}  # Many reads but no edits
+
+        error_msg = _generate_no_patch_error_message(
+            git_status=git_status,
+            git_stderr=git_stderr,
+            buggy_line="still buggy",
+            tool_usage=tool_usage,
+        )
+
+        # Should NOT claim edits were applied
+        assert "Edit applied" not in error_msg
+        # Should indicate what actually happened
+        assert "No patches applied" in error_msg or "Buggy line still present" in error_msg


### PR DESCRIPTION
## Summary

This PR fixes misleading error messages that wasted debugging time, particularly the error "Edit applied but git shows no changes (file unchanged?)" which appeared when no Edit/Write tools were actually called.

## Changes

1. Added `_generate_no_patch_error_message()` helper function that accurately detects and reports different failure modes
2. Improved error detection to distinguish between:
   - **Git missing**: "git command not found - ensure git is installed or use prebuilt images"
   - **No edits made**: "No patches applied - agent completed without making changes. Tools used: {list}"
   - **Edit failed**: "Edit/Write tools used but no changes detected - file may be unchanged"
   - **Buggy line still present**: "Buggy line still present: {buggy_line}"
3. Added tool usage context to error messages for better debugging
4. Created comprehensive test suite (`test_error_messages.py`) with 9 test cases covering all scenarios

## Problem Solved

The previous error message "Edit applied but git shows no changes" was misleading because it claimed an edit was applied when:
- Git was missing from the environment
- Agent hit max iterations without making changes  
- Agent completed without attempting to edit files

This caused confusion during debugging as the message didn't reflect what actually happened.

## Testing

All tests pass:
- 9 new tests in `test_error_messages.py` 
- No regressions in existing tests (`test_tool_failure_tracking.py`, `test_agent.py`)

## Example Error Messages

**Before**: "Edit applied but git shows no changes (file unchanged?)"  
**After (git missing)**: "git command not found - ensure git is installed in the environment or use prebuilt Docker images with git pre-installed"

**After (no edits)**: "No patches applied - agent completed without making changes. Tools used: Bash, Read"

**After (edit failed)**: "Edit tool(s) used but no changes detected - file may be unchanged or changes were reverted"

🤖 Generated with [Claude Code](https://claude.com/claude-code)