### PR TITLE
fix: Prevent evaluation from hanging after task completion

### DIFF
--- a/src/mcpbr/docker_env.py
+++ b/src/mcpbr/docker_env.py
@@ -724,6 +724,12 @@ CMD ["/bin/bash"]
         if self in _active_managers:
             _active_managers.remove(self)
 
+        # Close the Docker client to release background threads/connections
+        try:
+            self.client.close()
+        except Exception:
+            pass
+
         if report and cleanup_report.total_removed > 0:
             logger.info(str(cleanup_report))
 

--- a/src/mcpbr/harness.py
+++ b/src/mcpbr/harness.py
@@ -1125,6 +1125,10 @@ async def run_evaluation(
                         # Wait for cancellation to complete
                         await asyncio.gather(*async_tasks, return_exceptions=True)
                         break
+
+                # Explicitly stop before exiting context to avoid
+                # deadlock between Rich's rendering thread and asyncio
+                progress.stop()
         else:
             # In non-verbose mode, show overall progress bar + per-task spinners
             with Progress(
@@ -1172,6 +1176,10 @@ async def run_evaluation(
                         # Wait for cancellation to complete
                         await asyncio.gather(*async_tasks, return_exceptions=True)
                         break
+
+                # Explicitly stop before exiting context to avoid
+                # deadlock between Rich's rendering thread and asyncio
+                progress.stop()
     finally:
         await docker_manager.cleanup_all()
 


### PR DESCRIPTION
## Summary
- Fix deadlock between Rich's Progress rendering thread and asyncio event loop by explicitly calling `progress.stop()` before exiting the context manager
- Close the Docker client in `cleanup_all_sync()` to release background threads/connections

## Root Cause
After all tasks complete, the `with Progress(...)` context manager's `__exit__` tries to join Rich's background rendering thread. That thread is waiting for the asyncio event loop to process something, but the loop is blocked waiting for `__exit__` to return — classic deadlock. The Docker client also holds background threads that prevent clean process exit.

## Test plan
- [x] Ruff passes
- [ ] Run a small evaluation and verify the process exits cleanly after results are printed

Fixes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of background connections and resources to prevent leaks
  * Fixed potential deadlock issues in the progress rendering system during application shutdown

<!-- end of auto-generated comment: release notes by coderabbit.ai -->