### PR TITLE
feat: Add side-by-side MCP server comparison mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ mcpbr run -c comparison-config.yaml -o results.json
 
 ### Results Output
 
-```
+```text
 Side-by-Side MCP Server Comparison
 
 ┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━┓

--- a/README.md
+++ b/README.md
@@ -320,6 +320,60 @@ max_concurrent: 4
 mcpbr run --config config.yaml
 ```
 
+## Side-by-Side Server Comparison
+
+Compare two MCP servers head-to-head in a single evaluation run to see which implementation performs better.
+
+### Quick Example
+
+```yaml
+# comparison-config.yaml
+comparison_mode: true
+
+mcp_server_a:
+  name: "Task Queries"
+  command: node
+  args: [build/index.js]
+  cwd: /path/to/task-queries
+
+mcp_server_b:
+  name: "Edge Identity"
+  command: node
+  args: [build/index.js]
+  cwd: /path/to/edge-identity
+
+benchmark: swe-bench-lite
+sample_size: 10
+```
+
+```bash
+mcpbr run -c comparison-config.yaml -o results.json
+```
+
+### Results Output
+
+```
+Side-by-Side MCP Server Comparison
+
+┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━┓
+┃ Metric            ┃ Task Queries ┃ Edge Identity┃ Δ (A - B)┃
+┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━┩
+│ Resolved Tasks    │ 4/10         │ 2/10         │ +2       │
+│ Resolution Rate   │ 40.0%        │ 20.0%        │ +100.0%  │
+└───────────────────┴──────────────┴──────────────┴──────────┘
+
+✓ Task Queries unique wins: 2 tasks
+  - django__django-12286
+  - astropy__astropy-7606
+```
+
+**Use cases:**
+- **A/B testing**: Compare optimized vs. baseline implementations
+- **Tool evaluation**: Test different MCP tool sets
+- **Version comparison**: Benchmark v2.0 vs. v1.5
+
+See [docs/comparison-mode.md](docs/comparison-mode.md) for complete documentation.
+
 ## Claude Code Integration
 
 [![Claude Code Ready](https://img.shields.io/badge/Claude_Code-Ready-5865F2?style=flat&logo=anthropic)](https://claude.ai/download)

--- a/docs/comparison-mode.md
+++ b/docs/comparison-mode.md
@@ -48,7 +48,7 @@ mcpbr run -c comparison.yaml -o results.json
 
 The output will show:
 
-```
+```text
 Side-by-Side MCP Server Comparison
 
 ┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━┓
@@ -284,7 +284,7 @@ mcp_server_b:
 
 - **2x Execution Time**: Each task runs twice (once per server)
 - **2x API Costs**: Both servers make independent API calls
-- **2x Compute**: Both servers run simultaneously (sequential execution)
+- **2x Compute**: Both servers run sequentially (no parallel execution)
 
 ### Budget Tracking
 

--- a/docs/comparison-mode.md
+++ b/docs/comparison-mode.md
@@ -1,0 +1,422 @@
+# Side-by-Side MCP Server Comparison
+
+Compare two MCP servers head-to-head in a single evaluation run to understand which implementation performs better on your benchmark tasks.
+
+## Overview
+
+Comparison mode enables A/B testing of MCP servers by running the same tasks against two different server implementations simultaneously. This is useful for:
+
+- **Evaluating implementation alternatives**: Compare different MCP server architectures
+- **Testing optimizations**: Measure the impact of performance improvements
+- **Benchmarking tools**: Compare your MCP server against reference implementations
+- **Research**: Conduct controlled experiments on MCP server design decisions
+
+## Quick Start
+
+### 1. Create a Comparison Configuration
+
+Create a YAML config file (e.g., `comparison.yaml`):
+
+```yaml
+comparison_mode: true
+
+mcp_server_a:
+  name: "Task Queries"
+  command: node
+  args: [build/index.js]
+  cwd: /path/to/task-queries-server
+
+mcp_server_b:
+  name: "Edge Identity"
+  command: node
+  args: [build/index.js]
+  cwd: /path/to/edge-identity-server
+
+benchmark: swe-bench-lite
+sample_size: 10
+timeout_seconds: 300
+max_iterations: 10
+```
+
+### 2. Run the Comparison
+
+```bash
+mcpbr run -c comparison.yaml -o results.json
+```
+
+### 3. View Results
+
+The output will show:
+
+```
+Side-by-Side MCP Server Comparison
+
+┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━┓
+┃ Metric            ┃ Task Queries ┃ Edge Identity┃ Δ (A - B)┃
+┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━┩
+│ Resolved Tasks    │ 4/10         │ 2/10         │ +2       │
+│ Resolution Rate   │ 40.0%        │ 20.0%        │ +100.0%  │
+└───────────────────┴──────────────┴──────────────┴──────────┘
+
+Per-Task Results
+┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ Instance ID ┃ Task Queries ┃ Edge Identity┃ Winner       ┃
+┡━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
+│ task-1      │ PASS         │ FAIL         │ Task Queries │
+│ task-2      │ PASS         │ FAIL         │ Task Queries │
+│ task-3      │ PASS         │ PASS         │ Both         │
+└─────────────┴──────────────┴──────────────┴──────────────┘
+
+✓ Task Queries unique wins: 2 tasks
+  - task-1
+  - task-2
+```
+
+## Configuration
+
+### Required Fields
+
+When `comparison_mode: true`, you must provide:
+
+- `mcp_server_a`: Configuration for the first MCP server
+- `mcp_server_b`: Configuration for the second MCP server
+
+Both servers support the same configuration options as the standard `mcp_server` field:
+
+```yaml
+mcp_server_a:
+  name: "Server Name"           # Human-readable name (appears in reports)
+  command: "npx"                 # Command to start the server
+  args: ["-y", "package-name"]   # Command arguments
+  env:                           # Environment variables (optional)
+    API_KEY: "${API_KEY}"
+  cwd: "/path/to/server"         # Working directory (optional)
+  startup_timeout_ms: 60000      # Server startup timeout (optional)
+  tool_timeout_ms: 900000        # Tool call timeout (optional)
+```
+
+### Complete Example
+
+```yaml
+# Enable comparison mode
+comparison_mode: true
+
+# First MCP server
+mcp_server_a:
+  name: "Optimized Server"
+  command: node
+  args: [dist/server.js]
+  cwd: /Users/me/projects/optimized-mcp
+  env:
+    LOG_LEVEL: debug
+    CACHE_ENABLED: "true"
+
+# Second MCP server
+mcp_server_b:
+  name: "Baseline Server"
+  command: node
+  args: [dist/server.js]
+  cwd: /Users/me/projects/baseline-mcp
+  env:
+    LOG_LEVEL: debug
+    CACHE_ENABLED: "false"
+
+# Model and provider (shared by both servers)
+provider: anthropic
+model: claude-sonnet-4-20250514
+
+# Benchmark settings
+benchmark: swe-bench-verified
+sample_size: 50
+timeout_seconds: 600
+max_iterations: 15
+```
+
+## Output Format
+
+### JSON Results
+
+The results JSON includes comparison-specific fields:
+
+```json
+{
+  "metadata": {
+    "timestamp": "2026-01-30T10:00:00Z",
+    "config": {
+      "comparison_mode": true,
+      ...
+    },
+    "mcp_server_a": {
+      "name": "Task Queries",
+      "command": "node",
+      "args": ["build/index.js"]
+    },
+    "mcp_server_b": {
+      "name": "Edge Identity",
+      "command": "node",
+      "args": ["build/index.js"]
+    }
+  },
+  "summary": {
+    "mcp_server_a": {
+      "name": "Task Queries",
+      "resolved": 4,
+      "total": 10,
+      "resolution_rate": 0.4,
+      "cost": 0.50,
+      "tool_calls": 125
+    },
+    "mcp_server_b": {
+      "name": "Edge Identity",
+      "resolved": 2,
+      "total": 10,
+      "resolution_rate": 0.2,
+      "cost": 0.45,
+      "tool_calls": 98
+    },
+    "comparison": {
+      "a_vs_b_delta": 2,
+      "a_vs_b_improvement_pct": 100.0,
+      "a_unique_wins": ["task-1", "task-2"],
+      "b_unique_wins": [],
+      "both_wins": ["task-3"],
+      "both_fail": ["task-4", "task-5", ...]
+    }
+  },
+  "tasks": [
+    {
+      "instance_id": "task-1",
+      "mcp_server_a": {
+        "resolved": true,
+        "patch_generated": true,
+        "cost": 0.05,
+        ...
+      },
+      "mcp_server_b": {
+        "resolved": false,
+        "patch_generated": false,
+        "cost": 0.04,
+        ...
+      }
+    },
+    ...
+  ]
+}
+```
+
+### Understanding the Metrics
+
+- **Resolution Rate**: Percentage of tasks successfully resolved by each server
+- **Δ (A - B)**: Difference in resolved tasks (positive means A is better)
+- **Improvement %**: Percentage improvement of A over B
+- **Unique Wins**: Tasks where only one server succeeded
+- **Both Wins**: Tasks where both servers succeeded
+- **Both Fail**: Tasks where both servers failed
+
+## Use Cases
+
+### Comparing MCP Tools
+
+Test which tool implementations work best for your use case:
+
+```yaml
+comparison_mode: true
+
+mcp_server_a:
+  name: "Filesystem Tools"
+  command: npx
+  args: ["-y", "@modelcontextprotocol/server-filesystem", "{workdir}"]
+
+mcp_server_b:
+  name: "Git Tools"
+  command: npx
+  args: ["-y", "@modelcontextprotocol/server-git", "{workdir}"]
+
+benchmark: swe-bench-lite
+sample_size: 20
+```
+
+### Performance Optimization
+
+Measure the impact of caching, indexing, or other optimizations:
+
+```yaml
+comparison_mode: true
+
+mcp_server_a:
+  name: "With Cache"
+  command: node
+  args: [server.js]
+  env:
+    ENABLE_CACHE: "true"
+
+mcp_server_b:
+  name: "Without Cache"
+  command: node
+  args: [server.js]
+  env:
+    ENABLE_CACHE: "false"
+```
+
+### Version Comparison
+
+Compare different versions of the same server:
+
+```yaml
+comparison_mode: true
+
+mcp_server_a:
+  name: "v2.0"
+  command: node
+  args: [server.js]
+  cwd: /path/to/v2.0
+
+mcp_server_b:
+  name: "v1.5"
+  command: node
+  args: [server.js]
+  cwd: /path/to/v1.5
+```
+
+## Limitations
+
+### Resource Usage
+
+- **2x Execution Time**: Each task runs twice (once per server)
+- **2x API Costs**: Both servers make independent API calls
+- **2x Compute**: Both servers run simultaneously (sequential execution)
+
+### Budget Tracking
+
+When using `budget` parameter, costs from both servers count toward the limit:
+
+```yaml
+comparison_mode: true
+budget: 10.00  # Shared budget for both servers
+```
+
+### Baseline Evaluation
+
+Comparison mode is compatible with baseline evaluation:
+
+```bash
+# Run both servers + baseline
+mcpbr run -c comparison.yaml
+
+# Run only comparison (skip baseline)
+mcpbr run -c comparison.yaml -M
+```
+
+## Best Practices
+
+### 1. Use Meaningful Names
+
+Choose descriptive names that clearly identify what's being compared:
+
+```yaml
+mcp_server_a:
+  name: "GPT-4 Index"  # Good: specific and clear
+
+mcp_server_b:
+  name: "Server B"     # Bad: generic
+```
+
+### 2. Start Small
+
+Begin with a small sample size to verify your configuration:
+
+```yaml
+comparison_mode: true
+sample_size: 5  # Start with 5 tasks
+```
+
+Then scale up once you've validated the setup.
+
+### 3. Control Variables
+
+Change only one thing at a time for meaningful comparisons:
+
+```yaml
+# Good: Only caching differs
+mcp_server_a:
+  command: node
+  args: [server.js]
+  env: {CACHE: "on"}
+
+mcp_server_b:
+  command: node
+  args: [server.js]
+  env: {CACHE: "off"}
+
+# Bad: Multiple differences (harder to interpret)
+mcp_server_a:
+  command: python
+  args: [new_server.py]
+  env: {CACHE: "on", LOG_LEVEL: "debug"}
+
+mcp_server_b:
+  command: node
+  args: [old_server.js]
+  env: {CACHE: "off", LOG_LEVEL: "info"}
+```
+
+### 4. Run Multiple Trials
+
+For statistical confidence, run multiple evaluations:
+
+```bash
+for i in {1..5}; do
+  mcpbr run -c comparison.yaml --trial-mode -o trial_${i}.json
+done
+```
+
+## Backward Compatibility
+
+Comparison mode is fully backward compatible. Existing single-server configurations continue to work:
+
+```yaml
+# Old config (still works)
+mcp_server:
+  command: npx
+  args: ["-y", "server"]
+
+# New config (comparison mode)
+comparison_mode: true
+mcp_server_a:
+  command: npx
+  args: ["-y", "server-a"]
+mcp_server_b:
+  command: npx
+  args: ["-y", "server-b"]
+```
+
+## Troubleshooting
+
+### "requires both mcp_server_a and mcp_server_b"
+
+You enabled `comparison_mode: true` but only provided one server. Both servers are required.
+
+### "use mcp_server_a/b instead of mcp_server"
+
+You enabled comparison mode but also provided the legacy `mcp_server` field. Remove it:
+
+```yaml
+comparison_mode: true
+# mcp_server: ...  # Remove this
+mcp_server_a: ...
+mcp_server_b: ...
+```
+
+### "mcp_server_a/b only valid in comparison_mode"
+
+You provided comparison servers but didn't enable comparison mode:
+
+```yaml
+comparison_mode: true  # Add this
+mcp_server_a: ...
+mcp_server_b: ...
+```
+
+## Examples
+
+See the [examples/comparison/](../examples/comparison/) directory for complete working examples.

--- a/src/mcpbr/cli.py
+++ b/src/mcpbr/cli.py
@@ -751,7 +751,13 @@ To archive:
         if log_file:
             log_file.close()
 
-    print_summary(results, console)
+    # Use comparison summary if in comparison mode
+    if results.summary.get("mcp_server_a"):
+        from .reporting import print_comparison_summary
+
+        print_comparison_summary(results, console)
+    else:
+        print_summary(results, console)
 
     if output_path:
         save_json_results(results, output_path)

--- a/tests/test_comparison_aggregation.py
+++ b/tests/test_comparison_aggregation.py
@@ -1,0 +1,118 @@
+"""Tests for comparison result aggregation."""
+
+import pytest
+
+from mcpbr.harness import TaskResult, _aggregate_comparison_results
+
+
+class TestComparisonAggregation:
+    """Tests for comparison aggregation logic."""
+
+    def test_aggregate_with_one_unique_winner(self):
+        """Test aggregation when one server uniquely resolves tasks."""
+        results = [
+            TaskResult(
+                instance_id="task-1",
+                mcp_server_a={"resolved": True, "cost": 0.05, "tool_calls": 10},
+                mcp_server_b={"resolved": False, "cost": 0.03, "tool_calls": 8},
+            ),
+            TaskResult(
+                instance_id="task-2",
+                mcp_server_a={"resolved": True, "cost": 0.04, "tool_calls": 9},
+                mcp_server_b={"resolved": False, "cost": 0.02, "tool_calls": 7},
+            ),
+        ]
+
+        summary = _aggregate_comparison_results(results)
+
+        assert summary["stats_a"]["resolved"] == 2
+        assert summary["stats_b"]["resolved"] == 0
+        assert summary["a_vs_b_delta"] == 2
+        assert len(summary["a_unique_wins"]) == 2
+        assert len(summary["b_unique_wins"]) == 0
+        assert len(summary["both_wins"]) == 0
+
+    def test_aggregate_with_both_winners(self):
+        """Test aggregation when both servers resolve tasks."""
+        results = [
+            TaskResult(
+                instance_id="task-1",
+                mcp_server_a={"resolved": True, "cost": 0.05, "tool_calls": 10},
+                mcp_server_b={"resolved": True, "cost": 0.03, "tool_calls": 8},
+            ),
+            TaskResult(
+                instance_id="task-2",
+                mcp_server_a={"resolved": True, "cost": 0.04, "tool_calls": 9},
+                mcp_server_b={"resolved": False, "cost": 0.02, "tool_calls": 7},
+            ),
+        ]
+
+        summary = _aggregate_comparison_results(results)
+
+        assert summary["stats_a"]["resolved"] == 2
+        assert summary["stats_b"]["resolved"] == 1
+        assert summary["a_vs_b_delta"] == 1
+        assert len(summary["a_unique_wins"]) == 1
+        assert len(summary["both_wins"]) == 1
+
+    def test_resolution_rate_calculation(self):
+        """Test resolution rate percentage calculation."""
+        results = [
+            TaskResult(
+                instance_id=f"task-{i}",
+                mcp_server_a={"resolved": i < 8, "cost": 0.05, "tool_calls": 10},  # 8/10 = 80%
+                mcp_server_b={"resolved": i < 4, "cost": 0.03, "tool_calls": 8},  # 4/10 = 40%
+            )
+            for i in range(10)
+        ]
+
+        summary = _aggregate_comparison_results(results)
+
+        assert summary["resolution_rate_a"] == 0.8
+        assert summary["resolution_rate_b"] == 0.4
+        assert summary["a_vs_b_improvement_pct"] == pytest.approx(100.0)  # 2x better
+
+    def test_aggregate_with_both_failures(self):
+        """Test aggregation when both servers fail on tasks."""
+        results = [
+            TaskResult(
+                instance_id="task-1",
+                mcp_server_a={"resolved": False, "cost": 0.05, "tool_calls": 10},
+                mcp_server_b={"resolved": False, "cost": 0.03, "tool_calls": 8},
+            ),
+            TaskResult(
+                instance_id="task-2",
+                mcp_server_a={"resolved": False, "cost": 0.04, "tool_calls": 9},
+                mcp_server_b={"resolved": False, "cost": 0.02, "tool_calls": 7},
+            ),
+        ]
+
+        summary = _aggregate_comparison_results(results)
+
+        assert summary["stats_a"]["resolved"] == 0
+        assert summary["stats_b"]["resolved"] == 0
+        assert len(summary["both_fail"]) == 2
+        assert summary["resolution_rate_a"] == 0.0
+        assert summary["resolution_rate_b"] == 0.0
+
+    def test_cost_and_tool_call_aggregation(self):
+        """Test that costs and tool calls are properly summed."""
+        results = [
+            TaskResult(
+                instance_id="task-1",
+                mcp_server_a={"resolved": True, "cost": 0.05, "tool_calls": 10},
+                mcp_server_b={"resolved": True, "cost": 0.03, "tool_calls": 8},
+            ),
+            TaskResult(
+                instance_id="task-2",
+                mcp_server_a={"resolved": False, "cost": 0.04, "tool_calls": 9},
+                mcp_server_b={"resolved": False, "cost": 0.02, "tool_calls": 7},
+            ),
+        ]
+
+        summary = _aggregate_comparison_results(results)
+
+        assert summary["stats_a"]["cost"] == pytest.approx(0.09)
+        assert summary["stats_b"]["cost"] == pytest.approx(0.05)
+        assert summary["stats_a"]["tool_calls"] == 19
+        assert summary["stats_b"]["tool_calls"] == 15

--- a/tests/test_comparison_config.py
+++ b/tests/test_comparison_config.py
@@ -1,0 +1,74 @@
+"""Tests for comparison mode configuration."""
+
+import pytest
+
+from mcpbr.config import HarnessConfig, MCPServerConfig
+
+
+class TestComparisonConfig:
+    """Tests for comparison mode configuration validation."""
+
+    def test_comparison_mode_requires_both_servers(self):
+        """Test that comparison mode requires both mcp_server_a and mcp_server_b."""
+        with pytest.raises(ValueError, match="requires both mcp_server_a and mcp_server_b"):
+            HarnessConfig(
+                comparison_mode=True,
+                mcp_server_a=MCPServerConfig(command="npx", args=[]),
+                # Missing mcp_server_b
+            )
+
+    def test_comparison_mode_rejects_single_server(self):
+        """Test that comparison mode rejects mcp_server field."""
+        with pytest.raises(ValueError, match="use mcp_server_a/b instead"):
+            HarnessConfig(
+                comparison_mode=True,
+                mcp_server=MCPServerConfig(command="npx", args=[]),
+                mcp_server_a=MCPServerConfig(command="npx", args=[]),
+                mcp_server_b=MCPServerConfig(command="node", args=[]),
+            )
+
+    def test_single_server_mode_requires_mcp_server(self):
+        """Test that non-comparison mode requires mcp_server."""
+        with pytest.raises(ValueError, match="mcp_server required"):
+            HarnessConfig(
+                comparison_mode=False,
+                # Missing mcp_server
+            )
+
+    def test_single_server_mode_rejects_comparison_servers(self):
+        """Test that single server mode rejects mcp_server_a/b fields."""
+        with pytest.raises(ValueError, match="mcp_server_a/b only valid in comparison_mode"):
+            HarnessConfig(
+                comparison_mode=False,
+                mcp_server=MCPServerConfig(command="npx", args=[]),
+                mcp_server_a=MCPServerConfig(command="npx", args=[]),
+            )
+
+    def test_valid_comparison_config(self):
+        """Test valid comparison mode configuration."""
+        config = HarnessConfig(
+            comparison_mode=True,
+            mcp_server_a=MCPServerConfig(
+                name="Server A",
+                command="npx",
+                args=["-y", "server-a"],
+            ),
+            mcp_server_b=MCPServerConfig(
+                name="Server B",
+                command="npx",
+                args=["-y", "server-b"],
+            ),
+        )
+        assert config.comparison_mode
+        assert config.mcp_server_a.name == "Server A"
+        assert config.mcp_server_b.name == "Server B"
+
+    def test_backward_compatibility_single_server(self):
+        """Test backward compatibility with single server configs."""
+        config = HarnessConfig(
+            mcp_server=MCPServerConfig(command="npx", args=[]),
+        )
+        assert not config.comparison_mode
+        assert config.mcp_server is not None
+        assert config.mcp_server_a is None
+        assert config.mcp_server_b is None

--- a/tests/test_comparison_integration.py
+++ b/tests/test_comparison_integration.py
@@ -1,0 +1,108 @@
+"""Integration tests for comparison mode."""
+
+import os
+
+import pytest
+
+from mcpbr.config import HarnessConfig, MCPServerConfig
+from mcpbr.harness import run_evaluation
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_comparison_mode_evaluation():
+    """Test full evaluation in comparison mode."""
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        pytest.skip("ANTHROPIC_API_KEY not set")
+
+    config = HarnessConfig(
+        comparison_mode=True,
+        mcp_server_a=MCPServerConfig(
+            name="Filesystem A",
+            command="npx",
+            args=["-y", "@modelcontextprotocol/server-filesystem", "{workdir}"],
+        ),
+        mcp_server_b=MCPServerConfig(
+            name="Filesystem B",
+            command="npx",
+            args=["-y", "@modelcontextprotocol/server-filesystem", "{workdir}"],
+        ),
+        provider="anthropic",
+        model="claude-sonnet-4-20250514",
+        agent_harness="claude-code",
+        benchmark="swe-bench-lite",
+        sample_size=1,
+        timeout_seconds=300,
+        max_iterations=5,
+    )
+
+    results = await run_evaluation(
+        config=config,
+        run_mcp=True,
+        run_baseline=False,
+        verbose=True,
+    )
+
+    assert results is not None
+    assert len(results.tasks) == 1
+
+    task = results.tasks[0]
+    assert task.mcp_server_a is not None
+    assert task.mcp_server_b is not None
+    assert "comparison" in results.summary
+    assert "mcp_server_a" in results.summary
+    assert "mcp_server_b" in results.summary
+
+    # Verify comparison statistics are present
+    comp = results.summary["comparison"]
+    assert "a_vs_b_delta" in comp
+    assert "a_vs_b_improvement_pct" in comp
+    assert "a_unique_wins" in comp
+    assert "b_unique_wins" in comp
+    assert "both_wins" in comp
+    assert "both_fail" in comp
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_comparison_mode_with_different_servers():
+    """Test comparison mode with two different MCP servers."""
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        pytest.skip("ANTHROPIC_API_KEY not set")
+
+    config = HarnessConfig(
+        comparison_mode=True,
+        mcp_server_a=MCPServerConfig(
+            name="Filesystem",
+            command="npx",
+            args=["-y", "@modelcontextprotocol/server-filesystem", "{workdir}"],
+        ),
+        mcp_server_b=MCPServerConfig(
+            name="Memory (no MCP)",
+            command="echo",  # Dummy command that does nothing
+            args=[""],
+        ),
+        provider="anthropic",
+        model="claude-sonnet-4-20250514",
+        agent_harness="claude-code",
+        benchmark="swe-bench-lite",
+        sample_size=1,
+        timeout_seconds=300,
+        max_iterations=5,
+    )
+
+    results = await run_evaluation(
+        config=config,
+        run_mcp=True,
+        run_baseline=False,
+        verbose=True,
+    )
+
+    assert results is not None
+    assert len(results.tasks) == 1
+
+    # Verify metadata includes both server configs
+    assert "mcp_server_a" in results.metadata
+    assert "mcp_server_b" in results.metadata
+    assert results.metadata["mcp_server_a"]["name"] == "Filesystem"
+    assert results.metadata["mcp_server_b"]["name"] == "Memory (no MCP)"

--- a/tests/test_comparison_reporting.py
+++ b/tests/test_comparison_reporting.py
@@ -1,0 +1,169 @@
+"""Tests for comparison mode reporting."""
+
+from io import StringIO
+
+from rich.console import Console
+
+from mcpbr.harness import EvaluationResults, TaskResult
+from mcpbr.reporting import print_comparison_summary
+
+
+class TestComparisonReporting:
+    """Tests for comparison reporting output."""
+
+    def test_comparison_summary_output(self):
+        """Test comparison summary console output."""
+        results = EvaluationResults(
+            metadata={"timestamp": "2026-01-30", "config": {}},
+            summary={
+                "mcp_server_a": {
+                    "name": "Task Queries",
+                    "total": 10,
+                    "resolved": 4,
+                    "resolution_rate": 0.4,
+                    "cost": 0.50,
+                },
+                "mcp_server_b": {
+                    "name": "Edge Identity",
+                    "total": 10,
+                    "resolved": 2,
+                    "resolution_rate": 0.2,
+                    "cost": 0.45,
+                },
+                "comparison": {
+                    "a_vs_b_delta": 2,
+                    "a_vs_b_improvement_pct": 100.0,
+                    "a_unique_wins": ["task-1", "task-2"],
+                    "b_unique_wins": [],
+                    "both_wins": ["task-3", "task-4"],
+                    "both_fail": ["task-5"],
+                },
+            },
+            tasks=[
+                TaskResult(
+                    instance_id="task-1",
+                    mcp_server_a={"resolved": True},
+                    mcp_server_b={"resolved": False},
+                ),
+                TaskResult(
+                    instance_id="task-2",
+                    mcp_server_a={"resolved": True},
+                    mcp_server_b={"resolved": False},
+                ),
+                TaskResult(
+                    instance_id="task-3",
+                    mcp_server_a={"resolved": True},
+                    mcp_server_b={"resolved": True},
+                ),
+                TaskResult(
+                    instance_id="task-4",
+                    mcp_server_a={"resolved": True},
+                    mcp_server_b={"resolved": True},
+                ),
+                TaskResult(
+                    instance_id="task-5",
+                    mcp_server_a={"resolved": False},
+                    mcp_server_b={"resolved": False},
+                ),
+            ],
+        )
+
+        # Capture console output
+        string_io = StringIO()
+        console = Console(file=string_io, force_terminal=True, width=120)
+
+        print_comparison_summary(results, console)
+
+        output = string_io.getvalue()
+        assert "Side-by-Side MCP Server Comparison" in output
+        assert "Task Queries" in output
+        assert "Edge Identity" in output
+        assert "4/10" in output  # Server A resolved
+        assert "2/10" in output  # Server B resolved
+
+    def test_comparison_summary_with_no_unique_wins(self):
+        """Test comparison summary when both servers resolve the same tasks."""
+        results = EvaluationResults(
+            metadata={"timestamp": "2026-01-30", "config": {}},
+            summary={
+                "mcp_server_a": {
+                    "name": "Server A",
+                    "total": 2,
+                    "resolved": 1,
+                    "resolution_rate": 0.5,
+                    "cost": 0.10,
+                },
+                "mcp_server_b": {
+                    "name": "Server B",
+                    "total": 2,
+                    "resolved": 1,
+                    "resolution_rate": 0.5,
+                    "cost": 0.10,
+                },
+                "comparison": {
+                    "a_vs_b_delta": 0,
+                    "a_vs_b_improvement_pct": 0.0,
+                    "a_unique_wins": [],
+                    "b_unique_wins": [],
+                    "both_wins": ["task-1"],
+                    "both_fail": ["task-2"],
+                },
+            },
+            tasks=[
+                TaskResult(
+                    instance_id="task-1",
+                    mcp_server_a={"resolved": True},
+                    mcp_server_b={"resolved": True},
+                ),
+                TaskResult(
+                    instance_id="task-2",
+                    mcp_server_a={"resolved": False},
+                    mcp_server_b={"resolved": False},
+                ),
+            ],
+        )
+
+        string_io = StringIO()
+        console = Console(file=string_io, force_terminal=True, width=120)
+
+        print_comparison_summary(results, console)
+
+        output = string_io.getvalue()
+        # Should not show unique wins sections if lists are empty
+        assert "unique wins" not in output.lower() or "0 tasks" in output
+
+    def test_fallback_to_regular_summary(self):
+        """Test that non-comparison results fall back to regular print_summary."""
+        results = EvaluationResults(
+            metadata={"timestamp": "2026-01-30", "config": {}},
+            summary={
+                "mcp": {
+                    "resolved": 5,
+                    "total": 10,
+                    "rate": 0.5,
+                    "total_cost": 1.0,
+                    "cost_per_task": 0.1,
+                    "cost_per_resolved": 0.2,
+                },
+                "baseline": {
+                    "resolved": 3,
+                    "total": 10,
+                    "rate": 0.3,
+                    "total_cost": 0.5,
+                    "cost_per_task": 0.05,
+                    "cost_per_resolved": 0.16,
+                },
+                "improvement": "+66.7%",
+            },
+            tasks=[],
+        )
+
+        string_io = StringIO()
+        console = Console(file=string_io, force_terminal=True, width=120)
+
+        # Should not crash and should use regular summary
+        print_comparison_summary(results, console)
+
+        output = string_io.getvalue()
+        # Should show regular summary, not comparison
+        assert "Evaluation Results" in output or "Summary" in output

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -55,7 +55,16 @@ class TestGenerateJsonSchema:
         schema = generate_json_schema()
 
         mcp_server = schema["properties"]["mcp_server"]
-        assert "properties" in mcp_server or "allOf" in mcp_server or "$ref" in mcp_server
+        # Check direct structure
+        if "properties" in mcp_server or "allOf" in mcp_server or "$ref" in mcp_server:
+            assert True
+        # Check anyOf structure (for Optional fields in Pydantic)
+        elif "anyOf" in mcp_server:
+            # Find the non-null option in anyOf
+            refs = [opt for opt in mcp_server["anyOf"] if "$ref" in opt or "properties" in opt]
+            assert len(refs) > 0, "mcp_server anyOf should contain $ref or properties"
+        else:
+            assert False, f"mcp_server has unexpected structure: {mcp_server.keys()}"
 
     def test_schema_has_examples(self) -> None:
         """Test that schema includes example configurations."""


### PR DESCRIPTION
## Overview
Implements #349 - Adds support for evaluating two MCP servers side-by-side in a single evaluation run, enabling direct A/B testing of different MCP implementations.

## Features
✨ **Comparison Mode**
- New `comparison_mode` configuration option
- Runs two MCP servers (`mcp_server_a` and `mcp_server_b`) on the same tasks
- Side-by-side results with delta metrics, improvement percentages, and unique wins
- Fully backward compatible with existing single-server configs

📊 **Rich Reporting**
- Comparison summary tables with color-coded results
- Per-task breakdown showing which server won each task
- Unique wins highlighting (tasks where only one server succeeded)
- Export support for JSON, YAML, and XML formats

## Example Usage

```yaml
# comparison-config.yaml
comparison_mode: true

mcp_server_a:
  name: "Task Queries"
  command: node
  args: [build/index.js]
  cwd: /path/to/task-queries

mcp_server_b:
  name: "Edge Identity"
  command: node
  args: [build/index.js]
  cwd: /path/to/edge-identity

benchmark: swe-bench-lite
sample_size: 10
```

```bash
mcpbr run -c comparison-config.yaml -o results.json
```

## Output Example

```
Side-by-Side MCP Server Comparison

┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ Metric            ┃ Task Queries ┃ Edge Identity┃ Δ (A - B)┃
┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ Resolved Tasks    │ 4/10         │ 2/10         │ +2       │
│ Resolution Rate   │ 40.0%        │ 20.0%        │ +100.0%  │
└───────────────────┴──────────────┴──────────────┴──────────┘

✓ Task Queries unique wins: 2 tasks
```

## Implementation Details

### Core Changes
- **`src/mcpbr/config.py`**: Added `comparison_mode`, `mcp_server_a`, `mcp_server_b` fields with Pydantic validation
- **`src/mcpbr/harness.py`**: 
  - Modified `run_single_task()` to execute both servers sequentially
  - Added `_aggregate_comparison_results()` for statistical aggregation
  - Updated result structures to include comparison data
- **`src/mcpbr/reporting.py`**: 
  - Implemented `print_comparison_summary()` with rich tables
  - Updated JSON/YAML/XML exports to handle comparison fields
- **`src/mcpbr/cli.py`**: Auto-detection and routing for comparison mode
- **`README.md`**: Quick start documentation
- **`docs/comparison-mode.md`**: Comprehensive usage guide

### Validation Logic
The configuration validates that:
- Comparison mode requires both `mcp_server_a` and `mcp_server_b`
- Single-server mode requires `mcp_server` (backward compatibility)
- Cannot mix comparison and single-server fields
- Clear error messages for misconfiguration

## Test Coverage

✅ **16 new tests, all passing**

- **Configuration Tests** (6 tests): Validation logic for comparison mode
- **Aggregation Tests** (5 tests): Statistical calculations and metrics
- **Reporting Tests** (3 tests): Console output formatting
- **Integration Tests** (2 tests): End-to-end comparison workflow with real API calls

```bash
# Test results
======================== 16 passed in 204.49s (0:03:24) ========================
```

## Documentation

- 📖 Comprehensive guide: `docs/comparison-mode.md`
- 📝 Quick start in `README.md`
- 💡 Use cases, troubleshooting, and best practices included

## Backward Compatibility

✅ **100% backward compatible**
- Existing single-server configs work unchanged
- No breaking changes to API or CLI
- Comparison mode is opt-in via `comparison_mode: true`

## Related Issues

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced side-by-side MCP server comparison for A/B testing, tool evaluation, and version comparison with metrics including resolution rates, performance deltas, and win categorization.

* **Documentation**
  * Added comprehensive comparison mode guide with configuration examples, use cases, best practices, limitations, and troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->