### PR TITLE
feat: v0.10.0 Integrations & Notifications milestone

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ docs = [
 ]
 openai = ["openai>=1.0.0"]
 gemini = ["google-generativeai>=0.3.0"]
+wandb = ["wandb>=0.16.0"]
 all-providers = ["openai>=1.0.0", "google-generativeai>=0.3.0"]
 # Note: terminal-bench package (pip install terminal-bench) can be installed
 # separately if HuggingFace dataset loading fails. It requires Python 3.12+.

--- a/src/mcpbr/badges.py
+++ b/src/mcpbr/badges.py
@@ -1,0 +1,75 @@
+"""Badge generation for evaluation results.
+
+Generates shields.io badge markdown from evaluation results.
+"""
+
+from typing import Any
+from urllib.parse import quote
+
+
+def generate_badge(label: str, value: str, color: str) -> str:
+    """Generate a shields.io badge markdown string.
+
+    Args:
+        label: Badge label (left side).
+        value: Badge value (right side).
+        color: Badge color (e.g. "brightgreen", "red", "blue").
+
+    Returns:
+        Markdown image string for the badge.
+    """
+    encoded_label = quote(label.replace("-", "--"))
+    encoded_value = quote(value.replace("-", "--"))
+    url = f"https://img.shields.io/badge/{encoded_label}-{encoded_value}-{color}"
+    return f"![{label}: {value}]({url})"
+
+
+def get_badge_color(rate: float) -> str:
+    """Get badge color based on resolution rate thresholds.
+
+    Args:
+        rate: Resolution rate (0.0 to 1.0).
+
+    Returns:
+        Color string for shields.io badge.
+    """
+    if rate >= 0.5:
+        return "brightgreen"
+    elif rate >= 0.3:
+        return "yellow"
+    else:
+        return "red"
+
+
+def generate_badges_from_results(results: dict[str, Any]) -> list[str]:
+    """Generate badge markdown list from evaluation results.
+
+    Args:
+        results: Evaluation results dictionary with metadata and summary.
+
+    Returns:
+        List of markdown badge strings.
+    """
+    config = results.get("metadata", {}).get("config", {})
+    mcp = results.get("summary", {}).get("mcp", {})
+
+    benchmark = config.get("benchmark", "unknown")
+    model = config.get("model", "unknown")
+    rate = mcp.get("rate", 0)
+    resolved = mcp.get("resolved", 0)
+    total = mcp.get("total", 0)
+    cost = mcp.get("total_cost", 0)
+
+    rate_color = get_badge_color(rate)
+
+    badges = [
+        generate_badge("Benchmark", benchmark, "blue"),
+        generate_badge("Model", model, "purple"),
+        generate_badge("Resolution Rate", f"{rate:.0%}", rate_color),
+        generate_badge("Resolved", f"{resolved}/{total}", rate_color),
+    ]
+
+    if cost:
+        badges.append(generate_badge("Cost", f"${cost:.2f}", "informational"))
+
+    return badges

--- a/src/mcpbr/benchmarks/adversarial.py
+++ b/src/mcpbr/benchmarks/adversarial.py
@@ -108,6 +108,13 @@ class AdversarialBenchmark:
         _ = filter_difficulty
 
         dataset = load_dataset(self.dataset, self.subset, split="train")
+
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = bool(task_ids) or bool(filter_category) or bool(filter_tags)
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         tasks = list(dataset)
 
         if task_ids:

--- a/src/mcpbr/benchmarks/agentbench.py
+++ b/src/mcpbr/benchmarks/agentbench.py
@@ -56,6 +56,13 @@ class AgentBenchBenchmark:
         _ = filter_tags
 
         dataset = load_dataset(self.dataset, split="test")
+
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = bool(task_ids) or bool(filter_category)
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         tasks = list(dataset)
 
         if filter_category:

--- a/src/mcpbr/benchmarks/aider_polyglot.py
+++ b/src/mcpbr/benchmarks/aider_polyglot.py
@@ -56,6 +56,13 @@ class AiderPolyglotBenchmark:
         _ = filter_tags
 
         dataset = load_dataset(self.dataset, split="test")
+
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = bool(task_ids) or bool(filter_category)
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         tasks = list(dataset)
 
         if filter_category:

--- a/src/mcpbr/benchmarks/apps.py
+++ b/src/mcpbr/benchmarks/apps.py
@@ -60,6 +60,13 @@ class APPSBenchmark:
         _ = filter_tags
 
         dataset = load_dataset(self.dataset, split=self.split)
+
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = bool(task_ids) or bool(filter_difficulty)
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         tasks = list(dataset)
 
         if filter_difficulty:

--- a/src/mcpbr/benchmarks/arc.py
+++ b/src/mcpbr/benchmarks/arc.py
@@ -66,6 +66,13 @@ class ARCBenchmark:
                 subset = "ARC-Challenge"
 
         dataset = load_dataset(self.dataset, subset, split="test")
+
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = bool(task_ids)
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         tasks = list(dataset)
 
         if task_ids:

--- a/src/mcpbr/benchmarks/bigcodebench.py
+++ b/src/mcpbr/benchmarks/bigcodebench.py
@@ -55,6 +55,13 @@ class BigCodeBenchBenchmark:
         _ = filter_difficulty
 
         dataset = load_dataset(self.dataset, split="v0.1.2")
+
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = bool(task_ids) or bool(filter_category) or bool(filter_tags)
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         tasks = list(dataset)
 
         if task_ids:

--- a/src/mcpbr/benchmarks/codecontests.py
+++ b/src/mcpbr/benchmarks/codecontests.py
@@ -56,6 +56,15 @@ class CodeContestsBenchmark:
         _ = filter_tags
 
         dataset = load_dataset(self.dataset, split="test")
+
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = (
+            bool(task_ids) or bool(filter_difficulty) or bool(filter_category) or bool(level)
+        )
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         tasks = list(dataset)
 
         if level is not None:

--- a/src/mcpbr/benchmarks/codereval.py
+++ b/src/mcpbr/benchmarks/codereval.py
@@ -55,6 +55,15 @@ class CoderEvalBenchmark:
         _ = filter_tags
 
         dataset = load_dataset(self.dataset, split="test")
+
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = (
+            bool(task_ids) or bool(filter_difficulty) or bool(filter_category) or bool(level)
+        )
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         tasks = list(dataset)
 
         if level is not None:

--- a/src/mcpbr/benchmarks/cybergym.py
+++ b/src/mcpbr/benchmarks/cybergym.py
@@ -59,6 +59,12 @@ class CyberGymBenchmark:
 
         dataset = load_dataset(self.dataset, split="tasks")
 
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = bool(task_ids) or bool(filter_difficulty) or bool(filter_category)
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         if task_ids:
             tasks = []
             for item in dataset:

--- a/src/mcpbr/benchmarks/gaia.py
+++ b/src/mcpbr/benchmarks/gaia.py
@@ -58,6 +58,13 @@ class GAIABenchmark:
         _ = filter_tags
 
         dataset = load_dataset(self.dataset, self.subset, split="validation")
+
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = bool(task_ids) or bool(filter_difficulty) or bool(level)
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         tasks = list(dataset)
 
         if level is not None:

--- a/src/mcpbr/benchmarks/gsm8k.py
+++ b/src/mcpbr/benchmarks/gsm8k.py
@@ -57,6 +57,12 @@ class GSM8KBenchmark:
         # GSM8K uses 'test' split for evaluation
         dataset = load_dataset(self.dataset, self.subset, split="test")
 
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = bool(task_ids)
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         if task_ids:
             # task_ids in GSM8K are indices (0, 1, 2, ...)
             task_id_set = set(task_ids)

--- a/src/mcpbr/benchmarks/hellaswag.py
+++ b/src/mcpbr/benchmarks/hellaswag.py
@@ -57,6 +57,13 @@ class HellaSwagBenchmark:
         _ = filter_tags
 
         dataset = load_dataset(self.dataset, split="validation")
+
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = bool(task_ids) or bool(filter_category)
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         tasks = list(dataset)
 
         if task_ids:

--- a/src/mcpbr/benchmarks/humaneval.py
+++ b/src/mcpbr/benchmarks/humaneval.py
@@ -58,6 +58,12 @@ class HumanEvalBenchmark:
         _ = filter_tags
         dataset = load_dataset(self.dataset, split="test")
 
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = bool(task_ids)
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         if task_ids:
             # Use set for O(1) lookup performance
             task_id_set = set(task_ids)

--- a/src/mcpbr/benchmarks/intercode.py
+++ b/src/mcpbr/benchmarks/intercode.py
@@ -58,6 +58,13 @@ class InterCodeBenchmark:
         _ = filter_tags
 
         dataset = load_dataset(self.dataset, split="test")
+
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = bool(task_ids) or bool(filter_category)
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         tasks = list(dataset)
 
         if filter_category:

--- a/src/mcpbr/benchmarks/leetcode.py
+++ b/src/mcpbr/benchmarks/leetcode.py
@@ -54,6 +54,15 @@ class LeetCodeBenchmark:
         _ = level
 
         dataset = load_dataset(self.dataset, split="train")
+
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = (
+            bool(task_ids) or bool(filter_difficulty) or bool(filter_category) or bool(filter_tags)
+        )
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         tasks = list(dataset)
 
         if filter_difficulty:

--- a/src/mcpbr/benchmarks/math_benchmark.py
+++ b/src/mcpbr/benchmarks/math_benchmark.py
@@ -56,6 +56,15 @@ class MATHBenchmark:
         _ = filter_tags
 
         dataset = load_dataset(self.dataset, "default", split="test")
+
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = (
+            bool(task_ids) or bool(filter_difficulty) or bool(filter_category) or bool(level)
+        )
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         tasks = list(dataset)
 
         if task_ids:

--- a/src/mcpbr/benchmarks/mbpp.py
+++ b/src/mcpbr/benchmarks/mbpp.py
@@ -60,6 +60,12 @@ class MBPPBenchmark:
 
         dataset = load_dataset(self.dataset, self.subset, split="test")
 
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = bool(task_ids)
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         if task_ids:
             task_id_set = set(task_ids)
             tasks = [item for item in dataset if str(item.get("task_id", "")) in task_id_set]

--- a/src/mcpbr/benchmarks/mcptoolbench.py
+++ b/src/mcpbr/benchmarks/mcptoolbench.py
@@ -56,6 +56,12 @@ class MCPToolBenchmark:
         """
         dataset = load_dataset(self.dataset, split="train")
 
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = bool(task_ids) or bool(filter_difficulty) or bool(filter_category)
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         if task_ids:
             # Use set for O(1) lookup performance
             task_id_set = set(task_ids)

--- a/src/mcpbr/benchmarks/mlagentbench.py
+++ b/src/mcpbr/benchmarks/mlagentbench.py
@@ -58,6 +58,13 @@ class MLAgentBenchBenchmark:
         _ = filter_tags
 
         dataset = load_dataset(self.dataset, split="test")
+
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = bool(task_ids) or bool(filter_category)
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         tasks = list(dataset)
 
         if filter_category:

--- a/src/mcpbr/benchmarks/mmmu.py
+++ b/src/mcpbr/benchmarks/mmmu.py
@@ -70,6 +70,12 @@ class MMMUBenchmark:
         # MMMU uses 'validation' split for evaluation (test labels are hidden)
         dataset = load_dataset(self.dataset, subset, split="validation")
 
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = bool(task_ids)
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         tasks = list(dataset)
 
         if task_ids:

--- a/src/mcpbr/benchmarks/repoqa.py
+++ b/src/mcpbr/benchmarks/repoqa.py
@@ -57,6 +57,13 @@ class RepoQABenchmark:
         _ = filter_tags
 
         dataset = load_dataset(self.dataset, split="test")
+
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = bool(task_ids) or bool(filter_category)
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         tasks = list(dataset)
 
         if filter_category:

--- a/src/mcpbr/benchmarks/swebench.py
+++ b/src/mcpbr/benchmarks/swebench.py
@@ -50,6 +50,12 @@ class SWEBenchmark:
         """
         dataset = load_dataset(self.dataset, split="test")
 
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = bool(task_ids) or bool(filter_category)
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         if task_ids:
             # Use set for O(1) lookup performance
             task_id_set = set(task_ids)

--- a/src/mcpbr/benchmarks/terminalbench.py
+++ b/src/mcpbr/benchmarks/terminalbench.py
@@ -56,6 +56,13 @@ class TerminalBenchBenchmark:
         _ = filter_tags
 
         dataset = load_dataset(self.dataset, split="test")
+
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = bool(task_ids) or bool(filter_difficulty) or bool(filter_category)
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         tasks = list(dataset)
 
         if filter_difficulty:

--- a/src/mcpbr/benchmarks/toolbench.py
+++ b/src/mcpbr/benchmarks/toolbench.py
@@ -56,6 +56,15 @@ class ToolBenchBenchmark:
         _ = level
 
         dataset = load_dataset(self.dataset, split="train")
+
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = (
+            bool(task_ids) or bool(filter_difficulty) or bool(filter_category) or bool(filter_tags)
+        )
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         tasks = list(dataset)
 
         if filter_difficulty:

--- a/src/mcpbr/benchmarks/truthfulqa.py
+++ b/src/mcpbr/benchmarks/truthfulqa.py
@@ -59,6 +59,13 @@ class TruthfulQABenchmark:
         _ = filter_tags
 
         dataset = load_dataset(self.dataset, self.subset, split="validation")
+
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = bool(task_ids) or bool(filter_category)
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         tasks = list(dataset)
 
         if task_ids:

--- a/src/mcpbr/benchmarks/webarena.py
+++ b/src/mcpbr/benchmarks/webarena.py
@@ -57,6 +57,13 @@ class WebArenaBenchmark:
         _ = filter_tags
 
         dataset = load_dataset(self.dataset, split="test")
+
+        # Optimization: use dataset.select() for early truncation when no
+        # filtering is needed — avoids materializing the entire dataset.
+        needs_full_scan = bool(task_ids) or bool(filter_category)
+        if not needs_full_scan and sample_size is not None and len(dataset) > sample_size:
+            dataset = dataset.select(range(sample_size))
+
         tasks = list(dataset)
 
         if filter_category:

--- a/src/mcpbr/cli.py
+++ b/src/mcpbr/cli.py
@@ -419,6 +419,33 @@ def main() -> None:
     is_flag=True,
     help="Enable comprehensive performance profiling (tool latency, memory, overhead)",
 )
+@click.option(
+    "--sampling-strategy",
+    type=click.Choice(["sequential", "random", "stratified"]),
+    default=None,
+    help="Sampling strategy for task selection.",
+)
+@click.option(
+    "--random-seed", type=int, default=None, help="Random seed for reproducible sampling."
+)
+@click.option(
+    "--stratify-field",
+    type=str,
+    default=None,
+    help="Field to stratify by (requires --sampling-strategy stratified).",
+)
+@click.option(
+    "--notify-slack", type=str, default=None, help="Slack webhook URL for completion notifications."
+)
+@click.option(
+    "--notify-discord",
+    type=str,
+    default=None,
+    help="Discord webhook URL for completion notifications.",
+)
+@click.option("--notify-email", type=str, default=None, help="Email config JSON string.")
+@click.option("--wandb/--no-wandb", default=None, help="Enable/disable W&B logging.")
+@click.option("--wandb-project", type=str, default=None, help="W&B project name.")
 def run(
     config_path: Path,
     model_override: str | None,
@@ -468,6 +495,14 @@ def run(
     filter_category: tuple[str, ...],
     filter_tags: tuple[str, ...],
     profile: bool,
+    sampling_strategy: str | None,
+    random_seed: int | None,
+    stratify_field: str | None,
+    notify_slack: str | None,
+    notify_discord: str | None,
+    notify_email: str | None,
+    wandb: bool | None,
+    wandb_project: str | None,
 ) -> None:
     """Run benchmark evaluation with the configured MCP server.
 
@@ -604,6 +639,23 @@ def run(
 
     if profile:
         config.enable_profiling = True
+
+    if sampling_strategy:
+        config.sampling_strategy = sampling_strategy
+    if random_seed is not None:
+        config.random_seed = random_seed
+    if stratify_field:
+        config.stratify_field = stratify_field
+    if notify_slack:
+        config.notify_slack_webhook = notify_slack
+    if notify_discord:
+        config.notify_discord_webhook = notify_discord
+    if notify_email:
+        config.notify_email = json.loads(notify_email)
+    if wandb is not None:
+        config.wandb_enabled = wandb
+    if wandb_project:
+        config.wandb_project = wandb_project
 
     # Determine output directory AFTER all CLI overrides are applied
     import shutil
@@ -906,6 +958,37 @@ To archive:
                 f"[yellow]weasyprint not installed — saved print-ready HTML to {html_fallback}[/yellow]"
             )
             console.print("[dim]Install weasyprint for PDF: pip install weasyprint[/dim]")
+
+    # W&B logging (v0.10.0)
+    if getattr(config, "wandb_enabled", False):
+        try:
+            # Build results_dict if not already built
+            if "results_dict" not in dir():
+                results_dict = (
+                    json.loads(json.dumps(results, default=str))
+                    if not isinstance(results, dict)
+                    else results
+                )
+                if hasattr(results, "to_dict"):
+                    results_dict = results.to_dict()
+                elif hasattr(results, "__dict__"):
+                    results_dict = {
+                        "metadata": results.metadata,
+                        "summary": results.summary,
+                        "tasks": [
+                            {
+                                "instance_id": t.instance_id,
+                                "mcp": t.mcp,
+                                "baseline": t.baseline,
+                            }
+                            for t in results.tasks
+                        ],
+                    }
+            from .wandb_integration import log_evaluation
+
+            log_evaluation(results_dict, project=getattr(config, "wandb_project", None))
+        except Exception as e:
+            click.echo(f"W&B logging failed: {e}", err=True)
 
     # Regression detection
     if baseline_results:
@@ -2774,6 +2857,107 @@ def tutorial_reset(tutorial_id):
     engine = TutorialEngine()
     engine.reset_tutorial(tutorial_id)
     console.print(f"[green]Reset progress for tutorial: {tutorial_id}[/green]")
+
+
+@main.command()
+@click.argument("results_file", type=click.Path(exists=True))
+def badge(results_file):
+    """Generate shields.io badge markdown from evaluation results."""
+    import json
+
+    from .badges import generate_badges_from_results
+
+    with open(results_file) as f:
+        results = json.load(f)
+    badges = generate_badges_from_results(results)
+    for b in badges:
+        click.echo(b)
+
+
+@main.command("export-metrics")
+@click.argument("results_file", type=click.Path(exists=True))
+@click.option("-o", "--output", type=click.Path(), default=None, help="Output file path.")
+def export_metrics_cmd(results_file, output):
+    """Export evaluation results as Prometheus metrics."""
+    import json
+    from pathlib import Path
+
+    from .prometheus import export_metrics
+
+    with open(results_file) as f:
+        results = json.load(f)
+    output_path = Path(output) if output else None
+    metrics = export_metrics(results, output_path=output_path)
+    if not output:
+        click.echo(metrics)
+    else:
+        click.echo(f"Metrics written to {output}")
+
+
+@main.command("run-status")
+def run_status_cmd():
+    """Show status of the current Azure VM run."""
+    import json
+    from pathlib import Path
+
+    from .infrastructure.azure import AzureProvider
+    from .run_state import RunState
+
+    state_path = Path.home() / ".mcpbr" / "run_state.json"
+    state = RunState.load(state_path)
+    if state is None:
+        click.echo("No active run found.")
+        return
+    status = AzureProvider.get_run_status(state)
+    click.echo(json.dumps(status, indent=2))
+
+
+@main.command("run-ssh")
+def run_ssh_cmd():
+    """Print SSH command for the current Azure VM run."""
+    from pathlib import Path
+
+    from .infrastructure.azure import AzureProvider
+    from .run_state import RunState
+
+    state_path = Path.home() / ".mcpbr" / "run_state.json"
+    state = RunState.load(state_path)
+    if state is None:
+        click.echo("No active run found.")
+        return
+    click.echo(AzureProvider.get_ssh_command(state))
+
+
+@main.command("run-stop")
+def run_stop_cmd():
+    """Stop and deallocate the current Azure VM run."""
+    from pathlib import Path
+
+    from .infrastructure.azure import AzureProvider
+    from .run_state import RunState
+
+    state_path = Path.home() / ".mcpbr" / "run_state.json"
+    state = RunState.load(state_path)
+    if state is None:
+        click.echo("No active run found.")
+        return
+    AzureProvider.stop_run(state)
+    click.echo(f"VM {state.vm_name} deallocated.")
+
+
+@main.command("run-logs")
+def run_logs_cmd():
+    """Show logs from the current run."""
+    from pathlib import Path
+
+    state_dir = Path.home() / ".mcpbr"
+    log_dir = state_dir / "logs"
+    if not log_dir.exists():
+        click.echo("No logs found.")
+        return
+    for log_file in sorted(log_dir.glob("*.log")):
+        click.echo(f"--- {log_file.name} ---")
+        click.echo(log_file.read_text())
 
 
 if __name__ == "__main__":

--- a/src/mcpbr/config.py
+++ b/src/mcpbr/config.py
@@ -511,6 +511,35 @@ class HarnessConfig(BaseModel):
         description="Path to a checkpoint file to resume evaluation from",
     )
 
+    # --- Sampling (v0.10.0) ---
+    sampling_strategy: str = Field(
+        default="sequential",
+        description="Sampling strategy: sequential, random, or stratified.",
+    )
+    random_seed: int | None = Field(
+        default=None,
+        description="Random seed for reproducible sampling (None = non-deterministic).",
+    )
+    stratify_field: str | None = Field(
+        default=None,
+        description="Field to stratify by when using stratified sampling.",
+    )
+
+    # --- Integrations (v0.10.0) ---
+    wandb_enabled: bool = Field(default=False, description="Enable W&B logging.")
+    wandb_project: str = Field(default="mcpbr", description="W&B project name.")
+
+    # --- Notifications (v0.10.0) ---
+    notify_slack_webhook: str | None = Field(
+        default=None, description="Slack webhook URL for completion notifications."
+    )
+    notify_discord_webhook: str | None = Field(
+        default=None, description="Discord webhook URL for completion notifications."
+    )
+    notify_email: dict[str, Any] | None = Field(
+        default=None, description="Email config dict (smtp_host, smtp_port, from_addr, to_addrs)."
+    )
+
     @field_validator("checkpoint_interval")
     @classmethod
     def validate_checkpoint_interval(cls, v: int) -> int:
@@ -561,6 +590,14 @@ class HarnessConfig(BaseModel):
         """Validate data_retention_days is positive if set."""
         if v is not None and v < 1:
             raise ValueError("data_retention_days must be at least 1")
+        return v
+
+    @field_validator("sampling_strategy")
+    @classmethod
+    def validate_sampling_strategy(cls, v: str) -> str:
+        allowed = {"sequential", "random", "stratified"}
+        if v not in allowed:
+            raise ValueError(f"sampling_strategy must be one of {allowed}, got '{v}'")
         return v
 
     @field_validator("provider")

--- a/src/mcpbr/config.py
+++ b/src/mcpbr/config.py
@@ -540,6 +540,13 @@ class HarnessConfig(BaseModel):
         default=None, description="Email config dict (smtp_host, smtp_port, from_addr, to_addrs)."
     )
 
+    @model_validator(mode="after")
+    def validate_stratified_sampling(self) -> "HarnessConfig":
+        """Ensure stratify_field is set when using stratified sampling."""
+        if self.sampling_strategy == "stratified" and not self.stratify_field:
+            raise ValueError("stratify_field is required when sampling_strategy is 'stratified'")
+        return self
+
     @field_validator("checkpoint_interval")
     @classmethod
     def validate_checkpoint_interval(cls, v: int) -> int:

--- a/src/mcpbr/infrastructure/azure.py
+++ b/src/mcpbr/infrastructure/azure.py
@@ -458,9 +458,6 @@ class AzureProvider(InfrastructureProvider):
         Returns:
             Dict with status information from az vm show.
         """
-        import json
-        import subprocess
-
         result = subprocess.run(
             [
                 "az",
@@ -476,6 +473,7 @@ class AzureProvider(InfrastructureProvider):
             ],
             capture_output=True,
             text=True,
+            timeout=30,
         )
         if result.returncode != 0:
             return {"error": result.stderr.strip(), "status": "unknown"}
@@ -500,8 +498,6 @@ class AzureProvider(InfrastructureProvider):
         Args:
             state: RunState with vm_name and resource_group.
         """
-        import subprocess
-
         subprocess.run(
             [
                 "az",
@@ -513,6 +509,7 @@ class AzureProvider(InfrastructureProvider):
                 state.resource_group,
             ],
             check=True,
+            timeout=300,
         )
 
     async def setup(self) -> None:

--- a/src/mcpbr/infrastructure/azure.py
+++ b/src/mcpbr/infrastructure/azure.py
@@ -18,6 +18,7 @@ except ImportError:
 from rich.console import Console
 
 from ..config import HarnessConfig
+from ..run_state import RunState
 from .base import InfrastructureProvider
 
 
@@ -447,6 +448,73 @@ class AzureProvider(InfrastructureProvider):
 
         console.print("[green]✓ Test task passed - setup validated[/green]")
 
+    @staticmethod
+    def get_run_status(state: "RunState") -> dict:
+        """Get the status of an Azure VM run.
+
+        Args:
+            state: RunState with vm_name and resource_group.
+
+        Returns:
+            Dict with status information from az vm show.
+        """
+        import json
+        import subprocess
+
+        result = subprocess.run(
+            [
+                "az",
+                "vm",
+                "show",
+                "--name",
+                state.vm_name,
+                "--resource-group",
+                state.resource_group,
+                "--show-details",
+                "-o",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            return {"error": result.stderr.strip(), "status": "unknown"}
+        return json.loads(result.stdout)
+
+    @staticmethod
+    def get_ssh_command(state: "RunState") -> str:
+        """Get SSH command to connect to Azure VM.
+
+        Args:
+            state: RunState with vm_ip and ssh_key_path.
+
+        Returns:
+            SSH command string.
+        """
+        return f"ssh -i {state.ssh_key_path} azureuser@{state.vm_ip}"
+
+    @staticmethod
+    def stop_run(state: "RunState") -> None:
+        """Stop and deallocate an Azure VM.
+
+        Args:
+            state: RunState with vm_name and resource_group.
+        """
+        import subprocess
+
+        subprocess.run(
+            [
+                "az",
+                "vm",
+                "deallocate",
+                "--name",
+                state.vm_name,
+                "--resource-group",
+                state.resource_group,
+            ],
+            check=True,
+        )
+
     async def setup(self) -> None:
         """Provision Azure VM and prepare for evaluation.
 
@@ -492,6 +560,23 @@ class AzureProvider(InfrastructureProvider):
 
             # Run test task
             await self._run_test_task()
+
+            # Save run state for monitoring
+            from datetime import datetime
+
+            run_state = RunState(
+                vm_name=self.vm_name,
+                vm_ip=self.vm_ip,
+                resource_group=self.azure_config.resource_group,
+                location=self.azure_config.location,
+                ssh_key_path=str(self.ssh_key_path),
+                config_path=str(self.config.config_path)
+                if hasattr(self.config, "config_path")
+                else "",
+                started_at=datetime.now().isoformat(),
+            )
+            state_dir = Path.home() / ".mcpbr"
+            run_state.save(state_dir / "run_state.json")
 
             console.print("[green]✓ Azure VM ready for evaluation[/green]")
 

--- a/src/mcpbr/notifications.py
+++ b/src/mcpbr/notifications.py
@@ -165,7 +165,7 @@ def send_email_notification(config: dict[str, Any], event: NotificationEvent) ->
 
     use_tls = config.get("use_tls", True)
 
-    with smtplib.SMTP(config["smtp_host"], config.get("smtp_port", 587)) as server:
+    with smtplib.SMTP(config["smtp_host"], config.get("smtp_port", 587), timeout=30) as server:
         if use_tls:
             server.starttls()
         smtp_user = config.get("smtp_user")

--- a/src/mcpbr/notifications.py
+++ b/src/mcpbr/notifications.py
@@ -1,0 +1,204 @@
+"""General notification system for evaluation events.
+
+Supports Slack, Discord, and Email notifications for completion and regression
+events. Failures are caught and logged — notifications never raise exceptions
+to the caller.
+"""
+
+import logging
+import smtplib
+from dataclasses import dataclass, field
+from email.mime.text import MIMEText
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class NotificationEvent:
+    """Event payload for notifications."""
+
+    event_type: str  # "completion" or "regression"
+    benchmark: str
+    model: str
+    total_tasks: int
+    resolved_tasks: int
+    resolution_rate: float
+    total_cost: float | None = None
+    runtime_seconds: float | None = None
+    regression_count: int | None = None
+    improvement_count: int | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+def send_slack_notification(webhook_url: str, event: NotificationEvent) -> None:
+    """Send notification to Slack via webhook.
+
+    Args:
+        webhook_url: Slack webhook URL.
+        event: Notification event payload.
+    """
+    color = "good" if event.resolution_rate >= 0.3 else "warning"
+    if event.event_type == "regression" and event.regression_count:
+        color = "danger"
+
+    title = f"mcpbr {event.event_type.title()}: {event.benchmark}"
+
+    fields = [
+        {"title": "Model", "value": event.model, "short": True},
+        {"title": "Resolution Rate", "value": f"{event.resolution_rate:.1%}", "short": True},
+        {
+            "title": "Tasks",
+            "value": f"{event.resolved_tasks}/{event.total_tasks}",
+            "short": True,
+        },
+    ]
+
+    if event.total_cost is not None:
+        fields.append({"title": "Cost", "value": f"${event.total_cost:.2f}", "short": True})
+
+    if event.runtime_seconds is not None:
+        mins = event.runtime_seconds / 60
+        fields.append({"title": "Runtime", "value": f"{mins:.1f} min", "short": True})
+
+    if event.regression_count is not None:
+        fields.append({"title": "Regressions", "value": str(event.regression_count), "short": True})
+    if event.improvement_count is not None:
+        fields.append(
+            {"title": "Improvements", "value": str(event.improvement_count), "short": True}
+        )
+
+    payload = {"attachments": [{"color": color, "title": title, "fields": fields}]}
+
+    response = requests.post(webhook_url, json=payload, timeout=10)
+    response.raise_for_status()
+
+
+def send_discord_notification(webhook_url: str, event: NotificationEvent) -> None:
+    """Send notification to Discord via webhook.
+
+    Args:
+        webhook_url: Discord webhook URL.
+        event: Notification event payload.
+    """
+    color = 0x00FF00 if event.resolution_rate >= 0.3 else 0xFFA500  # Green or Orange
+    if event.event_type == "regression" and event.regression_count:
+        color = 0xFF0000  # Red
+
+    title = f"mcpbr {event.event_type.title()}: {event.benchmark}"
+
+    description = (
+        f"**Model:** {event.model}\n"
+        f"**Resolution Rate:** {event.resolution_rate:.1%}\n"
+        f"**Tasks:** {event.resolved_tasks}/{event.total_tasks}\n"
+    )
+
+    if event.total_cost is not None:
+        description += f"**Cost:** ${event.total_cost:.2f}\n"
+
+    if event.runtime_seconds is not None:
+        mins = event.runtime_seconds / 60
+        description += f"**Runtime:** {mins:.1f} min\n"
+
+    embed_fields = []
+    if event.regression_count is not None:
+        embed_fields.append(
+            {"name": "Regressions", "value": str(event.regression_count), "inline": True}
+        )
+    if event.improvement_count is not None:
+        embed_fields.append(
+            {"name": "Improvements", "value": str(event.improvement_count), "inline": True}
+        )
+
+    payload = {
+        "embeds": [
+            {
+                "title": title,
+                "description": description,
+                "color": color,
+                "fields": embed_fields,
+            }
+        ]
+    }
+
+    response = requests.post(webhook_url, json=payload, timeout=10)
+    response.raise_for_status()
+
+
+def send_email_notification(config: dict[str, Any], event: NotificationEvent) -> None:
+    """Send notification via SMTP email.
+
+    Args:
+        config: Email configuration with smtp_host, smtp_port, from_email, to_email,
+                and optional smtp_user, smtp_password, use_tls.
+        event: Notification event payload.
+    """
+    subject = f"mcpbr {event.event_type.title()}: {event.benchmark} — {event.resolution_rate:.1%}"
+
+    body_lines = [
+        f"Benchmark: {event.benchmark}",
+        f"Model: {event.model}",
+        f"Resolution Rate: {event.resolution_rate:.1%}",
+        f"Tasks: {event.resolved_tasks}/{event.total_tasks}",
+    ]
+
+    if event.total_cost is not None:
+        body_lines.append(f"Cost: ${event.total_cost:.2f}")
+
+    if event.runtime_seconds is not None:
+        mins = event.runtime_seconds / 60
+        body_lines.append(f"Runtime: {mins:.1f} min")
+
+    if event.regression_count is not None:
+        body_lines.append(f"Regressions: {event.regression_count}")
+    if event.improvement_count is not None:
+        body_lines.append(f"Improvements: {event.improvement_count}")
+
+    body = "\n".join(body_lines)
+
+    msg = MIMEText(body)
+    msg["Subject"] = subject
+    msg["From"] = config["from_email"]
+    msg["To"] = config["to_email"]
+
+    use_tls = config.get("use_tls", True)
+
+    with smtplib.SMTP(config["smtp_host"], config.get("smtp_port", 587)) as server:
+        if use_tls:
+            server.starttls()
+        smtp_user = config.get("smtp_user")
+        smtp_password = config.get("smtp_password")
+        if smtp_user and smtp_password:
+            server.login(smtp_user, smtp_password)
+        server.send_message(msg)
+
+
+def dispatch_notification(config: dict[str, Any], event: NotificationEvent) -> None:
+    """Send notifications to all configured channels.
+
+    Failures are caught and logged — never raises.
+
+    Args:
+        config: Notification configuration with optional keys:
+                slack_webhook, discord_webhook, email (dict).
+        event: Notification event payload.
+    """
+    if config.get("slack_webhook"):
+        try:
+            send_slack_notification(config["slack_webhook"], event)
+        except Exception as e:
+            logger.warning("Failed to send Slack notification: %s", e)
+
+    if config.get("discord_webhook"):
+        try:
+            send_discord_notification(config["discord_webhook"], event)
+        except Exception as e:
+            logger.warning("Failed to send Discord notification: %s", e)
+
+    if config.get("email"):
+        try:
+            send_email_notification(config["email"], event)
+        except Exception as e:
+            logger.warning("Failed to send email notification: %s", e)

--- a/src/mcpbr/prometheus.py
+++ b/src/mcpbr/prometheus.py
@@ -1,0 +1,152 @@
+"""Prometheus metrics formatting and file export.
+
+Produces metrics in the Prometheus exposition format for scraping or file-based
+consumption.
+"""
+
+from pathlib import Path
+from typing import Any
+
+
+def format_metric(
+    name: str,
+    value: int | float,
+    labels: dict[str, str] | None = None,
+    help_text: str | None = None,
+    metric_type: str | None = None,
+) -> str:
+    """Format a single metric in Prometheus exposition format.
+
+    Args:
+        name: Metric name (e.g., 'mcpbr_resolution_rate').
+        value: Metric value.
+        labels: Optional label key-value pairs.
+        help_text: Optional HELP line text.
+        metric_type: Optional TYPE line (gauge, counter, histogram, summary).
+
+    Returns:
+        Formatted Prometheus metric string.
+    """
+    lines = []
+
+    if help_text:
+        lines.append(f"# HELP {name} {help_text}")
+
+    if metric_type:
+        lines.append(f"# TYPE {name} {metric_type}")
+
+    if labels:
+        label_str = ",".join(f'{k}="{v}"' for k, v in sorted(labels.items()))
+        lines.append(f"{name}{{{label_str}}} {value}")
+    else:
+        lines.append(f"{name} {value}")
+
+    return "\n".join(lines)
+
+
+def export_metrics(
+    results: dict[str, Any],
+    output_path: Path | None = None,
+) -> str:
+    """Export evaluation results as Prometheus metrics.
+
+    Args:
+        results: Evaluation results dictionary with metadata and summary.
+        output_path: Optional file path to write metrics to.
+
+    Returns:
+        Complete Prometheus exposition format string.
+    """
+    config = results.get("metadata", {}).get("config", {})
+    labels = {
+        "benchmark": config.get("benchmark", "unknown"),
+        "model": config.get("model", "unknown"),
+    }
+
+    mcp = results.get("summary", {}).get("mcp", {})
+    baseline = results.get("summary", {}).get("baseline", {})
+
+    lines = []
+
+    # MCP metrics
+    lines.append(
+        format_metric(
+            "mcpbr_resolution_rate",
+            mcp.get("rate", 0),
+            labels={**labels, "agent": "mcp"},
+            help_text="Task resolution rate",
+            metric_type="gauge",
+        )
+    )
+
+    lines.append(
+        format_metric(
+            "mcpbr_tasks_total",
+            mcp.get("total", 0),
+            labels={**labels, "agent": "mcp"},
+            help_text="Total tasks evaluated",
+            metric_type="gauge",
+        )
+    )
+
+    lines.append(
+        format_metric(
+            "mcpbr_tasks_resolved",
+            mcp.get("resolved", 0),
+            labels={**labels, "agent": "mcp"},
+            help_text="Tasks resolved successfully",
+            metric_type="gauge",
+        )
+    )
+
+    lines.append(
+        format_metric(
+            "mcpbr_total_cost",
+            mcp.get("total_cost", 0),
+            labels={**labels, "agent": "mcp"},
+            help_text="Total cost in USD",
+            metric_type="gauge",
+        )
+    )
+
+    # Baseline metrics (if present)
+    if baseline:
+        lines.append(
+            format_metric(
+                "mcpbr_resolution_rate",
+                baseline.get("rate", 0),
+                labels={**labels, "agent": "baseline"},
+            )
+        )
+
+        lines.append(
+            format_metric(
+                "mcpbr_tasks_total",
+                baseline.get("total", 0),
+                labels={**labels, "agent": "baseline"},
+            )
+        )
+
+        lines.append(
+            format_metric(
+                "mcpbr_tasks_resolved",
+                baseline.get("resolved", 0),
+                labels={**labels, "agent": "baseline"},
+            )
+        )
+
+        lines.append(
+            format_metric(
+                "mcpbr_total_cost",
+                baseline.get("total_cost", 0),
+                labels={**labels, "agent": "baseline"},
+            )
+        )
+
+    output = "\n\n".join(lines) + "\n"
+
+    if output_path:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(output)
+
+    return output

--- a/src/mcpbr/run_state.py
+++ b/src/mcpbr/run_state.py
@@ -1,0 +1,57 @@
+"""Run state persistence for Azure evaluation runs.
+
+Stores VM details so monitoring commands (status, logs, ssh, stop) can
+operate on running evaluations.
+"""
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class RunState:
+    """Persistent state for an evaluation run on Azure."""
+
+    vm_name: str
+    vm_ip: str
+    resource_group: str
+    location: str
+    ssh_key_path: str
+    config_path: str
+    started_at: str
+    status: str = "running"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dictionary."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "RunState":
+        """Deserialize from dictionary."""
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+    def save(self, path: Path) -> None:
+        """Save state to a JSON file.
+
+        Args:
+            path: File path to write state to.
+        """
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(self.to_dict(), indent=2))
+
+    @classmethod
+    def load(cls, path: Path) -> "RunState | None":
+        """Load state from a JSON file.
+
+        Args:
+            path: File path to read state from.
+
+        Returns:
+            RunState instance or None if file doesn't exist.
+        """
+        if not path.exists():
+            return None
+        data = json.loads(path.read_text())
+        return cls.from_dict(data)

--- a/src/mcpbr/run_state.py
+++ b/src/mcpbr/run_state.py
@@ -53,5 +53,8 @@ class RunState:
         """
         if not path.exists():
             return None
-        data = json.loads(path.read_text())
-        return cls.from_dict(data)
+        try:
+            data = json.loads(path.read_text())
+            return cls.from_dict(data)
+        except (json.JSONDecodeError, KeyError, TypeError):
+            return None

--- a/src/mcpbr/wandb_integration.py
+++ b/src/mcpbr/wandb_integration.py
@@ -63,33 +63,34 @@ def log_evaluation(
         tags=tags or [config.get("benchmark", ""), config.get("model", "")],
     )
 
-    # Log summary metrics
-    wandb.log(
-        {
-            "resolution_rate": summary.get("rate", 0),
-            "total_tasks": summary.get("total", 0),
-            "resolved_tasks": summary.get("resolved", 0),
-            "total_cost": summary.get("total_cost", 0),
-            "cost_per_task": summary.get("cost_per_task", 0),
-        }
-    )
+    try:
+        # Log summary metrics
+        wandb.log(
+            {
+                "resolution_rate": summary.get("rate", 0),
+                "total_tasks": summary.get("total", 0),
+                "resolved_tasks": summary.get("resolved", 0),
+                "total_cost": summary.get("total_cost", 0),
+                "cost_per_task": summary.get("cost_per_task", 0),
+            }
+        )
 
-    # Log per-task results as a W&B Table
-    if tasks:
-        columns = ["instance_id", "resolved", "cost", "error"]
-        table_data = []
-        for task in tasks:
-            mcp = task.get("mcp", {}) or {}
-            table_data.append(
-                [
-                    task.get("instance_id", ""),
-                    mcp.get("resolved", False),
-                    mcp.get("cost", 0),
-                    mcp.get("error", ""),
-                ]
-            )
+        # Log per-task results as a W&B Table
+        if tasks:
+            columns = ["instance_id", "resolved", "cost", "error"]
+            table_data = []
+            for task in tasks:
+                mcp = task.get("mcp", {}) or {}
+                table_data.append(
+                    [
+                        task.get("instance_id", ""),
+                        mcp.get("resolved", False),
+                        mcp.get("cost", 0),
+                        mcp.get("error", ""),
+                    ]
+                )
 
-        table = wandb.Table(columns=columns, data=table_data)
-        wandb.log({"task_results": table})
-
-    wandb.finish()
+            table = wandb.Table(columns=columns, data=table_data)
+            wandb.log({"task_results": table})
+    finally:
+        wandb.finish()

--- a/src/mcpbr/wandb_integration.py
+++ b/src/mcpbr/wandb_integration.py
@@ -1,0 +1,95 @@
+"""Weights & Biases integration for evaluation logging.
+
+Provides lazy import of wandb to avoid hard dependency. Falls back gracefully
+when wandb is not installed.
+"""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _get_wandb() -> Any | None:
+    """Lazily import wandb.
+
+    Returns:
+        The wandb module, or None if not installed.
+    """
+    try:
+        import wandb
+
+        return wandb
+    except ImportError:
+        return None
+
+
+def log_evaluation(
+    results: dict[str, Any],
+    project: str = "mcpbr",
+    entity: str | None = None,
+    tags: list[str] | None = None,
+) -> None:
+    """Log evaluation results to Weights & Biases.
+
+    Args:
+        results: Evaluation results dictionary with metadata, summary, and tasks.
+        project: W&B project name.
+        entity: W&B entity (team or user).
+        tags: Optional tags for the run.
+    """
+    wandb = _get_wandb()
+    if wandb is None:
+        logger.warning("wandb is not installed. Install with: pip install wandb")
+        return
+
+    config = results.get("metadata", {}).get("config", {})
+    summary = results.get("summary", {}).get("mcp", {})
+    tasks = results.get("tasks", [])
+
+    # Initialize W&B run
+    run_config = {
+        "benchmark": config.get("benchmark", "unknown"),
+        "model": config.get("model", "unknown"),
+        "provider": config.get("provider", "unknown"),
+        "sample_size": config.get("sample_size"),
+        "timeout_seconds": config.get("timeout_seconds"),
+    }
+
+    wandb.init(
+        project=project,
+        entity=entity,
+        config=run_config,
+        tags=tags or [config.get("benchmark", ""), config.get("model", "")],
+    )
+
+    # Log summary metrics
+    wandb.log(
+        {
+            "resolution_rate": summary.get("rate", 0),
+            "total_tasks": summary.get("total", 0),
+            "resolved_tasks": summary.get("resolved", 0),
+            "total_cost": summary.get("total_cost", 0),
+            "cost_per_task": summary.get("cost_per_task", 0),
+        }
+    )
+
+    # Log per-task results as a W&B Table
+    if tasks:
+        columns = ["instance_id", "resolved", "cost", "error"]
+        table_data = []
+        for task in tasks:
+            mcp = task.get("mcp", {}) or {}
+            table_data.append(
+                [
+                    task.get("instance_id", ""),
+                    mcp.get("resolved", False),
+                    mcp.get("cost", 0),
+                    mcp.get("error", ""),
+                ]
+            )
+
+        table = wandb.Table(columns=columns, data=table_data)
+        wandb.log({"task_results": table})
+
+    wandb.finish()

--- a/tests/test_adversarial_benchmark.py
+++ b/tests/test_adversarial_benchmark.py
@@ -80,6 +80,12 @@ def _create_mock_dataset(data: list[dict]) -> MagicMock:
     mock_ds = MagicMock()
     mock_ds.__iter__ = MagicMock(return_value=iter(data))
     mock_ds.__len__ = MagicMock(return_value=len(data))
+
+    def _select(indices):
+        selected = [data[i] for i in indices]
+        return _create_mock_dataset(selected)
+
+    mock_ds.select = MagicMock(side_effect=_select)
     return mock_ds
 
 

--- a/tests/test_azure_monitoring.py
+++ b/tests/test_azure_monitoring.py
@@ -1,0 +1,154 @@
+"""Tests for Azure monitoring — RunState, status, logs, ssh, stop commands."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from mcpbr.run_state import RunState
+
+
+class TestRunState:
+    """RunState persistence and serialization."""
+
+    def test_serializes_to_json(self):
+        state = RunState(
+            vm_name="mcpbr-eval-12345",
+            vm_ip="10.0.0.1",
+            resource_group="mcpbr-rg",
+            location="eastus",
+            ssh_key_path="/home/user/.ssh/mcpbr_azure",
+            config_path="/home/user/config.yaml",
+            started_at="2025-01-01T00:00:00Z",
+        )
+        data = state.to_dict()
+        assert data["vm_name"] == "mcpbr-eval-12345"
+        assert data["vm_ip"] == "10.0.0.1"
+        assert data["resource_group"] == "mcpbr-rg"
+
+    def test_deserializes_from_json(self):
+        data = {
+            "vm_name": "mcpbr-eval-12345",
+            "vm_ip": "10.0.0.1",
+            "resource_group": "mcpbr-rg",
+            "location": "eastus",
+            "ssh_key_path": "/home/user/.ssh/mcpbr_azure",
+            "config_path": "/home/user/config.yaml",
+            "started_at": "2025-01-01T00:00:00Z",
+        }
+        state = RunState.from_dict(data)
+        assert state.vm_name == "mcpbr-eval-12345"
+        assert state.vm_ip == "10.0.0.1"
+
+    def test_saves_to_disk(self):
+        state = RunState(
+            vm_name="mcpbr-eval-12345",
+            vm_ip="10.0.0.1",
+            resource_group="mcpbr-rg",
+            location="eastus",
+            ssh_key_path="/home/user/.ssh/mcpbr_azure",
+            config_path="/home/user/config.yaml",
+            started_at="2025-01-01T00:00:00Z",
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "run_state.json"
+            state.save(path)
+            assert path.exists()
+            data = json.loads(path.read_text())
+            assert data["vm_name"] == "mcpbr-eval-12345"
+
+    def test_loads_from_disk(self):
+        state = RunState(
+            vm_name="mcpbr-eval-12345",
+            vm_ip="10.0.0.1",
+            resource_group="mcpbr-rg",
+            location="eastus",
+            ssh_key_path="/home/user/.ssh/mcpbr_azure",
+            config_path="/home/user/config.yaml",
+            started_at="2025-01-01T00:00:00Z",
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "run_state.json"
+            state.save(path)
+            loaded = RunState.load(path)
+            assert loaded.vm_name == state.vm_name
+            assert loaded.vm_ip == state.vm_ip
+            assert loaded.resource_group == state.resource_group
+
+    def test_load_nonexistent_returns_none(self):
+        result = RunState.load(Path("/nonexistent/run_state.json"))
+        assert result is None
+
+
+class TestAzureMonitoring:
+    """Azure provider monitoring methods."""
+
+    @patch("subprocess.run")
+    def test_get_status_calls_az_vm_show(self, mock_run):
+        from mcpbr.infrastructure.azure import AzureProvider
+
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout='{"powerState": "VM running"}',
+        )
+
+        state = RunState(
+            vm_name="mcpbr-eval-12345",
+            vm_ip="10.0.0.1",
+            resource_group="mcpbr-rg",
+            location="eastus",
+            ssh_key_path="/home/user/.ssh/mcpbr_azure",
+            config_path="/home/user/config.yaml",
+            started_at="2025-01-01T00:00:00Z",
+        )
+
+        result = AzureProvider.get_run_status(state)
+        assert result["powerState"] == "VM running"
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "az" in cmd
+        assert "vm" in cmd
+        assert "show" in cmd
+
+    def test_get_ssh_command(self):
+        from mcpbr.infrastructure.azure import AzureProvider
+
+        state = RunState(
+            vm_name="mcpbr-eval-12345",
+            vm_ip="10.0.0.1",
+            resource_group="mcpbr-rg",
+            location="eastus",
+            ssh_key_path="/home/user/.ssh/mcpbr_azure",
+            config_path="/home/user/config.yaml",
+            started_at="2025-01-01T00:00:00Z",
+        )
+
+        ssh_cmd = AzureProvider.get_ssh_command(state)
+        assert "ssh" in ssh_cmd
+        assert "10.0.0.1" in ssh_cmd
+        assert "mcpbr_azure" in ssh_cmd
+
+    @patch("subprocess.run")
+    def test_stop_calls_az_vm_deallocate(self, mock_run):
+        from mcpbr.infrastructure.azure import AzureProvider
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+
+        state = RunState(
+            vm_name="mcpbr-eval-12345",
+            vm_ip="10.0.0.1",
+            resource_group="mcpbr-rg",
+            location="eastus",
+            ssh_key_path="/home/user/.ssh/mcpbr_azure",
+            config_path="/home/user/config.yaml",
+            started_at="2025-01-01T00:00:00Z",
+        )
+
+        AzureProvider.stop_run(state)
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "az" in cmd
+        assert "vm" in cmd
+        assert "deallocate" in cmd

--- a/tests/test_azure_monitoring.py
+++ b/tests/test_azure_monitoring.py
@@ -79,6 +79,12 @@ class TestRunState:
         result = RunState.load(Path("/nonexistent/run_state.json"))
         assert result is None
 
+    def test_load_corrupt_json_returns_none(self, tmp_path):
+        path = tmp_path / "corrupt.json"
+        path.write_text("not valid json{{{")
+        result = RunState.load(path)
+        assert result is None
+
 
 class TestAzureMonitoring:
     """Azure provider monitoring methods."""

--- a/tests/test_badges.py
+++ b/tests/test_badges.py
@@ -1,0 +1,95 @@
+"""Tests for badge generation."""
+
+import json
+import tempfile
+from pathlib import Path
+
+from mcpbr.badges import generate_badges_from_results, get_badge_color
+
+
+class TestBadgeColors:
+    """Badge color thresholds."""
+
+    def test_green_for_50_percent_or_above(self):
+        assert get_badge_color(0.5) == "brightgreen"
+        assert get_badge_color(0.75) == "brightgreen"
+        assert get_badge_color(1.0) == "brightgreen"
+
+    def test_yellow_for_30_to_50_percent(self):
+        assert get_badge_color(0.3) == "yellow"
+        assert get_badge_color(0.49) == "yellow"
+
+    def test_red_below_30_percent(self):
+        assert get_badge_color(0.0) == "red"
+        assert get_badge_color(0.1) == "red"
+        assert get_badge_color(0.29) == "red"
+
+
+class TestGenerateBadgesFromResults:
+    """generate_badges_from_results reads JSON and returns badge markdown list."""
+
+    def test_returns_badge_markdown(self):
+        results = {
+            "metadata": {"config": {"benchmark": "humaneval", "model": "claude-sonnet-4-5"}},
+            "summary": {
+                "mcp": {"resolved": 8, "total": 10, "rate": 0.8, "total_cost": 12.50},
+                "baseline": {"resolved": 3, "total": 10, "rate": 0.3, "total_cost": 5.00},
+            },
+        }
+        badges = generate_badges_from_results(results)
+        assert isinstance(badges, list)
+        assert len(badges) >= 2  # At least resolution rate and benchmark badges
+
+    def test_badge_uses_shields_io_format(self):
+        results = {
+            "metadata": {"config": {"benchmark": "humaneval", "model": "claude-sonnet-4-5"}},
+            "summary": {
+                "mcp": {"resolved": 8, "total": 10, "rate": 0.8, "total_cost": 12.50},
+                "baseline": {"resolved": 3, "total": 10, "rate": 0.3, "total_cost": 5.00},
+            },
+        }
+        badges = generate_badges_from_results(results)
+        for badge in badges:
+            assert "img.shields.io/badge" in badge
+            assert badge.startswith("![")
+
+    def test_badge_color_reflects_rate(self):
+        results = {
+            "metadata": {"config": {"benchmark": "humaneval", "model": "claude-sonnet-4-5"}},
+            "summary": {
+                "mcp": {"resolved": 8, "total": 10, "rate": 0.8, "total_cost": 12.50},
+                "baseline": {"resolved": 3, "total": 10, "rate": 0.3, "total_cost": 5.00},
+            },
+        }
+        badges = generate_badges_from_results(results)
+        # High resolution (80%) should have green badge
+        resolution_badge = [b for b in badges if "Resolution" in b or "80" in b][0]
+        assert "brightgreen" in resolution_badge
+
+    def test_reads_from_json_file(self):
+        results = {
+            "metadata": {"config": {"benchmark": "humaneval", "model": "claude-sonnet-4-5"}},
+            "summary": {
+                "mcp": {"resolved": 8, "total": 10, "rate": 0.8, "total_cost": 12.50},
+                "baseline": {"resolved": 3, "total": 10, "rate": 0.3, "total_cost": 5.00},
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "results.json"
+            path.write_text(json.dumps(results))
+
+            data = json.loads(path.read_text())
+            badges = generate_badges_from_results(data)
+            assert len(badges) >= 2
+
+    def test_includes_benchmark_badge(self):
+        results = {
+            "metadata": {"config": {"benchmark": "humaneval", "model": "claude-sonnet-4-5"}},
+            "summary": {
+                "mcp": {"resolved": 8, "total": 10, "rate": 0.8, "total_cost": 12.50},
+                "baseline": {"resolved": 3, "total": 10, "rate": 0.3, "total_cost": 5.00},
+            },
+        }
+        badges = generate_badges_from_results(results)
+        benchmark_badges = [b for b in badges if "humaneval" in b.lower()]
+        assert len(benchmark_badges) >= 1

--- a/tests/test_benchmark_loading_perf.py
+++ b/tests/test_benchmark_loading_perf.py
@@ -1,0 +1,109 @@
+"""Tests for dataset loading performance — dataset.select() optimization."""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestDatasetSelectOptimization:
+    """Verify benchmarks use dataset.select(range(n)) when sample_size is set."""
+
+    def _make_mock_dataset(self, size=100, id_field="instance_id"):
+        """Create a mock HuggingFace dataset with select() support."""
+        items = [
+            {
+                id_field: f"task-{i}",
+                "instance_id": f"task-{i}",
+                "task_id": f"HumanEval/{i}",
+                "text": f"problem {i}",
+                "prompt": f"def f{i}():",
+                "canonical_solution": "pass",
+                "test": "",
+                "entry_point": f"f{i}",
+                "problem_statement": f"problem {i}",
+                "repo": "test/repo",
+                "base_commit": "abc123",
+            }
+            for i in range(size)
+        ]
+        dataset = MagicMock()
+        dataset.__len__ = MagicMock(return_value=size)
+        dataset.__iter__ = MagicMock(return_value=iter(items))
+
+        def select_fn(indices):
+            selected = [items[i] for i in indices]
+            sub_ds = MagicMock()
+            sub_ds.__iter__ = MagicMock(return_value=iter(selected))
+            sub_ds.__len__ = MagicMock(return_value=len(selected))
+            return sub_ds
+
+        dataset.select = MagicMock(side_effect=select_fn)
+        return dataset
+
+    @patch("mcpbr.benchmarks.swebench.load_dataset")
+    def test_swebench_uses_select_with_sample_size(self, mock_load):
+        """SWE-bench should use dataset.select() when sample_size is set."""
+        from mcpbr.benchmarks.swebench import SWEBenchmark
+
+        mock_ds = self._make_mock_dataset(100)
+        mock_load.return_value = mock_ds
+
+        benchmark = SWEBenchmark()
+        tasks = benchmark.load_tasks(sample_size=5)
+
+        # select() should have been called
+        mock_ds.select.assert_called_once_with(range(5))
+        assert len(tasks) == 5
+
+    @patch("mcpbr.benchmarks.swebench.load_dataset")
+    def test_swebench_full_load_without_sample_size(self, mock_load):
+        """SWE-bench should NOT use select() when sample_size is None."""
+        from mcpbr.benchmarks.swebench import SWEBenchmark
+
+        mock_ds = self._make_mock_dataset(100)
+        mock_load.return_value = mock_ds
+
+        benchmark = SWEBenchmark()
+        benchmark.load_tasks(sample_size=None)
+
+        # select() should NOT have been called
+        mock_ds.select.assert_not_called()
+
+    @patch("mcpbr.benchmarks.swebench.load_dataset")
+    def test_swebench_full_load_with_task_ids(self, mock_load):
+        """When task_ids are provided, should load all then filter by ID."""
+        from mcpbr.benchmarks.swebench import SWEBenchmark
+
+        mock_ds = self._make_mock_dataset(100)
+        mock_load.return_value = mock_ds
+
+        benchmark = SWEBenchmark()
+        benchmark.load_tasks(sample_size=5, task_ids=["task-0", "task-1"])
+
+        # With task_ids, select() should NOT be called — we need full scan for ID matching
+        mock_ds.select.assert_not_called()
+
+    @patch("mcpbr.benchmarks.humaneval.load_dataset")
+    def test_humaneval_uses_select_with_sample_size(self, mock_load):
+        """HumanEval should use dataset.select() when sample_size is set."""
+        from mcpbr.benchmarks.humaneval import HumanEvalBenchmark
+
+        mock_ds = self._make_mock_dataset(164)
+        mock_load.return_value = mock_ds
+
+        benchmark = HumanEvalBenchmark()
+        tasks = benchmark.load_tasks(sample_size=3)
+
+        mock_ds.select.assert_called_once_with(range(3))
+        assert len(tasks) == 3
+
+    @patch("mcpbr.benchmarks.humaneval.load_dataset")
+    def test_humaneval_full_load_without_sample_size(self, mock_load):
+        """HumanEval should NOT use select() when sample_size is None."""
+        from mcpbr.benchmarks.humaneval import HumanEvalBenchmark
+
+        mock_ds = self._make_mock_dataset(164)
+        mock_load.return_value = mock_ds
+
+        benchmark = HumanEvalBenchmark()
+        benchmark.load_tasks(sample_size=None)
+
+        mock_ds.select.assert_not_called()

--- a/tests/test_mcptoolbench_benchmark.py
+++ b/tests/test_mcptoolbench_benchmark.py
@@ -53,6 +53,12 @@ def _mock_dataset(tasks: list[dict[str, Any]]) -> MagicMock:
     dataset = MagicMock()
     dataset.__iter__ = MagicMock(return_value=iter(tasks))
     dataset.__len__ = MagicMock(return_value=len(tasks))
+
+    def _select(indices):
+        selected = [tasks[i] for i in indices]
+        return _mock_dataset(selected)
+
+    dataset.select = MagicMock(side_effect=_select)
     return dataset
 
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,216 @@
+"""Tests for the general notifications module."""
+
+from unittest.mock import MagicMock, patch
+
+from mcpbr.notifications import (
+    NotificationEvent,
+    dispatch_notification,
+    send_discord_notification,
+    send_email_notification,
+    send_slack_notification,
+)
+
+
+class TestNotificationEvent:
+    """NotificationEvent dataclass."""
+
+    def test_completion_event(self):
+        event = NotificationEvent(
+            event_type="completion",
+            benchmark="swe-bench-verified",
+            model="claude-sonnet-4-5-20250929",
+            total_tasks=10,
+            resolved_tasks=6,
+            resolution_rate=0.6,
+            total_cost=12.50,
+            runtime_seconds=3600.0,
+        )
+        assert event.event_type == "completion"
+        assert event.resolution_rate == 0.6
+
+    def test_regression_event(self):
+        event = NotificationEvent(
+            event_type="regression",
+            benchmark="swe-bench-verified",
+            model="claude-sonnet-4-5-20250929",
+            total_tasks=10,
+            resolved_tasks=6,
+            resolution_rate=0.6,
+            regression_count=3,
+            improvement_count=1,
+        )
+        assert event.event_type == "regression"
+        assert event.regression_count == 3
+
+
+class TestSlackNotification:
+    """send_slack_notification POSTs correct payload."""
+
+    @patch("mcpbr.notifications.requests.post")
+    def test_posts_to_webhook(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        event = NotificationEvent(
+            event_type="completion",
+            benchmark="humaneval",
+            model="claude-sonnet-4-5-20250929",
+            total_tasks=10,
+            resolved_tasks=8,
+            resolution_rate=0.8,
+        )
+        send_slack_notification("https://hooks.slack.com/test", event)
+
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        payload = call_args.kwargs.get("json") or call_args[1].get("json")
+        assert "attachments" in payload
+        assert payload["attachments"][0]["color"] == "good"
+
+    @patch("mcpbr.notifications.requests.post")
+    def test_low_resolution_shows_warning_color(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        event = NotificationEvent(
+            event_type="completion",
+            benchmark="humaneval",
+            model="claude-sonnet-4-5-20250929",
+            total_tasks=10,
+            resolved_tasks=1,
+            resolution_rate=0.1,
+        )
+        send_slack_notification("https://hooks.slack.com/test", event)
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert payload["attachments"][0]["color"] == "warning"
+
+
+class TestDiscordNotification:
+    """send_discord_notification POSTs correct embed."""
+
+    @patch("mcpbr.notifications.requests.post")
+    def test_posts_embed(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        event = NotificationEvent(
+            event_type="completion",
+            benchmark="humaneval",
+            model="claude-sonnet-4-5-20250929",
+            total_tasks=10,
+            resolved_tasks=8,
+            resolution_rate=0.8,
+        )
+        send_discord_notification("https://discord.com/api/webhooks/test", event)
+
+        mock_post.assert_called_once()
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert "embeds" in payload
+        # Green for good performance
+        assert payload["embeds"][0]["color"] == 0x00FF00
+
+
+class TestEmailNotification:
+    """send_email_notification sends via SMTP."""
+
+    @patch("mcpbr.notifications.smtplib.SMTP")
+    def test_sends_email(self, mock_smtp_class):
+        mock_smtp = MagicMock()
+        mock_smtp_class.return_value.__enter__ = MagicMock(return_value=mock_smtp)
+        mock_smtp_class.return_value.__exit__ = MagicMock(return_value=False)
+
+        event = NotificationEvent(
+            event_type="completion",
+            benchmark="humaneval",
+            model="claude-sonnet-4-5-20250929",
+            total_tasks=10,
+            resolved_tasks=8,
+            resolution_rate=0.8,
+        )
+        email_config = {
+            "smtp_host": "smtp.example.com",
+            "smtp_port": 587,
+            "from_email": "test@example.com",
+            "to_email": "admin@example.com",
+        }
+        send_email_notification(email_config, event)
+
+        mock_smtp.send_message.assert_called_once()
+
+
+class TestDispatchNotification:
+    """dispatch_notification sends to all configured channels."""
+
+    @patch("mcpbr.notifications.send_slack_notification")
+    @patch("mcpbr.notifications.send_discord_notification")
+    @patch("mcpbr.notifications.send_email_notification")
+    def test_dispatches_to_all_channels(self, mock_email, mock_discord, mock_slack):
+        event = NotificationEvent(
+            event_type="completion",
+            benchmark="humaneval",
+            model="claude-sonnet-4-5-20250929",
+            total_tasks=10,
+            resolved_tasks=8,
+            resolution_rate=0.8,
+        )
+        config = {
+            "slack_webhook": "https://hooks.slack.com/test",
+            "discord_webhook": "https://discord.com/api/webhooks/test",
+            "email": {
+                "smtp_host": "smtp.example.com",
+                "smtp_port": 587,
+                "from_email": "test@example.com",
+                "to_email": "admin@example.com",
+            },
+        }
+        dispatch_notification(config, event)
+
+        mock_slack.assert_called_once()
+        mock_discord.assert_called_once()
+        mock_email.assert_called_once()
+
+    @patch("mcpbr.notifications.send_slack_notification")
+    def test_dispatches_slack_only(self, mock_slack):
+        event = NotificationEvent(
+            event_type="completion",
+            benchmark="humaneval",
+            model="claude-sonnet-4-5-20250929",
+            total_tasks=10,
+            resolved_tasks=8,
+            resolution_rate=0.8,
+        )
+        config = {"slack_webhook": "https://hooks.slack.com/test"}
+        dispatch_notification(config, event)
+
+        mock_slack.assert_called_once()
+
+    @patch("mcpbr.notifications.send_slack_notification")
+    def test_failure_caught_and_logged(self, mock_slack):
+        """Failures are caught and logged, never raise."""
+        mock_slack.side_effect = Exception("network error")
+
+        event = NotificationEvent(
+            event_type="completion",
+            benchmark="humaneval",
+            model="claude-sonnet-4-5-20250929",
+            total_tasks=10,
+            resolved_tasks=8,
+            resolution_rate=0.8,
+        )
+        config = {"slack_webhook": "https://hooks.slack.com/test"}
+
+        # Should NOT raise
+        dispatch_notification(config, event)
+
+    def test_empty_config_does_nothing(self):
+        event = NotificationEvent(
+            event_type="completion",
+            benchmark="humaneval",
+            model="claude-sonnet-4-5-20250929",
+            total_tasks=10,
+            resolved_tasks=8,
+            resolution_rate=0.8,
+        )
+        # Should not raise
+        dispatch_notification({}, event)

--- a/tests/test_prometheus.py
+++ b/tests/test_prometheus.py
@@ -1,0 +1,115 @@
+"""Tests for Prometheus metrics export."""
+
+import tempfile
+from pathlib import Path
+
+from mcpbr.prometheus import export_metrics, format_metric
+
+
+class TestFormatMetric:
+    """format_metric() produces valid Prometheus exposition lines."""
+
+    def test_basic_metric(self):
+        line = format_metric("mcpbr_resolution_rate", 0.75)
+        assert line == "mcpbr_resolution_rate 0.75"
+
+    def test_metric_with_labels(self):
+        line = format_metric(
+            "mcpbr_resolution_rate",
+            0.75,
+            labels={"benchmark": "humaneval", "model": "claude-sonnet-4-5"},
+        )
+        assert "mcpbr_resolution_rate{" in line
+        assert 'benchmark="humaneval"' in line
+        assert 'model="claude-sonnet-4-5"' in line
+        assert "} 0.75" in line
+
+    def test_metric_with_help(self):
+        line = format_metric("mcpbr_total_cost", 12.5, help_text="Total cost in USD")
+        assert "# HELP mcpbr_total_cost Total cost in USD" in line
+        assert "mcpbr_total_cost 12.5" in line
+
+    def test_metric_with_type(self):
+        line = format_metric("mcpbr_total_cost", 12.5, metric_type="gauge")
+        assert "# TYPE mcpbr_total_cost gauge" in line
+
+    def test_integer_value(self):
+        line = format_metric("mcpbr_tasks_total", 42)
+        assert "mcpbr_tasks_total 42" in line
+
+
+class TestExportMetrics:
+    """export_metrics() includes resolution_rate, cost, runtime with labels."""
+
+    def test_includes_resolution_rate(self):
+        results = {
+            "metadata": {"config": {"benchmark": "humaneval", "model": "claude-sonnet-4-5"}},
+            "summary": {
+                "mcp": {
+                    "resolved": 8,
+                    "total": 10,
+                    "rate": 0.8,
+                    "total_cost": 12.50,
+                },
+                "baseline": {
+                    "resolved": 3,
+                    "total": 10,
+                    "rate": 0.3,
+                    "total_cost": 5.00,
+                },
+            },
+        }
+        output = export_metrics(results)
+        assert "mcpbr_resolution_rate" in output
+        assert "0.8" in output
+
+    def test_includes_cost(self):
+        results = {
+            "metadata": {"config": {"benchmark": "humaneval", "model": "claude-sonnet-4-5"}},
+            "summary": {
+                "mcp": {"resolved": 8, "total": 10, "rate": 0.8, "total_cost": 12.50},
+                "baseline": {"resolved": 3, "total": 10, "rate": 0.3, "total_cost": 5.00},
+            },
+        }
+        output = export_metrics(results)
+        assert "mcpbr_total_cost" in output
+        assert "12.5" in output
+
+    def test_includes_task_counts(self):
+        results = {
+            "metadata": {"config": {"benchmark": "humaneval", "model": "claude-sonnet-4-5"}},
+            "summary": {
+                "mcp": {"resolved": 8, "total": 10, "rate": 0.8, "total_cost": 12.50},
+                "baseline": {"resolved": 3, "total": 10, "rate": 0.3, "total_cost": 5.00},
+            },
+        }
+        output = export_metrics(results)
+        assert "mcpbr_tasks_total" in output
+        assert "mcpbr_tasks_resolved" in output
+
+    def test_file_export(self):
+        results = {
+            "metadata": {"config": {"benchmark": "humaneval", "model": "claude-sonnet-4-5"}},
+            "summary": {
+                "mcp": {"resolved": 8, "total": 10, "rate": 0.8, "total_cost": 12.50},
+                "baseline": {"resolved": 3, "total": 10, "rate": 0.3, "total_cost": 5.00},
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "metrics.prom"
+            export_metrics(results, output_path=path)
+            assert path.exists()
+            content = path.read_text()
+            assert "mcpbr_resolution_rate" in content
+
+    def test_labels_include_benchmark_and_model(self):
+        results = {
+            "metadata": {"config": {"benchmark": "humaneval", "model": "claude-sonnet-4-5"}},
+            "summary": {
+                "mcp": {"resolved": 8, "total": 10, "rate": 0.8, "total_cost": 12.50},
+                "baseline": {"resolved": 3, "total": 10, "rate": 0.3, "total_cost": 5.00},
+            },
+        }
+        output = export_metrics(results)
+        assert 'benchmark="humaneval"' in output
+        assert 'model="claude-sonnet-4-5"' in output

--- a/tests/test_sampling_integration.py
+++ b/tests/test_sampling_integration.py
@@ -1,0 +1,195 @@
+"""Tests for sampling integration — wiring sampling.py into harness/config."""
+
+import pytest
+
+from mcpbr.config import HarnessConfig, MCPServerConfig
+from mcpbr.sampling import SamplingStrategy, sample_tasks
+
+# ---------------------------------------------------------------------------
+# Config acceptance tests
+# ---------------------------------------------------------------------------
+
+
+class TestSamplingConfig:
+    """Config accepts sampling_strategy, random_seed, stratify_field."""
+
+    def _make_config(self, **overrides):
+        defaults = {
+            "mcp_server": MCPServerConfig(command="echo", args=[]),
+            "benchmark": "humaneval",
+        }
+        defaults.update(overrides)
+        return HarnessConfig(**defaults)
+
+    def test_default_sampling_strategy_is_sequential(self):
+        cfg = self._make_config()
+        assert cfg.sampling_strategy == "sequential"
+
+    def test_accepts_random_strategy(self):
+        cfg = self._make_config(sampling_strategy="random")
+        assert cfg.sampling_strategy == "random"
+
+    def test_accepts_stratified_strategy(self):
+        cfg = self._make_config(sampling_strategy="stratified")
+        assert cfg.sampling_strategy == "stratified"
+
+    def test_rejects_invalid_strategy(self):
+        with pytest.raises(ValueError):
+            self._make_config(sampling_strategy="bogus")
+
+    def test_random_seed_default_none(self):
+        cfg = self._make_config()
+        assert cfg.random_seed is None
+
+    def test_random_seed_accepts_int(self):
+        cfg = self._make_config(random_seed=42)
+        assert cfg.random_seed == 42
+
+    def test_stratify_field_default_none(self):
+        cfg = self._make_config()
+        assert cfg.stratify_field is None
+
+    def test_stratify_field_accepts_string(self):
+        cfg = self._make_config(stratify_field="difficulty")
+        assert cfg.stratify_field == "difficulty"
+
+
+# ---------------------------------------------------------------------------
+# Harness wiring tests
+# ---------------------------------------------------------------------------
+
+FAKE_TASKS = [
+    {"instance_id": f"task-{i}", "difficulty": "easy" if i < 5 else "hard"} for i in range(10)
+]
+
+
+class TestHarnessSamplingWiring:
+    """Harness applies sample_tasks() after benchmark.load_tasks()."""
+
+    def _make_config(self, **overrides):
+        defaults = {
+            "mcp_server": MCPServerConfig(command="echo", args=[]),
+            "benchmark": "humaneval",
+            "sample_size": 3,
+        }
+        defaults.update(overrides)
+        return HarnessConfig(**defaults)
+
+    @pytest.mark.asyncio
+    async def test_sequential_strategy_uses_first_n(self):
+        """Default sequential strategy takes first N tasks."""
+        cfg = self._make_config(sampling_strategy="sequential")
+        tasks = list(FAKE_TASKS)
+        result = sample_tasks(
+            tasks,
+            sample_size=cfg.sample_size,
+            strategy=SamplingStrategy(cfg.sampling_strategy),
+            seed=cfg.random_seed,
+        )
+        assert result == tasks[:3]
+
+    @pytest.mark.asyncio
+    async def test_random_strategy_shuffles(self):
+        """Random strategy with a seed produces a shuffled subset."""
+        cfg = self._make_config(sampling_strategy="random", random_seed=42)
+        tasks = list(FAKE_TASKS)
+        result = sample_tasks(
+            tasks,
+            sample_size=cfg.sample_size,
+            strategy=SamplingStrategy(cfg.sampling_strategy),
+            seed=cfg.random_seed,
+        )
+        # Should have correct count
+        assert len(result) == 3
+        # Should NOT be the first 3 (with overwhelming probability for seed=42)
+        assert result != tasks[:3]
+
+    @pytest.mark.asyncio
+    async def test_same_seed_produces_identical_selection(self):
+        """Same random_seed yields identical task selection."""
+        cfg = self._make_config(sampling_strategy="random", random_seed=99)
+        tasks = list(FAKE_TASKS)
+        r1 = sample_tasks(
+            tasks,
+            sample_size=cfg.sample_size,
+            strategy=SamplingStrategy(cfg.sampling_strategy),
+            seed=cfg.random_seed,
+        )
+        r2 = sample_tasks(
+            tasks,
+            sample_size=cfg.sample_size,
+            strategy=SamplingStrategy(cfg.sampling_strategy),
+            seed=cfg.random_seed,
+        )
+        assert r1 == r2
+
+    @pytest.mark.asyncio
+    async def test_different_seeds_differ(self):
+        """Different seeds produce different selections."""
+        tasks = list(FAKE_TASKS)
+        r1 = sample_tasks(tasks, sample_size=3, strategy=SamplingStrategy.RANDOM, seed=1)
+        r2 = sample_tasks(tasks, sample_size=3, strategy=SamplingStrategy.RANDOM, seed=2)
+        assert r1 != r2
+
+    @pytest.mark.asyncio
+    async def test_global_seed_fallback(self):
+        """When random_seed is None, global_seed is used."""
+        cfg = self._make_config(
+            sampling_strategy="random",
+            random_seed=None,
+            global_seed=42,
+        )
+        seed = cfg.random_seed if cfg.random_seed is not None else cfg.global_seed
+        tasks = list(FAKE_TASKS)
+        result = sample_tasks(
+            tasks,
+            sample_size=cfg.sample_size,
+            strategy=SamplingStrategy(cfg.sampling_strategy),
+            seed=seed,
+        )
+        assert len(result) == 3
+
+    @pytest.mark.asyncio
+    async def test_non_sequential_loads_all_then_samples(self):
+        """When strategy != sequential, harness should pass sample_size=None
+        to benchmark.load_tasks() and apply sampling after."""
+        cfg = self._make_config(sampling_strategy="random", random_seed=42, sample_size=3)
+
+        # The key contract: when sampling_strategy != sequential,
+        # benchmark gets sample_size=None (load all) and sampling happens after
+        strategy = SamplingStrategy(cfg.sampling_strategy)
+        assert strategy != SamplingStrategy.SEQUENTIAL
+
+        # Load all tasks (simulating benchmark.load_tasks(sample_size=None))
+        all_tasks = list(FAKE_TASKS)  # 10 tasks
+        # Then sample
+        result = sample_tasks(
+            all_tasks,
+            sample_size=cfg.sample_size,
+            strategy=strategy,
+            seed=cfg.random_seed,
+        )
+        assert len(result) == 3
+
+    @pytest.mark.asyncio
+    async def test_stratified_with_field(self):
+        """Stratified sampling groups by stratify_field."""
+        cfg = self._make_config(
+            sampling_strategy="stratified",
+            random_seed=42,
+            sample_size=4,
+            stratify_field="difficulty",
+        )
+        tasks = list(FAKE_TASKS)  # 5 easy + 5 hard
+        result = sample_tasks(
+            tasks,
+            sample_size=cfg.sample_size,
+            strategy=SamplingStrategy(cfg.sampling_strategy),
+            seed=cfg.random_seed,
+            stratify_field=cfg.stratify_field,
+        )
+        assert len(result) == 4
+        # Both groups should be represented
+        difficulties = {t["difficulty"] for t in result}
+        assert "easy" in difficulties
+        assert "hard" in difficulties

--- a/tests/test_wandb_integration.py
+++ b/tests/test_wandb_integration.py
@@ -1,0 +1,130 @@
+"""Tests for W&B integration."""
+
+from unittest.mock import MagicMock, patch
+
+from mcpbr.wandb_integration import log_evaluation
+
+
+class TestWandbIntegration:
+    """W&B logging integration tests."""
+
+    @patch("mcpbr.wandb_integration._get_wandb")
+    def test_log_evaluation_calls_wandb_init(self, mock_get_wandb):
+        mock_wandb = MagicMock()
+        mock_get_wandb.return_value = mock_wandb
+
+        results = {
+            "metadata": {
+                "config": {"benchmark": "humaneval", "model": "claude-sonnet-4-5"},
+            },
+            "summary": {
+                "mcp": {"resolved": 8, "total": 10, "rate": 0.8, "total_cost": 12.50},
+            },
+            "tasks": [
+                {
+                    "instance_id": "task-0",
+                    "mcp": {"resolved": True, "cost": 1.25},
+                },
+            ],
+        }
+
+        log_evaluation(results, project="test-project")
+
+        mock_wandb.init.assert_called_once()
+        init_kwargs = mock_wandb.init.call_args.kwargs
+        assert init_kwargs["project"] == "test-project"
+
+    @patch("mcpbr.wandb_integration._get_wandb")
+    def test_config_logged_to_wandb(self, mock_get_wandb):
+        mock_wandb = MagicMock()
+        mock_get_wandb.return_value = mock_wandb
+
+        results = {
+            "metadata": {
+                "config": {"benchmark": "humaneval", "model": "claude-sonnet-4-5"},
+            },
+            "summary": {
+                "mcp": {"resolved": 8, "total": 10, "rate": 0.8, "total_cost": 12.50},
+            },
+            "tasks": [],
+        }
+
+        log_evaluation(results, project="test-project")
+
+        init_kwargs = mock_wandb.init.call_args.kwargs
+        assert init_kwargs["config"]["benchmark"] == "humaneval"
+        assert init_kwargs["config"]["model"] == "claude-sonnet-4-5"
+
+    @patch("mcpbr.wandb_integration._get_wandb")
+    def test_summary_logged(self, mock_get_wandb):
+        mock_wandb = MagicMock()
+        mock_get_wandb.return_value = mock_wandb
+
+        results = {
+            "metadata": {
+                "config": {"benchmark": "humaneval", "model": "claude-sonnet-4-5"},
+            },
+            "summary": {
+                "mcp": {"resolved": 8, "total": 10, "rate": 0.8, "total_cost": 12.50},
+            },
+            "tasks": [],
+        }
+
+        log_evaluation(results, project="test-project")
+
+        mock_wandb.log.assert_called()
+        log_kwargs = mock_wandb.log.call_args[0][0]
+        assert log_kwargs["resolution_rate"] == 0.8
+        assert log_kwargs["total_cost"] == 12.50
+
+    @patch("mcpbr.wandb_integration._get_wandb")
+    def test_per_task_results_logged_as_table(self, mock_get_wandb):
+        mock_wandb = MagicMock()
+        mock_wandb.Table = MagicMock()
+        mock_get_wandb.return_value = mock_wandb
+
+        results = {
+            "metadata": {
+                "config": {"benchmark": "humaneval", "model": "claude-sonnet-4-5"},
+            },
+            "summary": {
+                "mcp": {"resolved": 8, "total": 10, "rate": 0.8, "total_cost": 12.50},
+            },
+            "tasks": [
+                {"instance_id": "task-0", "mcp": {"resolved": True, "cost": 1.25}},
+                {"instance_id": "task-1", "mcp": {"resolved": False, "cost": 0.50}},
+            ],
+        }
+
+        log_evaluation(results, project="test-project")
+
+        mock_wandb.Table.assert_called_once()
+        mock_wandb.finish.assert_called_once()
+
+    @patch("mcpbr.wandb_integration._get_wandb")
+    def test_wandb_finish_called(self, mock_get_wandb):
+        mock_wandb = MagicMock()
+        mock_get_wandb.return_value = mock_wandb
+
+        results = {
+            "metadata": {"config": {"benchmark": "humaneval", "model": "claude-sonnet-4-5"}},
+            "summary": {"mcp": {"resolved": 8, "total": 10, "rate": 0.8, "total_cost": 12.50}},
+            "tasks": [],
+        }
+
+        log_evaluation(results, project="test-project")
+        mock_wandb.finish.assert_called_once()
+
+    @patch("mcpbr.wandb_integration._get_wandb")
+    def test_graceful_when_wandb_not_installed(self, mock_get_wandb):
+        """Should log a warning, not raise, when wandb is not installed."""
+        mock_get_wandb.return_value = None
+
+        results = {
+            "metadata": {"config": {"benchmark": "humaneval", "model": "claude-sonnet-4-5"}},
+            "summary": {"mcp": {"resolved": 8, "total": 10, "rate": 0.8, "total_cost": 12.50}},
+            "tasks": [],
+        }
+
+        # Should NOT raise
+        log_evaluation(results, project="test-project")

--- a/uv.lock
+++ b/uv.lock
@@ -4,13 +4,16 @@ requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version < '3.13' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'linux'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -743,6 +746,30 @@ wheels = [
 ]
 
 [[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.46"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
+]
+
+[[package]]
 name = "google-ai-generativelanguage"
 version = "0.6.15"
 source = { registry = "https://pypi.org/simple" }
@@ -866,53 +893,53 @@ wheels = [
 
 [[package]]
 name = "grpcio"
-version = "1.76.0"
+version = "1.78.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/e0/318c1ce3ae5a17894d5791e87aea147587c9e702f24122cc7a5c8bbaeeb1/grpcio-1.76.0.tar.gz", hash = "sha256:7be78388d6da1a25c0d5ec506523db58b18be22d9c37d8d3a32c08be4987bd73", size = 12785182, upload-time = "2025-10-21T16:23:12.106Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/8a/3d098f35c143a89520e568e6539cc098fcd294495910e359889ce8741c84/grpcio-1.78.0.tar.gz", hash = "sha256:7382b95189546f375c174f53a5fa873cef91c4b8005faa05cc5b3beea9c4f1c5", size = 12852416, upload-time = "2026-02-06T09:57:18.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/00/8163a1beeb6971f66b4bbe6ac9457b97948beba8dd2fc8e1281dce7f79ec/grpcio-1.76.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:2e1743fbd7f5fa713a1b0a8ac8ebabf0ec980b5d8809ec358d488e273b9cf02a", size = 5843567, upload-time = "2025-10-21T16:20:52.829Z" },
-    { url = "https://files.pythonhosted.org/packages/10/c1/934202f5cf335e6d852530ce14ddb0fef21be612ba9ecbbcbd4d748ca32d/grpcio-1.76.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:a8c2cf1209497cf659a667d7dea88985e834c24b7c3b605e6254cbb5076d985c", size = 11848017, upload-time = "2025-10-21T16:20:56.705Z" },
-    { url = "https://files.pythonhosted.org/packages/11/0b/8dec16b1863d74af6eb3543928600ec2195af49ca58b16334972f6775663/grpcio-1.76.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:08caea849a9d3c71a542827d6df9d5a69067b0a1efbea8a855633ff5d9571465", size = 6412027, upload-time = "2025-10-21T16:20:59.3Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/64/7b9e6e7ab910bea9d46f2c090380bab274a0b91fb0a2fe9b0cd399fffa12/grpcio-1.76.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f0e34c2079d47ae9f6188211db9e777c619a21d4faba6977774e8fa43b085e48", size = 7075913, upload-time = "2025-10-21T16:21:01.645Z" },
-    { url = "https://files.pythonhosted.org/packages/68/86/093c46e9546073cefa789bd76d44c5cb2abc824ca62af0c18be590ff13ba/grpcio-1.76.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8843114c0cfce61b40ad48df65abcfc00d4dba82eae8718fab5352390848c5da", size = 6615417, upload-time = "2025-10-21T16:21:03.844Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/b6/5709a3a68500a9c03da6fb71740dcdd5ef245e39266461a03f31a57036d8/grpcio-1.76.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8eddfb4d203a237da6f3cc8a540dad0517d274b5a1e9e636fd8d2c79b5c1d397", size = 7199683, upload-time = "2025-10-21T16:21:06.195Z" },
-    { url = "https://files.pythonhosted.org/packages/91/d3/4b1f2bf16ed52ce0b508161df3a2d186e4935379a159a834cb4a7d687429/grpcio-1.76.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:32483fe2aab2c3794101c2a159070584e5db11d0aa091b2c0ea9c4fc43d0d749", size = 8163109, upload-time = "2025-10-21T16:21:08.498Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/61/d9043f95f5f4cf085ac5dd6137b469d41befb04bd80280952ffa2a4c3f12/grpcio-1.76.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:dcfe41187da8992c5f40aa8c5ec086fa3672834d2be57a32384c08d5a05b4c00", size = 7626676, upload-time = "2025-10-21T16:21:10.693Z" },
-    { url = "https://files.pythonhosted.org/packages/36/95/fd9a5152ca02d8881e4dd419cdd790e11805979f499a2e5b96488b85cf27/grpcio-1.76.0-cp311-cp311-win32.whl", hash = "sha256:2107b0c024d1b35f4083f11245c0e23846ae64d02f40b2b226684840260ed054", size = 3997688, upload-time = "2025-10-21T16:21:12.746Z" },
-    { url = "https://files.pythonhosted.org/packages/60/9c/5c359c8d4c9176cfa3c61ecd4efe5affe1f38d9bae81e81ac7186b4c9cc8/grpcio-1.76.0-cp311-cp311-win_amd64.whl", hash = "sha256:522175aba7af9113c48ec10cc471b9b9bd4f6ceb36aeb4544a8e2c80ed9d252d", size = 4709315, upload-time = "2025-10-21T16:21:15.26Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/05/8e29121994b8d959ffa0afd28996d452f291b48cfc0875619de0bde2c50c/grpcio-1.76.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:81fd9652b37b36f16138611c7e884eb82e0cec137c40d3ef7c3f9b3ed00f6ed8", size = 5799718, upload-time = "2025-10-21T16:21:17.939Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/75/11d0e66b3cdf998c996489581bdad8900db79ebd83513e45c19548f1cba4/grpcio-1.76.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:04bbe1bfe3a68bbfd4e52402ab7d4eb59d72d02647ae2042204326cf4bbad280", size = 11825627, upload-time = "2025-10-21T16:21:20.466Z" },
-    { url = "https://files.pythonhosted.org/packages/28/50/2f0aa0498bc188048f5d9504dcc5c2c24f2eb1a9337cd0fa09a61a2e75f0/grpcio-1.76.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d388087771c837cdb6515539f43b9d4bf0b0f23593a24054ac16f7a960be16f4", size = 6359167, upload-time = "2025-10-21T16:21:23.122Z" },
-    { url = "https://files.pythonhosted.org/packages/66/e5/bbf0bb97d29ede1d59d6588af40018cfc345b17ce979b7b45424628dc8bb/grpcio-1.76.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:9f8f757bebaaea112c00dba718fc0d3260052ce714e25804a03f93f5d1c6cc11", size = 7044267, upload-time = "2025-10-21T16:21:25.995Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/86/f6ec2164f743d9609691115ae8ece098c76b894ebe4f7c94a655c6b03e98/grpcio-1.76.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:980a846182ce88c4f2f7e2c22c56aefd515daeb36149d1c897f83cf57999e0b6", size = 6573963, upload-time = "2025-10-21T16:21:28.631Z" },
-    { url = "https://files.pythonhosted.org/packages/60/bc/8d9d0d8505feccfdf38a766d262c71e73639c165b311c9457208b56d92ae/grpcio-1.76.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f92f88e6c033db65a5ae3d97905c8fea9c725b63e28d5a75cb73b49bda5024d8", size = 7164484, upload-time = "2025-10-21T16:21:30.837Z" },
-    { url = "https://files.pythonhosted.org/packages/67/e6/5d6c2fc10b95edf6df9b8f19cf10a34263b7fd48493936fffd5085521292/grpcio-1.76.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4baf3cbe2f0be3289eb68ac8ae771156971848bb8aaff60bad42005539431980", size = 8127777, upload-time = "2025-10-21T16:21:33.577Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/c8/dce8ff21c86abe025efe304d9e31fdb0deaaa3b502b6a78141080f206da0/grpcio-1.76.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:615ba64c208aaceb5ec83bfdce7728b80bfeb8be97562944836a7a0a9647d882", size = 7594014, upload-time = "2025-10-21T16:21:41.882Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/42/ad28191ebf983a5d0ecef90bab66baa5a6b18f2bfdef9d0a63b1973d9f75/grpcio-1.76.0-cp312-cp312-win32.whl", hash = "sha256:45d59a649a82df5718fd9527ce775fd66d1af35e6d31abdcdc906a49c6822958", size = 3984750, upload-time = "2025-10-21T16:21:44.006Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/00/7bd478cbb851c04a48baccaa49b75abaa8e4122f7d86da797500cccdd771/grpcio-1.76.0-cp312-cp312-win_amd64.whl", hash = "sha256:c088e7a90b6017307f423efbb9d1ba97a22aa2170876223f9709e9d1de0b5347", size = 4704003, upload-time = "2025-10-21T16:21:46.244Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/ed/71467ab770effc9e8cef5f2e7388beb2be26ed642d567697bb103a790c72/grpcio-1.76.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:26ef06c73eb53267c2b319f43e6634c7556ea37672029241a056629af27c10e2", size = 5807716, upload-time = "2025-10-21T16:21:48.475Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/85/c6ed56f9817fab03fa8a111ca91469941fb514e3e3ce6d793cb8f1e1347b/grpcio-1.76.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:45e0111e73f43f735d70786557dc38141185072d7ff8dc1829d6a77ac1471468", size = 11821522, upload-time = "2025-10-21T16:21:51.142Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/31/2b8a235ab40c39cbc141ef647f8a6eb7b0028f023015a4842933bc0d6831/grpcio-1.76.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83d57312a58dcfe2a3a0f9d1389b299438909a02db60e2f2ea2ae2d8034909d3", size = 6362558, upload-time = "2025-10-21T16:21:54.213Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/64/9784eab483358e08847498ee56faf8ff6ea8e0a4592568d9f68edc97e9e9/grpcio-1.76.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3e2a27c89eb9ac3d81ec8835e12414d73536c6e620355d65102503064a4ed6eb", size = 7049990, upload-time = "2025-10-21T16:21:56.476Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/94/8c12319a6369434e7a184b987e8e9f3b49a114c489b8315f029e24de4837/grpcio-1.76.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61f69297cba3950a524f61c7c8ee12e55c486cb5f7db47ff9dcee33da6f0d3ae", size = 6575387, upload-time = "2025-10-21T16:21:59.051Z" },
-    { url = "https://files.pythonhosted.org/packages/15/0f/f12c32b03f731f4a6242f771f63039df182c8b8e2cf8075b245b409259d4/grpcio-1.76.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6a15c17af8839b6801d554263c546c69c4d7718ad4321e3166175b37eaacca77", size = 7166668, upload-time = "2025-10-21T16:22:02.049Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/2d/3ec9ce0c2b1d92dd59d1c3264aaec9f0f7c817d6e8ac683b97198a36ed5a/grpcio-1.76.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:25a18e9810fbc7e7f03ec2516addc116a957f8cbb8cbc95ccc80faa072743d03", size = 8124928, upload-time = "2025-10-21T16:22:04.984Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/74/fd3317be5672f4856bcdd1a9e7b5e17554692d3db9a3b273879dc02d657d/grpcio-1.76.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:931091142fd8cc14edccc0845a79248bc155425eee9a98b2db2ea4f00a235a42", size = 7589983, upload-time = "2025-10-21T16:22:07.881Z" },
-    { url = "https://files.pythonhosted.org/packages/45/bb/ca038cf420f405971f19821c8c15bcbc875505f6ffadafe9ffd77871dc4c/grpcio-1.76.0-cp313-cp313-win32.whl", hash = "sha256:5e8571632780e08526f118f74170ad8d50fb0a48c23a746bef2a6ebade3abd6f", size = 3984727, upload-time = "2025-10-21T16:22:10.032Z" },
-    { url = "https://files.pythonhosted.org/packages/41/80/84087dc56437ced7cdd4b13d7875e7439a52a261e3ab4e06488ba6173b0a/grpcio-1.76.0-cp313-cp313-win_amd64.whl", hash = "sha256:f9f7bd5faab55f47231ad8dba7787866b69f5e93bc306e3915606779bbfb4ba8", size = 4702799, upload-time = "2025-10-21T16:22:12.709Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/46/39adac80de49d678e6e073b70204091e76631e03e94928b9ea4ecf0f6e0e/grpcio-1.76.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:ff8a59ea85a1f2191a0ffcc61298c571bc566332f82e5f5be1b83c9d8e668a62", size = 5808417, upload-time = "2025-10-21T16:22:15.02Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/f5/a4531f7fb8b4e2a60b94e39d5d924469b7a6988176b3422487be61fe2998/grpcio-1.76.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:06c3d6b076e7b593905d04fdba6a0525711b3466f43b3400266f04ff735de0cd", size = 11828219, upload-time = "2025-10-21T16:22:17.954Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/1c/de55d868ed7a8bd6acc6b1d6ddc4aa36d07a9f31d33c912c804adb1b971b/grpcio-1.76.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd5ef5932f6475c436c4a55e4336ebbe47bd3272be04964a03d316bbf4afbcbc", size = 6367826, upload-time = "2025-10-21T16:22:20.721Z" },
-    { url = "https://files.pythonhosted.org/packages/59/64/99e44c02b5adb0ad13ab3adc89cb33cb54bfa90c74770f2607eea629b86f/grpcio-1.76.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b331680e46239e090f5b3cead313cc772f6caa7d0fc8de349337563125361a4a", size = 7049550, upload-time = "2025-10-21T16:22:23.637Z" },
-    { url = "https://files.pythonhosted.org/packages/43/28/40a5be3f9a86949b83e7d6a2ad6011d993cbe9b6bd27bea881f61c7788b6/grpcio-1.76.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2229ae655ec4e8999599469559e97630185fdd53ae1e8997d147b7c9b2b72cba", size = 6575564, upload-time = "2025-10-21T16:22:26.016Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/a9/1be18e6055b64467440208a8559afac243c66a8b904213af6f392dc2212f/grpcio-1.76.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:490fa6d203992c47c7b9e4a9d39003a0c2bcc1c9aa3c058730884bbbb0ee9f09", size = 7176236, upload-time = "2025-10-21T16:22:28.362Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/55/dba05d3fcc151ce6e81327541d2cc8394f442f6b350fead67401661bf041/grpcio-1.76.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:479496325ce554792dba6548fae3df31a72cef7bad71ca2e12b0e58f9b336bfc", size = 8125795, upload-time = "2025-10-21T16:22:31.075Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/45/122df922d05655f63930cf42c9e3f72ba20aadb26c100ee105cad4ce4257/grpcio-1.76.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1c9b93f79f48b03ada57ea24725d83a30284a012ec27eab2cf7e50a550cbbbcc", size = 7592214, upload-time = "2025-10-21T16:22:33.831Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/6e/0b899b7f6b66e5af39e377055fb4a6675c9ee28431df5708139df2e93233/grpcio-1.76.0-cp314-cp314-win32.whl", hash = "sha256:747fa73efa9b8b1488a95d0ba1039c8e2dca0f741612d80415b1e1c560febf4e", size = 4062961, upload-time = "2025-10-21T16:22:36.468Z" },
-    { url = "https://files.pythonhosted.org/packages/19/41/0b430b01a2eb38ee887f88c1f07644a1df8e289353b78e82b37ef988fb64/grpcio-1.76.0-cp314-cp314-win_amd64.whl", hash = "sha256:922fa70ba549fce362d2e2871ab542082d66e2aaf0c19480ea453905b01f384e", size = 4834462, upload-time = "2025-10-21T16:22:39.772Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c7/d0b780a29b0837bf4ca9580904dfb275c1fc321ded7897d620af7047ec57/grpcio-1.78.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:2777b783f6c13b92bd7b716667452c329eefd646bfb3f2e9dabea2e05dbd34f6", size = 5951525, upload-time = "2026-02-06T09:55:01.989Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b1/96920bf2ee61df85a9503cb6f733fe711c0ff321a5a697d791b075673281/grpcio-1.78.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:9dca934f24c732750389ce49d638069c3892ad065df86cb465b3fa3012b70c9e", size = 11830418, upload-time = "2026-02-06T09:55:04.462Z" },
+    { url = "https://files.pythonhosted.org/packages/83/0c/7c1528f098aeb75a97de2bae18c530f56959fb7ad6c882db45d9884d6edc/grpcio-1.78.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:459ab414b35f4496138d0ecd735fed26f1318af5e52cb1efbc82a09f0d5aa911", size = 6524477, upload-time = "2026-02-06T09:55:07.111Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/52/e7c1f3688f949058e19a011c4e0dec973da3d0ae5e033909677f967ae1f4/grpcio-1.78.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:082653eecbdf290e6e3e2c276ab2c54b9e7c299e07f4221872380312d8cf395e", size = 7198266, upload-time = "2026-02-06T09:55:10.016Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/61/8ac32517c1e856677282c34f2e7812d6c328fa02b8f4067ab80e77fdc9c9/grpcio-1.78.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:85f93781028ec63f383f6bc90db785a016319c561cc11151fbb7b34e0d012303", size = 6730552, upload-time = "2026-02-06T09:55:12.207Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/98/b8ee0158199250220734f620b12e4a345955ac7329cfd908d0bf0fda77f0/grpcio-1.78.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f12857d24d98441af6a1d5c87442d624411db486f7ba12550b07788f74b67b04", size = 7304296, upload-time = "2026-02-06T09:55:15.044Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/0f/7b72762e0d8840b58032a56fdbd02b78fc645b9fa993d71abf04edbc54f4/grpcio-1.78.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5397fff416b79e4b284959642a4e95ac4b0f1ece82c9993658e0e477d40551ec", size = 8288298, upload-time = "2026-02-06T09:55:17.276Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ae/ae4ce56bc5bb5caa3a486d60f5f6083ac3469228faa734362487176c15c5/grpcio-1.78.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:fbe6e89c7ffb48518384068321621b2a69cab509f58e40e4399fdd378fa6d074", size = 7730953, upload-time = "2026-02-06T09:55:19.545Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/6e/8052e3a28eb6a820c372b2eb4b5e32d195c661e137d3eca94d534a4cfd8a/grpcio-1.78.0-cp311-cp311-win32.whl", hash = "sha256:6092beabe1966a3229f599d7088b38dfc8ffa1608b5b5cdda31e591e6500f856", size = 4076503, upload-time = "2026-02-06T09:55:21.521Z" },
+    { url = "https://files.pythonhosted.org/packages/08/62/f22c98c5265dfad327251fa2f840b591b1df5f5e15d88b19c18c86965b27/grpcio-1.78.0-cp311-cp311-win_amd64.whl", hash = "sha256:1afa62af6e23f88629f2b29ec9e52ec7c65a7176c1e0a83292b93c76ca882558", size = 4799767, upload-time = "2026-02-06T09:55:24.107Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/f4/7384ed0178203d6074446b3c4f46c90a22ddf7ae0b3aee521627f54cfc2a/grpcio-1.78.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:f9ab915a267fc47c7e88c387a3a28325b58c898e23d4995f765728f4e3dedb97", size = 5913985, upload-time = "2026-02-06T09:55:26.832Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ed/be1caa25f06594463f685b3790b320f18aea49b33166f4141bfdc2bfb236/grpcio-1.78.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3f8904a8165ab21e07e58bf3e30a73f4dffc7a1e0dbc32d51c61b5360d26f43e", size = 11811853, upload-time = "2026-02-06T09:55:29.224Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a7/f06d151afc4e64b7e3cc3e872d331d011c279aaab02831e40a81c691fb65/grpcio-1.78.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:859b13906ce098c0b493af92142ad051bf64c7870fa58a123911c88606714996", size = 6475766, upload-time = "2026-02-06T09:55:31.825Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a8/4482922da832ec0082d0f2cc3a10976d84a7424707f25780b82814aafc0a/grpcio-1.78.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b2342d87af32790f934a79c3112641e7b27d63c261b8b4395350dad43eff1dc7", size = 7170027, upload-time = "2026-02-06T09:55:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bf/f4a3b9693e35d25b24b0b39fa46d7d8a3c439e0a3036c3451764678fec20/grpcio-1.78.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:12a771591ae40bc65ba67048fa52ef4f0e6db8279e595fd349f9dfddeef571f9", size = 6690766, upload-time = "2026-02-06T09:55:36.902Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b9/521875265cc99fe5ad4c5a17010018085cae2810a928bf15ebe7d8bcd9cc/grpcio-1.78.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:185dea0d5260cbb2d224c507bf2a5444d5abbb1fa3594c1ed7e4c709d5eb8383", size = 7266161, upload-time = "2026-02-06T09:55:39.824Z" },
+    { url = "https://files.pythonhosted.org/packages/05/86/296a82844fd40a4ad4a95f100b55044b4f817dece732bf686aea1a284147/grpcio-1.78.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:51b13f9aed9d59ee389ad666b8c2214cc87b5de258fa712f9ab05f922e3896c6", size = 8253303, upload-time = "2026-02-06T09:55:42.353Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e4/ea3c0caf5468537f27ad5aab92b681ed7cc0ef5f8c9196d3fd42c8c2286b/grpcio-1.78.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd5f135b1bd58ab088930b3c613455796dfa0393626a6972663ccdda5b4ac6ce", size = 7698222, upload-time = "2026-02-06T09:55:44.629Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/47/7f05f81e4bb6b831e93271fb12fd52ba7b319b5402cbc101d588f435df00/grpcio-1.78.0-cp312-cp312-win32.whl", hash = "sha256:94309f498bcc07e5a7d16089ab984d42ad96af1d94b5a4eb966a266d9fcabf68", size = 4066123, upload-time = "2026-02-06T09:55:47.644Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/e7/d6914822c88aa2974dbbd10903d801a28a19ce9cd8bad7e694cbbcf61528/grpcio-1.78.0-cp312-cp312-win_amd64.whl", hash = "sha256:9566fe4ababbb2610c39190791e5b829869351d14369603702e890ef3ad2d06e", size = 4797657, upload-time = "2026-02-06T09:55:49.86Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a9/8f75894993895f361ed8636cd9237f4ab39ef87fd30db17467235ed1c045/grpcio-1.78.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:ce3a90455492bf8bfa38e56fbbe1dbd4f872a3d8eeaf7337dc3b1c8aa28c271b", size = 5920143, upload-time = "2026-02-06T09:55:52.035Z" },
+    { url = "https://files.pythonhosted.org/packages/55/06/0b78408e938ac424100100fd081189451b472236e8a3a1f6500390dc4954/grpcio-1.78.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:2bf5e2e163b356978b23652c4818ce4759d40f4712ee9ec5a83c4be6f8c23a3a", size = 11803926, upload-time = "2026-02-06T09:55:55.494Z" },
+    { url = "https://files.pythonhosted.org/packages/88/93/b59fe7832ff6ae3c78b813ea43dac60e295fa03606d14d89d2e0ec29f4f3/grpcio-1.78.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8f2ac84905d12918e4e55a16da17939eb63e433dc11b677267c35568aa63fc84", size = 6478628, upload-time = "2026-02-06T09:55:58.533Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/df/e67e3734527f9926b7d9c0dde6cd998d1d26850c3ed8eeec81297967ac67/grpcio-1.78.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b58f37edab4a3881bc6c9bca52670610e0c9ca14e2ea3cf9debf185b870457fb", size = 7173574, upload-time = "2026-02-06T09:56:01.786Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/cc03fffb07bfba982a9ec097b164e8835546980aec25ecfa5f9c1a47e022/grpcio-1.78.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:735e38e176a88ce41840c21bb49098ab66177c64c82426e24e0082500cc68af5", size = 6692639, upload-time = "2026-02-06T09:56:04.529Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9a/289c32e301b85bdb67d7ec68b752155e674ee3ba2173a1858f118e399ef3/grpcio-1.78.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2045397e63a7a0ee7957c25f7dbb36ddc110e0cfb418403d110c0a7a68a844e9", size = 7268838, upload-time = "2026-02-06T09:56:08.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/79/1be93f32add280461fa4773880196572563e9c8510861ac2da0ea0f892b6/grpcio-1.78.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a9f136fbafe7ccf4ac7e8e0c28b31066e810be52d6e344ef954a3a70234e1702", size = 8251878, upload-time = "2026-02-06T09:56:10.914Z" },
+    { url = "https://files.pythonhosted.org/packages/65/65/793f8e95296ab92e4164593674ae6291b204bb5f67f9d4a711489cd30ffa/grpcio-1.78.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:748b6138585379c737adc08aeffd21222abbda1a86a0dca2a39682feb9196c20", size = 7695412, upload-time = "2026-02-06T09:56:13.593Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9f/1e233fe697ecc82845942c2822ed06bb522e70d6771c28d5528e4c50f6a4/grpcio-1.78.0-cp313-cp313-win32.whl", hash = "sha256:271c73e6e5676afe4fc52907686670c7cea22ab2310b76a59b678403ed40d670", size = 4064899, upload-time = "2026-02-06T09:56:15.601Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/27/d86b89e36de8a951501fb06a0f38df19853210f341d0b28f83f4aa0ffa08/grpcio-1.78.0-cp313-cp313-win_amd64.whl", hash = "sha256:f2d4e43ee362adfc05994ed479334d5a451ab7bc3f3fee1b796b8ca66895acb4", size = 4797393, upload-time = "2026-02-06T09:56:17.882Z" },
+    { url = "https://files.pythonhosted.org/packages/29/f2/b56e43e3c968bfe822fa6ce5bca10d5c723aa40875b48791ce1029bb78c7/grpcio-1.78.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:e87cbc002b6f440482b3519e36e1313eb5443e9e9e73d6a52d43bd2004fcfd8e", size = 5920591, upload-time = "2026-02-06T09:56:20.758Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/81/1f3b65bd30c334167bfa8b0d23300a44e2725ce39bba5b76a2460d85f745/grpcio-1.78.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:c41bc64626db62e72afec66b0c8a0da76491510015417c127bfc53b2fe6d7f7f", size = 11813685, upload-time = "2026-02-06T09:56:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/1c/bbe2f8216a5bd3036119c544d63c2e592bdf4a8ec6e4a1867592f4586b26/grpcio-1.78.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8dfffba826efcf366b1e3ccc37e67afe676f290e13a3b48d31a46739f80a8724", size = 6487803, upload-time = "2026-02-06T09:56:27.367Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5c/a6b2419723ea7ddce6308259a55e8e7593d88464ce8db9f4aa857aba96fa/grpcio-1.78.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:74be1268d1439eaaf552c698cdb11cd594f0c49295ae6bb72c34ee31abbe611b", size = 7173206, upload-time = "2026-02-06T09:56:29.876Z" },
+    { url = "https://files.pythonhosted.org/packages/df/1e/b8801345629a415ea7e26c83d75eb5dbe91b07ffe5210cc517348a8d4218/grpcio-1.78.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be63c88b32e6c0f1429f1398ca5c09bc64b0d80950c8bb7807d7d7fb36fb84c7", size = 6693826, upload-time = "2026-02-06T09:56:32.305Z" },
+    { url = "https://files.pythonhosted.org/packages/34/84/0de28eac0377742679a510784f049738a80424b17287739fc47d63c2439e/grpcio-1.78.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3c586ac70e855c721bda8f548d38c3ca66ac791dc49b66a8281a1f99db85e452", size = 7277897, upload-time = "2026-02-06T09:56:34.915Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/9c/ad8685cfe20559a9edb66f735afdcb2b7d3de69b13666fdfc542e1916ebd/grpcio-1.78.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:35eb275bf1751d2ffbd8f57cdbc46058e857cf3971041521b78b7db94bdaf127", size = 8252404, upload-time = "2026-02-06T09:56:37.553Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/05/33a7a4985586f27e1de4803887c417ec7ced145ebd069bc38a9607059e2b/grpcio-1.78.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:207db540302c884b8848036b80db352a832b99dfdf41db1eb554c2c2c7800f65", size = 7696837, upload-time = "2026-02-06T09:56:40.173Z" },
+    { url = "https://files.pythonhosted.org/packages/73/77/7382241caf88729b106e49e7d18e3116216c778e6a7e833826eb96de22f7/grpcio-1.78.0-cp314-cp314-win32.whl", hash = "sha256:57bab6deef2f4f1ca76cc04565df38dc5713ae6c17de690721bdf30cb1e0545c", size = 4142439, upload-time = "2026-02-06T09:56:43.258Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b2/b096ccce418882fbfda4f7496f9357aaa9a5af1896a9a7f60d9f2b275a06/grpcio-1.78.0-cp314-cp314-win_amd64.whl", hash = "sha256:dce09d6116df20a96acfdbf85e4866258c3758180e8c49845d6ba8248b6d0bbb", size = 4929852, upload-time = "2026-02-06T09:56:45.885Z" },
 ]
 
 [[package]]
@@ -1333,7 +1360,7 @@ wheels = [
 
 [[package]]
 name = "mcpbr"
-version = "0.6.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -1373,6 +1400,9 @@ gemini = [
 openai = [
     { name = "openai" },
 ]
+wandb = [
+    { name = "wandb" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1400,8 +1430,9 @@ requires-dist = [
     { name = "requests", specifier = ">=2.31.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "wandb", marker = "extra == 'wandb'", specifier = ">=0.16.0" },
 ]
-provides-extras = ["dev", "docs", "openai", "gemini", "all-providers"]
+provides-extras = ["dev", "docs", "openai", "gemini", "wandb", "all-providers"]
 
 [[package]]
 name = "mdurl"
@@ -2708,6 +2739,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.52.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/eb/1b497650eb564701f9a7b8a95c51b2abe9347ed2c0b290ba78f027ebe4ea/sentry_sdk-2.52.0.tar.gz", hash = "sha256:fa0bec872cfec0302970b2996825723d67390cdd5f0229fb9efed93bd5384899", size = 410273, upload-time = "2026-02-04T15:03:54.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/63/2c6daf59d86b1c30600bff679d039f57fd1932af82c43c0bde1cbc55e8d4/sentry_sdk-2.52.0-py2.py3-none-any.whl", hash = "sha256:931c8f86169fc6f2752cb5c4e6480f0d516112e78750c312e081ababecbaf2ed", size = 435547, upload-time = "2026-02-04T15:03:51.567Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2723,6 +2767,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "smmap"
+version = "5.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329, upload-time = "2025-01-02T07:14:40.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303, upload-time = "2025-01-02T07:14:38.724Z" },
 ]
 
 [[package]]
@@ -2858,6 +2911,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/2a/dc2228b2888f51192c7dc766106cd475f1b768c10caaf9727659726f7391/virtualenv-20.36.1-py3-none-any.whl", hash = "sha256:575a8d6b124ef88f6f51d56d656132389f961062a9177016a50e4f507bbcc19f", size = 6008258, upload-time = "2026-01-09T18:20:59.425Z" },
+]
+
+[[package]]
+name = "wandb"
+version = "0.24.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "gitpython" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sentry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/5c/53cf9f74b89e90facc8c7892d1449f7b39527e50e5cd577346baeb97e423/wandb-0.24.2.tar.gz", hash = "sha256:968b5b91d0a164dfb2f8c604cdf69e6fb09de6596b85b9f9d3c916b71ae86198", size = 44237317, upload-time = "2026-02-05T00:12:16.739Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/82/5299fa22faf2dd55f33f05c26bf908b11ea4d25f32ac270d4bf838b0d97e/wandb-0.24.2-py3-none-macosx_12_0_arm64.whl", hash = "sha256:755b8a92edd28e15c052dc2bdc4652e26bce379fa7745360249cbfc589ff5f53", size = 21640026, upload-time = "2026-02-05T00:11:55.267Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/38/33cb321258778c25c00fb7eb578e69ce99428a66d4376eee4058f230a21a/wandb-0.24.2-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:5e6c0ad176792c7c3d1620a2ad65bd9a5f3886c69362af540d3667bfc97b67fb", size = 22894053, upload-time = "2026-02-05T00:11:58.304Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/99/33b0281ac9a0b0c251195e6ce6cb310efa2f84ee117a15e9997fc2f9503b/wandb-0.24.2-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:85861f9b3e54a07b84bade0aa5f4caa156028ab959351d98816a45e3b1411d35", size = 21286409, upload-time = "2026-02-05T00:12:00.584Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c8/1b758bd903afee000f023cd03f335ff328a21b3914f9f9deda49b1e57723/wandb-0.24.2-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:38661c666e70d7e1f460fc0a0edab8a393eaaa5f8773c17be534961a7022779d", size = 23026085, upload-time = "2026-02-05T00:12:02.682Z" },
+    { url = "https://files.pythonhosted.org/packages/60/87/724583f258aaeb2c368c79d7412167ce628f8a5ca667faed3cd427dd3be2/wandb-0.24.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:656a4272000999569eb8e0773f1259403bc6bd3e7d1c7d2238d3e359874da9c4", size = 21342088, upload-time = "2026-02-05T00:12:05.375Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5c/e9b36ddc9beb2745a4fb1ec67ae7f995c31f7305a6d17837b72b228360ff/wandb-0.24.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:33cba098d95fd46720cc9023bd23e4a38e9b11836a836b4a57b8d41cff8985f2", size = 23120819, upload-time = "2026-02-05T00:12:07.487Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6e/1ad011da4a5c860fdb88645c738a2dae914b1eea2249aa606659ccd1443f/wandb-0.24.2-py3-none-win32.whl", hash = "sha256:70db8680e8d7edb5bd60dfb7f31aeb5af30b31ad72498c47e1aba7471c337bb2", size = 22295643, upload-time = "2026-02-05T00:12:09.85Z" },
+    { url = "https://files.pythonhosted.org/packages/38/8b/721c77616bd1fca8963bffef309da09cdff71002f9d4201dfd5bd370591a/wandb-0.24.2-py3-none-win_amd64.whl", hash = "sha256:a78ac1fa116b196cd33250b3d80f4a5c05c141ad949175515c007ec9826e49a6", size = 22295646, upload-time = "2026-02-05T00:12:11.898Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/9a/f3919d7ee7ba99dabf0aac7e299c6c328f5eae94f9f6b28c76005f882d5d/wandb-0.24.2-py3-none-win_arm64.whl", hash = "sha256:b42614b99f8b9af69f88c15a84283a973c8cd5750e9c4752aa3ce21f13dbac9a", size = 20268261, upload-time = "2026-02-05T00:12:14.353Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Random sampling** (#372): Wire existing `sampling.py` into harness/config with `--sampling-strategy` (sequential/random/stratified), `--random-seed`, and `--stratify-field` CLI flags
- **Dataset loading perf** (#360, #361): Add `dataset.select(range(n))` optimization to all 26 HuggingFace benchmarks to avoid materializing full datasets when only a sample is needed
- **Notifications** (#80, #206, #207, #208): New `notifications.py` module with Slack, Discord, and email completion alerts dispatched from harness after evaluation; `--notify-slack`, `--notify-discord`, `--notify-email` CLI flags
- **Azure monitoring** (#363): New `run_state.py` for VM state persistence + `get_run_status()`, `get_ssh_command()`, `stop_run()` on AzureProvider; `run-status`, `run-ssh`, `run-stop`, `run-logs` CLI commands
- **Prometheus metrics** (#81, #209): New `prometheus.py` with exposition format export; `export-metrics` CLI command
- **W&B integration** (#82): New `wandb_integration.py` with lazy import and `log_evaluation()`; `--wandb/--no-wandb`, `--wandb-project` CLI flags
- **Result badges** (#211): New `badges.py` with shields.io URL generation; `badge` CLI command

## Changes

- 47 files changed, +2290/-51 lines
- 5 new source modules, 7 new test files, 26 benchmark files optimized
- 62 new tests, 3649 total passing, lint clean

## Test plan

- [x] `uv run pytest tests/test_sampling_integration.py tests/test_benchmark_loading_perf.py tests/test_notifications.py tests/test_azure_monitoring.py tests/test_prometheus.py tests/test_wandb_integration.py tests/test_badges.py -v` — 62/62 pass
- [x] `uv run pytest tests/ -m "not integration" --ignore=tests/test_benchmark_integration.py -q` — 3649 passed, 0 failed
- [x] `uv run ruff check src/ tests/` — All checks passed
- [x] Pre-commit hooks (ruff, ruff-format, trailing whitespace, merge conflicts) — All passed
- [ ] Manual: `mcpbr run -c config/example.yaml -n 2 --sampling-strategy random --random-seed 42`

Closes #372, #360, #361, #80, #206, #207, #208, #363, #81, #209, #82, #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Badge generation from evaluation results.
  * Prometheus metrics export for evaluations.
  * Azure VM run commands: status, SSH, stop, and logs.
  * Completion notifications via Slack, Discord, and email.
  * Optional Weights & Biases logging integration.
  * CLI options for sampling, notifications, and W&B.

* **Performance**
  * Avoid full dataset materialization when sampling without filtering (faster, lower memory).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->