### PR TITLE
fix: Pin mcpbr version in Azure provisioner

### DIFF
--- a/src/mcpbr/infrastructure/azure.py
+++ b/src/mcpbr/infrastructure/azure.py
@@ -17,6 +17,7 @@ except ImportError:
 
 from rich.console import Console
 
+from .. import __version__
 from ..config import HarnessConfig
 from .base import InfrastructureProvider
 
@@ -342,9 +343,9 @@ class AzureProvider(InfrastructureProvider):
         else:
             console.print("[green]✓ Node.js installed[/green]")
 
-        # Step 4: Install mcpbr
-        console.print("[cyan]Installing mcpbr...[/cyan]")
-        step4_cmd = f"python{py_ver} -m pip install mcpbr"
+        # Step 4: Install mcpbr (pin to local version)
+        console.print(f"[cyan]Installing mcpbr=={__version__}...[/cyan]")
+        step4_cmd = f"python{py_ver} -m pip install mcpbr=={__version__}"
         exit_code, _stdout, stderr = await self._ssh_exec(step4_cmd, timeout=300)
         if exit_code != 0:
             console.print(f"[yellow]⚠ mcpbr install issues: {stderr[:300]}[/yellow]")


### PR DESCRIPTION
## Summary

- Azure provisioner now installs `mcpbr==<local_version>` instead of latest PyPI version
- Prevents version mismatch between local runner and remote VM

## Context

The Azure provisioner ran `pip install mcpbr` (latest) on the remote VM regardless of what version was running locally. When frozen on `0.5.2`, the VM got `0.9.1` — a completely different version with different bugs. All 5 agent tasks completed but mcpbr hung during evaluation, wasting API costs and time.

## Changes

| File | Change |
|---|---|
| `src/mcpbr/infrastructure/azure.py` | Import `__version__`, pin install to `mcpbr=={__version__}` |

## Test plan

- [x] All 80 Azure infrastructure tests pass
- [x] Substring assertion `"pip install mcpbr"` still matches the pinned version string

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced installation reliability by pinning package versions to ensure consistent and deterministic deployments across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->