### PR TITLE
fix: Run setup_command outside the agent timer

### DIFF
--- a/src/mcpbr/harness.py
+++ b/src/mcpbr/harness.py
@@ -431,6 +431,12 @@ async def _run_mcp_evaluation(
             config, benchmark, verbosity, log_file, mcp_logs_dir, mcp_server_config
         )
 
+        # Run setup_command OUTSIDE the agent timer. This is for expensive
+        # one-time operations (e.g. pre-computing code graphs) that must not
+        # count against timeout_seconds.
+        if env and hasattr(agent, "run_setup_command"):
+            await agent.run_setup_command(env, verbose=verbose)
+
         # Sample memory before agent execution
         if profiler:
             profiler.sample_memory()

--- a/src/mcpbr/harness.py
+++ b/src/mcpbr/harness.py
@@ -435,7 +435,12 @@ async def _run_mcp_evaluation(
         # one-time operations (e.g. pre-computing code graphs) that must not
         # count against timeout_seconds.
         if env and hasattr(agent, "run_setup_command"):
-            await agent.run_setup_command(env, verbose=verbose)
+            try:
+                await agent.run_setup_command(env, verbose=verbose)
+            except asyncio.TimeoutError:
+                # Setup timeout is non-fatal – the agent still gets its
+                # full timeout budget even if setup didn't finish.
+                pass
 
         # Sample memory before agent execution
         if profiler:

--- a/src/mcpbr/harnesses.py
+++ b/src/mcpbr/harnesses.py
@@ -571,7 +571,7 @@ class ClaudeCodeHarness:
             return
 
         setup_cmd = self.mcp_server.get_setup_command_for_workdir(env.workdir)
-        setup_timeout = int(self.mcp_server.setup_timeout_ms / 1000)
+        setup_timeout = max(1, int(self.mcp_server.setup_timeout_ms / 1000))
 
         if verbose:
             self._console.print(

--- a/src/mcpbr/harnesses.py
+++ b/src/mcpbr/harnesses.py
@@ -555,6 +555,48 @@ class ClaudeCodeHarness:
         self.thinking_budget = thinking_budget
         self._console = Console()
 
+    async def run_setup_command(
+        self,
+        env: TaskEnvironment,
+        verbose: bool = False,
+    ) -> None:
+        """Run MCP server setup_command inside the container.
+
+        This MUST be called from the evaluation harness BEFORE the agent timer
+        starts (i.e. before asyncio.wait_for wraps agent.solve()). Expensive
+        operations like pre-computing code graphs happen here and should never
+        count against the task timeout.
+        """
+        if not self.mcp_server or not self.mcp_server.setup_command:
+            return
+
+        setup_cmd = self.mcp_server.get_setup_command_for_workdir(env.workdir)
+        setup_timeout = int(self.mcp_server.setup_timeout_ms / 1000)
+
+        if verbose:
+            self._console.print(
+                f"[cyan]Running setup command (timeout: {setup_timeout:.0f}s)...[/cyan]"
+            )
+
+        # Source the env file so setup_command has access to API keys etc.
+        env_file = "/tmp/.mcpbr_env.sh"
+        setup_full_cmd = f"source {shlex.quote(env_file)} && {setup_cmd}"
+        setup_exit, _setup_stdout, setup_stderr = await env.exec_command(
+            ["/bin/bash", "-c", setup_full_cmd],
+            timeout=setup_timeout,
+        )
+
+        if setup_exit != 0:
+            if verbose:
+                self._console.print(
+                    f"[yellow]⚠ Setup command exited with code {setup_exit}[/yellow]"
+                )
+                if setup_stderr:
+                    self._console.print(f"[dim]{setup_stderr[:500]}[/dim]")
+            # Non-fatal: continue with agent even if setup fails
+        elif verbose:
+            self._console.print("[green]✓ Setup command completed[/green]")
+
     async def solve(
         self,
         task: dict[str, Any],
@@ -895,34 +937,10 @@ class ClaudeCodeHarness:
                     cost_usd=None,
                 )
 
-        # Run setup_command if configured (BEFORE agent, OUTSIDE task timer).
-        # This is the right place for expensive one-time operations like
-        # pre-computing caches that should not count against timeout_seconds.
-        if self.mcp_server and self.mcp_server.setup_command:
-            setup_cmd = self.mcp_server.get_setup_command_for_workdir(env.workdir)
-            setup_timeout = int(self.mcp_server.setup_timeout_ms / 1000)
-
-            if verbose:
-                self._console.print(
-                    f"[cyan]Running setup command (timeout: {setup_timeout:.0f}s)...[/cyan]"
-                )
-
-            setup_full_cmd = f"source {shlex.quote(env_file)} && {setup_cmd}"
-            setup_exit, _setup_stdout, setup_stderr = await env.exec_command(
-                ["/bin/bash", "-c", setup_full_cmd],
-                timeout=setup_timeout,
-            )
-
-            if setup_exit != 0:
-                if verbose:
-                    self._console.print(
-                        f"[yellow]⚠ Setup command exited with code {setup_exit}[/yellow]"
-                    )
-                    if setup_stderr:
-                        self._console.print(f"[dim]{setup_stderr[:500]}[/dim]")
-                # Non-fatal: continue with agent even if setup fails
-            elif verbose:
-                self._console.print("[green]✓ Setup command completed[/green]")
+        # NOTE: setup_command is intentionally NOT run here. It must be called
+        # from the evaluation harness (harness.py) BEFORE the agent timer starts,
+        # using run_setup_command(). Running it here would include it in the
+        # asyncio.wait_for() timeout that wraps agent.solve().
 
         try:
             claude_args = [

--- a/tests/test_timeout_tracking.py
+++ b/tests/test_timeout_tracking.py
@@ -154,6 +154,9 @@ async def test_run_mcp_evaluation_timeout_fallback():
     ):
         result = await _run_mcp_evaluation(task, config, docker_manager, benchmark, verbose=False)
 
+    # Verify setup_command was called before the timer
+    mock_agent.run_setup_command.assert_awaited_once()
+
     # Verify timeout fallback sets status field
     assert result.get("status") == "timeout"
     assert result.get("error") == "Timeout"

--- a/tests/test_timeout_tracking.py
+++ b/tests/test_timeout_tracking.py
@@ -133,6 +133,7 @@ async def test_run_mcp_evaluation_timeout_fallback():
     config.timeout_seconds = 10
     config.model = "claude-sonnet-4-5-20250929"
     config.agent_harness = "claude-code"  # Required field
+    config.enable_profiling = False
 
     benchmark = Mock()
     benchmark.get_prompt_template.return_value = "Test prompt"
@@ -142,8 +143,15 @@ async def test_run_mcp_evaluation_timeout_fallback():
 
     task = {"instance_id": "test-task", "problem_statement": "Fix the bug"}
 
+    # Mock _create_mcp_agent so the returned agent has run_setup_command
+    mock_agent = Mock()
+    mock_agent.run_setup_command = AsyncMock()
+
     # Simulate timeout by raising asyncio.TimeoutError
-    with patch("mcpbr.harness.asyncio.wait_for", side_effect=asyncio.TimeoutError):
+    with (
+        patch("mcpbr.harness._create_mcp_agent", return_value=mock_agent),
+        patch("mcpbr.harness.asyncio.wait_for", side_effect=asyncio.TimeoutError),
+    ):
         result = await _run_mcp_evaluation(task, config, docker_manager, benchmark, verbose=False)
 
     # Verify timeout fallback sets status field


### PR DESCRIPTION
## Summary

- **Moved `setup_command` execution out of `_solve_in_docker()`** — it was running inside `asyncio.wait_for(timeout=config.timeout_seconds + 60)`, making pre-computation time count against the task timeout
- **Added `run_setup_command()` public method** to `ClaudeCodeHarness`, called from `_run_mcp_evaluation()` in `harness.py` BEFORE the timer wraps `agent.solve()`
- In SWE-bench evaluation, 222/273 MCP tasks timed out because graph generation (~5-15 min) ate into the 300s task budget

## Context

The `setup_command` config field was designed for expensive one-time operations (e.g. pre-computing code graphs) that should run BEFORE the agent timer starts. However, the actual execution happened inside `_solve_in_docker()` → `agent.solve()` → `asyncio.wait_for()`, defeating the purpose entirely.

## Test plan

- [x] All 30 existing harness tests pass
- [ ] Run 1-2 task evaluation to verify setup_command completes before timer starts
- [ ] Verify agent gets full timeout_seconds for actual work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Agent setup operations now execute independently of timeout limits, ensuring expensive one-time setup processes don't count against configured timeout constraints and won't cause unexpected failures.

* **Tests**
  * Enhanced timeout test coverage to properly exercise the agent setup flow with improved mocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->