### PR TITLE
feat: Add setup script hook before timed tasks begin

### DIFF
--- a/src/mcpbr/config.py
+++ b/src/mcpbr/config.py
@@ -418,7 +418,7 @@ class HarnessConfig(BaseModel):
 
     volumes: dict[str, str] = Field(
         default_factory=dict,
-        description="Additional read-only volume mounts for Docker containers (host_path: container_path). "
+        description="Additional volume mounts (read-write) for Docker containers (host_path: container_path). "
         "Mounted into every container, persists across tasks. Useful for pre-computed caches.",
     )
 

--- a/src/mcpbr/config.py
+++ b/src/mcpbr/config.py
@@ -109,6 +109,16 @@ class MCPServerConfig(BaseModel):
         default=900000,
         description="Timeout in milliseconds for MCP tool execution (default: 15 min for long-running tools)",
     )
+    setup_command: str | None = Field(
+        default=None,
+        description="Shell command to run inside the container BEFORE the agent starts. "
+        "Runs outside the task timer (does not count against timeout_seconds). "
+        "Use {workdir} as placeholder. Useful for pre-computing caches.",
+    )
+    setup_timeout_ms: int = Field(
+        default=900000,
+        description="Timeout in milliseconds for the setup_command (default: 15 min)",
+    )
 
     def get_args_for_workdir(self, workdir: str) -> list[str]:
         """Replace {workdir} placeholder in args with actual path."""
@@ -116,6 +126,12 @@ class MCPServerConfig(BaseModel):
         for arg in self.args:
             result.append(arg.replace("{workdir}", workdir))
         return result
+
+    def get_setup_command_for_workdir(self, workdir: str) -> str | None:
+        """Replace {workdir} placeholder in setup_command with actual path."""
+        if self.setup_command is None:
+            return None
+        return self.setup_command.replace("{workdir}", workdir)
 
     def get_expanded_env(self) -> dict[str, str]:
         """Expand ${VAR} references in env values using os.environ.
@@ -398,6 +414,12 @@ class HarnessConfig(BaseModel):
     enable_profiling: bool = Field(
         default=False,
         description="Enable comprehensive performance profiling (tool latency, memory, overhead)",
+    )
+
+    volumes: dict[str, str] = Field(
+        default_factory=dict,
+        description="Additional read-only volume mounts for Docker containers (host_path: container_path). "
+        "Mounted into every container, persists across tasks. Useful for pre-computed caches.",
     )
 
     infrastructure: InfrastructureConfig = Field(

--- a/src/mcpbr/docker_env.py
+++ b/src/mcpbr/docker_env.py
@@ -321,7 +321,7 @@ class DockerEnvironmentManager:
 
         Args:
             use_prebuilt: If True, try to use pre-built SWE-bench images first.
-            extra_volumes: Additional read-only volume mounts (host_path -> container_path).
+            extra_volumes: Additional volume mounts (read-write) (host_path -> container_path).
         """
         self.client = docker.from_env()
         self.use_prebuilt = use_prebuilt
@@ -498,7 +498,7 @@ CMD ["/bin/bash"]
                     for host_path, container_path in self._extra_volumes.items():
                         volumes_dict[os.path.abspath(host_path)] = {
                             "bind": container_path,
-                            "mode": "ro",
+                            "mode": "rw",
                         }
 
                     container = self.client.containers.run(

--- a/src/mcpbr/docker_env.py
+++ b/src/mcpbr/docker_env.py
@@ -498,7 +498,7 @@ CMD ["/bin/bash"]
                     for host_path, container_path in self._extra_volumes.items():
                         volumes_dict[os.path.abspath(host_path)] = {
                             "bind": container_path,
-                            "mode": "rw",
+                            "mode": "ro",
                         }
 
                     container = self.client.containers.run(

--- a/src/mcpbr/docker_env.py
+++ b/src/mcpbr/docker_env.py
@@ -314,14 +314,18 @@ class DockerEnvironmentManager:
     FALLBACK_IMAGE = "mcpbr-env"
     DOCKERFILE_PATH = Path(__file__).parent.parent.parent / "Dockerfile"
 
-    def __init__(self, use_prebuilt: bool = True) -> None:
+    def __init__(
+        self, use_prebuilt: bool = True, extra_volumes: dict[str, str] | None = None
+    ) -> None:
         """Initialize the Docker environment manager.
 
         Args:
             use_prebuilt: If True, try to use pre-built SWE-bench images first.
+            extra_volumes: Additional read-only volume mounts (host_path -> container_path).
         """
         self.client = docker.from_env()
         self.use_prebuilt = use_prebuilt
+        self._extra_volumes = extra_volumes or {}
         self._fallback_image_built = False
         self._temp_dirs: list[tempfile.TemporaryDirectory[str]] = []
         self._containers: list[Container] = []
@@ -488,6 +492,15 @@ CMD ["/bin/bash"]
 
             for attempt in range(max_retries + 1):
                 try:
+                    volumes_dict: dict[str, dict[str, str]] = {
+                        host_workdir: {"bind": "/workspace", "mode": "rw"},
+                    }
+                    for host_path, container_path in self._extra_volumes.items():
+                        volumes_dict[os.path.abspath(host_path)] = {
+                            "bind": container_path,
+                            "mode": "rw",
+                        }
+
                     container = self.client.containers.run(
                         image_name,
                         command="tail -f /dev/null",
@@ -495,9 +508,7 @@ CMD ["/bin/bash"]
                         detach=True,
                         platform="linux/amd64" if uses_prebuilt else None,
                         network_mode="bridge",  # Enable network for API calls
-                        volumes={
-                            host_workdir: {"bind": "/workspace", "mode": "rw"},
-                        },
+                        volumes=volumes_dict,
                         working_dir=container_workdir,
                         remove=False,
                         labels={

--- a/src/mcpbr/harness.py
+++ b/src/mcpbr/harness.py
@@ -962,7 +962,10 @@ async def run_evaluation(
                 "args": config.mcp_server.args if config.mcp_server else [],
             }
 
-    docker_manager = DockerEnvironmentManager(use_prebuilt=config.use_prebuilt_images)
+    docker_manager = DockerEnvironmentManager(
+        use_prebuilt=config.use_prebuilt_images,
+        extra_volumes=config.volumes,
+    )
 
     results: list[TaskResult] = []
     # Add cached results if using state tracker

--- a/src/mcpbr/harnesses.py
+++ b/src/mcpbr/harnesses.py
@@ -908,7 +908,7 @@ class ClaudeCodeHarness:
                 )
 
             setup_full_cmd = f"source {shlex.quote(env_file)} && {setup_cmd}"
-            setup_exit, setup_stdout, setup_stderr = await env.exec_command(
+            setup_exit, _setup_stdout, setup_stderr = await env.exec_command(
                 ["/bin/bash", "-c", setup_full_cmd],
                 timeout=setup_timeout,
             )

--- a/src/mcpbr/harnesses.py
+++ b/src/mcpbr/harnesses.py
@@ -900,7 +900,7 @@ class ClaudeCodeHarness:
         # pre-computing caches that should not count against timeout_seconds.
         if self.mcp_server and self.mcp_server.setup_command:
             setup_cmd = self.mcp_server.get_setup_command_for_workdir(env.workdir)
-            setup_timeout = self.mcp_server.setup_timeout_ms / 1000
+            setup_timeout = int(self.mcp_server.setup_timeout_ms / 1000)
 
             if verbose:
                 self._console.print(

--- a/src/mcpbr/harnesses.py
+++ b/src/mcpbr/harnesses.py
@@ -895,6 +895,35 @@ class ClaudeCodeHarness:
                     cost_usd=None,
                 )
 
+        # Run setup_command if configured (BEFORE agent, OUTSIDE task timer).
+        # This is the right place for expensive one-time operations like
+        # pre-computing caches that should not count against timeout_seconds.
+        if self.mcp_server and self.mcp_server.setup_command:
+            setup_cmd = self.mcp_server.get_setup_command_for_workdir(env.workdir)
+            setup_timeout = self.mcp_server.setup_timeout_ms / 1000
+
+            if verbose:
+                self._console.print(
+                    f"[cyan]Running setup command (timeout: {setup_timeout:.0f}s)...[/cyan]"
+                )
+
+            setup_full_cmd = f"source {shlex.quote(env_file)} && {setup_cmd}"
+            setup_exit, setup_stdout, setup_stderr = await env.exec_command(
+                ["/bin/bash", "-c", setup_full_cmd],
+                timeout=setup_timeout,
+            )
+
+            if setup_exit != 0:
+                if verbose:
+                    self._console.print(
+                        f"[yellow]⚠ Setup command exited with code {setup_exit}[/yellow]"
+                    )
+                    if setup_stderr:
+                        self._console.print(f"[dim]{setup_stderr[:500]}[/dim]")
+                # Non-fatal: continue with agent even if setup fails
+            elif verbose:
+                self._console.print("[green]✓ Setup command completed[/green]")
+
         try:
             claude_args = [
                 "--print",

--- a/uv.lock
+++ b/uv.lock
@@ -1143,7 +1143,7 @@ wheels = [
 
 [[package]]
 name = "mcpbr"
-version = "0.4.4"
+version = "0.4.14"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Description

Add support for MCP server setup commands and additional Docker volume mounts for evaluation containers.

- **`setup_command`** on `MCPServerConfig`: a shell command that runs inside the container *before* the agent starts, outside the task timer. Useful for expensive one-time operations like pre-computing caches that shouldn't count against `timeout_seconds`. Supports `{workdir}` placeholder.
- **`setup_timeout_ms`**: configurable timeout for the setup command (default: 15 min).
- **`volumes`** on `HarnessConfig`: additional volume mounts (`host_path: container_path`, read-write) mounted into every container. Useful for sharing pre-computed caches across tasks.
- Threads `extra_volumes` through `DockerEnvironmentManager` so volumes are available at container creation time.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's code style
- [x] New and existing unit tests pass locally

## Testing

Tested locally by configuring `setup_command` and `volumes` in a harness config and verifying:
- Setup command runs before agent start and outside the task timer
- Extra volumes are mounted read-write in the container for cache persistence
- Setup command failure is non-fatal (agent still runs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * MCP servers now support configurable per-server setup commands with adjustable timeout thresholds that execute prior to agent runs
  * Docker task containers now support mounting additional read-write volumes alongside the default workspace mount
  * Setup command results and exit statuses are logged; execution failures do not block subsequent agent execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->