### PR TITLE
fix: Preserve agent metrics on eval timeout and prevent process hang

### DIFF
--- a/src/mcpbr/harness.py
+++ b/src/mcpbr/harness.py
@@ -1214,8 +1214,8 @@ async def run_evaluation(
             if executor is not None:
                 executor.shutdown(wait=False, cancel_futures=True)
                 loop._default_executor = None
-        except Exception:
-            pass
+        except RuntimeError as exc:
+            console.print(f"[yellow]Default executor shutdown skipped: {exc}[/yellow]")
 
     # Check if we're in comparison mode
     if config.comparison_mode:


### PR DESCRIPTION
## Summary
- **Zero-cost bug**: When a timeout/exception occurred during patch evaluation (after the agent already completed successfully), the outer error handler discarded all agent metrics and returned zeros. The agent's cost, tokens, and iterations are now preserved.
- **Hang bug**: `asyncio.run()` blocks indefinitely during cleanup because `executor.shutdown(wait=True)` waits on Docker SDK background threads that linger after `client.close()`. The default executor is now force-shutdown with `wait=False` after Docker cleanup.

## Test plan
- [x] 1741 tests pass, 0 regressions (14 pre-existing failures unrelated to changes)
- [ ] Run a local evaluation to verify process exits cleanly
- [ ] Run an evaluation with tasks that trigger eval timeouts to verify agent metrics are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling to preserve partial evaluation metrics when timeouts or exceptions occur
  * Enhanced cleanup process to prevent potential hanging during evaluation finalization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->