### PR TITLE
fix: Use upstream SWE-bench test commands for non-pytest projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Repository-aware test commands for non-pytest projects** (#365): Use upstream SWE-bench test command specs for sympy (`bin/test`), sphinx (`tox`), and other non-pytest repos instead of defaulting to `python -m pytest`
+- **Flaky Azure and trial mode tests**: Fixed tests that depended on local `~/.ssh/mcpbr_azure` state and updated assertions for multi-step dependency installation
 - **SEO improvements** for documentation site
   - Added robots.txt with sitemap reference
   - Added Open Graph and Twitter Card meta tags on all pages

--- a/src/mcpbr/swebench_test_specs.py
+++ b/src/mcpbr/swebench_test_specs.py
@@ -1,0 +1,33 @@
+"""Test command specs from upstream SWE-bench harness.
+
+Maps repositories to their correct test commands. mcpbr defaults to pytest
+for all non-Django projects, but some projects (e.g., sympy) use custom test
+runners that aren't pytest-compatible.
+
+Source: https://github.com/SWE-bench/SWE-bench/blob/main/swebench/harness/constants/python.py
+"""
+
+# Base test commands per framework (from upstream constants/python.py)
+TEST_PYTEST = "pytest --no-header -rA --tb=no -p no:cacheprovider"
+TEST_DJANGO = "./tests/runtests.py --verbosity 2 --settings=test_sqlite --parallel 1"
+TEST_SYMPY = "PYTHONWARNINGS='ignore::UserWarning,ignore::SyntaxWarning' bin/test -C --verbose"
+TEST_SPHINX = "tox --current-env -epy39 -v --"
+TEST_ASTROPY = "pytest -rA -vv -o console_output_style=classic --tb=no"
+TEST_SEABORN = "pytest --no-header -rA"
+
+# Repo → test command mapping
+# Only non-pytest entries need to be here — pytest is the default fallback.
+# Django is included for documentation but its existing handler takes precedence.
+REPO_TO_TEST_CMD: dict[str, str] = {
+    "sympy/sympy": TEST_SYMPY,
+    "django/django": TEST_DJANGO,
+    "sphinx-doc/sphinx": TEST_SPHINX,
+}
+
+
+def get_repo_test_command(repo: str) -> str | None:
+    """Look up the upstream test command for a repo.
+
+    Returns None if repo uses standard pytest (handled by existing logic).
+    """
+    return REPO_TO_TEST_CMD.get(repo)

--- a/tests/test_build_test_command.py
+++ b/tests/test_build_test_command.py
@@ -1,4 +1,4 @@
-"""Test Django test runner detection and command building."""
+"""Test test runner detection and command building."""
 
 from mcpbr.evaluation import _build_test_command
 
@@ -60,6 +60,14 @@ class TestDjangoRunner:
         assert "./runtests.py" in cmd
         assert "test_utils.tests" in cmd
 
+    def test_django_with_repo_param_still_uses_existing_handler(self):
+        """Django should use existing handler even with repo param."""
+        test = "test_utils.tests.TestClass.test_method"
+        cmd = _build_test_command(test, uses_prebuilt=True, repo="django/django")
+
+        assert "./runtests.py" in cmd
+        assert "test_utils.tests" in cmd
+
     def test_pytest_format_with_double_colon(self):
         """Test that pytest format with :: is not treated as Django."""
         test = "tests/test_file.py::TestClass::test_method"
@@ -102,3 +110,67 @@ class TestDjangoRunner:
         # Should use pytest since it's a path
         assert "python -m pytest" in cmd
         assert "runtests.py" not in cmd
+
+
+class TestSympyRunner:
+    """Test sympy test runner detection via upstream SWE-bench mapping."""
+
+    def test_sympy_uses_bin_test(self):
+        """Sympy should use bin/test instead of pytest."""
+        test = "sympy/core/tests/test_basic.py"
+        cmd = _build_test_command(test, uses_prebuilt=True, repo="sympy/sympy")
+
+        assert "bin/test -C --verbose" in cmd
+        assert "sympy/core/tests/test_basic.py" in cmd
+        assert "pytest" not in cmd
+        assert "conda activate testbed" in cmd
+
+    def test_sympy_without_prebuilt(self):
+        """Sympy bin/test should work without conda activation too."""
+        test = "sympy/core/tests/test_basic.py"
+        cmd = _build_test_command(test, uses_prebuilt=False, repo="sympy/sympy")
+
+        assert "bin/test -C --verbose" in cmd
+        assert "conda activate" not in cmd
+
+    def test_sympy_without_repo_falls_back_to_pytest(self):
+        """Without repo param, sympy tests fall back to pytest."""
+        test = "sympy/core/tests/test_basic.py"
+        cmd = _build_test_command(test, uses_prebuilt=True)
+
+        assert "python -m pytest" in cmd
+
+
+class TestRepoFallback:
+    """Test that unknown repos fall back to pytest."""
+
+    def test_unknown_repo_with_py_file(self):
+        test = "tests/test_foo.py"
+        cmd = _build_test_command(test, uses_prebuilt=True, repo="some/unknown-repo")
+
+        assert "python -m pytest" in cmd
+
+    def test_unknown_repo_with_double_colon(self):
+        test = "tests/test_foo.py::test_bar"
+        cmd = _build_test_command(test, uses_prebuilt=False, repo="some/unknown-repo")
+
+        assert "python -m pytest" in cmd
+
+    def test_none_repo_uses_pytest(self):
+        test = "tests/test_foo.py"
+        cmd = _build_test_command(test, uses_prebuilt=False, repo=None)
+
+        assert "python -m pytest" in cmd
+
+
+class TestSphinxRunner:
+    """Test sphinx test runner detection."""
+
+    def test_sphinx_uses_tox(self):
+        """Sphinx should use tox instead of pytest."""
+        test = "tests/test_build.py"
+        cmd = _build_test_command(test, uses_prebuilt=True, repo="sphinx-doc/sphinx")
+
+        assert "tox" in cmd
+        assert "tests/test_build.py" in cmd
+        assert "python -m pytest" not in cmd

--- a/tests/test_trial_mode.py
+++ b/tests/test_trial_mode.py
@@ -58,6 +58,7 @@ mcp_server:
             mock_config.output_dir = None
             mock_config.use_prebuilt_images = True
             mock_config.budget = None
+            mock_config.infrastructure = None
             mock_load_config.return_value = mock_config
 
             # Mock run_evaluation to capture the state_tracker parameter
@@ -106,6 +107,7 @@ mcp_server:
             mock_config.output_dir = None
             mock_config.use_prebuilt_images = True
             mock_config.budget = None
+            mock_config.infrastructure = None
             mock_load_config.return_value = mock_config
 
             # Mock run_evaluation
@@ -151,6 +153,7 @@ mcp_server:
             mock_config.output_dir = None
             mock_config.use_prebuilt_images = True
             mock_config.budget = None
+            mock_config.infrastructure = None
             mock_load_config.return_value = mock_config
 
             # Mock run_evaluation
@@ -201,6 +204,7 @@ mcp_server:
             mock_config.output_dir = None
             mock_config.use_prebuilt_images = True
             mock_config.budget = None
+            mock_config.infrastructure = None
             mock_load_config.return_value = mock_config
 
             # Mock run_evaluation
@@ -252,6 +256,7 @@ mcp_server:
             mock_config.output_dir = None
             mock_config.use_prebuilt_images = True
             mock_config.budget = None
+            mock_config.infrastructure = None
             mock_load_config.return_value = mock_config
 
             # Mock run_evaluation
@@ -304,6 +309,7 @@ mcp_server:
             mock_config.output_dir = None
             mock_config.use_prebuilt_images = True
             mock_config.budget = None
+            mock_config.infrastructure = None
             mock_load_config.return_value = mock_config
 
             # Mock run_evaluation


### PR DESCRIPTION
## Summary

- Sympy uses `bin/test`, not pytest. The eval harness sends all non-Django tests to `python -m pytest`, which fails with `No module named pytest` for sympy — all 75 sympy tasks score 0% on both sides.
- Adds a repo→test-command mapping from [upstream SWE-bench constants](https://github.com/SWE-bench/SWE-bench/blob/main/swebench/harness/constants/python.py) and checks it before falling back to pytest.
- Django's existing handler is preserved. Sphinx (`tox`) is also mapped.
- No behavior change for any other project — pytest remains the default.

## Test plan

- [x] All 18 unit tests pass (11 existing Django/pytest + 7 new sympy/sphinx/fallback)
- [ ] Rerun 75 sympy tasks with this fix to verify non-zero resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository-aware test command execution to select ecosystem-specific test runners instead of a single default.

* **Tests**
  * Expanded coverage for repo-specific command selection, fallback scenarios, and multiple framework runners.
  * Improved tests to isolate SSH key handling and trial-mode setups.

* **Bug Fixes**
  * Fixes to reduce flaky tests by isolating SSH key state and ensuring trial-mode infra is handled explicitly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->