### PR TITLE
feat: Rich Slack notifications with file upload and Gist links

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,6 +727,17 @@ Run SWE-bench evaluation with the configured MCP server.
 | `--smtp-port PORT` | | SMTP server port (default: 587) |
 | `--smtp-user USER` | | SMTP username for authentication |
 | `--smtp-password PASS` | | SMTP password for authentication |
+| `--sampling-strategy TEXT` | | Task sampling strategy (`sequential`, `random`, `stratified`) |
+| `--random-seed INT` | | Random seed for reproducible sampling |
+| `--stratify-field TEXT` | | Field to stratify by (requires `--sampling-strategy stratified`) |
+| `--notify-slack URL` | | Slack webhook URL for completion notifications |
+| `--notify-discord URL` | | Discord webhook URL for completion notifications |
+| `--notify-email JSON` | | Email config as JSON string |
+| `--slack-bot-token TOKEN` | | Slack bot token (`xoxb-...`) for uploading results.json to a channel |
+| `--slack-channel ID` | | Slack channel ID for file uploads (used with `--slack-bot-token`) |
+| `--github-token TOKEN` | | GitHub token for auto-creating a Gist with full results (linked in notifications) |
+| `--wandb/--no-wandb` | | Enable/disable Weights & Biases logging |
+| `--wandb-project TEXT` | | W&B project name |
 | `--profile` | | Enable comprehensive performance profiling (tool latency, memory, overhead) |
 | `--help` | `-h` | Show help message |
 

--- a/src/mcpbr/cli.py
+++ b/src/mcpbr/cli.py
@@ -466,6 +466,16 @@ def _build_results_dict(results):
     help="Discord webhook URL for completion notifications.",
 )
 @click.option("--notify-email", type=str, default=None, help="Email config JSON string.")
+@click.option(
+    "--slack-bot-token", type=str, default=None, help="Slack bot token for file uploads (xoxb-...)."
+)
+@click.option("--slack-channel", type=str, default=None, help="Slack channel ID for file uploads.")
+@click.option(
+    "--github-token",
+    type=str,
+    default=None,
+    help="GitHub token for creating Gist reports in notifications.",
+)
 @click.option("--wandb/--no-wandb", default=None, help="Enable/disable W&B logging.")
 @click.option("--wandb-project", type=str, default=None, help="W&B project name.")
 def run(
@@ -523,6 +533,9 @@ def run(
     notify_slack: str | None,
     notify_discord: str | None,
     notify_email: str | None,
+    slack_bot_token: str | None,
+    slack_channel: str | None,
+    github_token: str | None,
     wandb: bool | None,
     wandb_project: str | None,
 ) -> None:
@@ -678,6 +691,12 @@ def run(
         except json.JSONDecodeError as e:
             console.print(f"[red]Error: --notify-email must be valid JSON: {e}[/red]")
             sys.exit(1)
+    if slack_bot_token:
+        config.slack_bot_token = slack_bot_token
+    if slack_channel:
+        config.slack_channel = slack_channel
+    if github_token:
+        config.github_token = github_token
     if wandb is not None:
         config.wandb_enabled = wandb
     if wandb_project:

--- a/src/mcpbr/config.py
+++ b/src/mcpbr/config.py
@@ -539,6 +539,15 @@ class HarnessConfig(BaseModel):
     notify_email: dict[str, Any] | None = Field(
         default=None, description="Email config dict (smtp_host, smtp_port, from_addr, to_addrs)."
     )
+    slack_bot_token: str | None = Field(
+        default=None, description="Slack bot token for file uploads (xoxb-...)."
+    )
+    slack_channel: str | None = Field(
+        default=None, description="Slack channel ID for file uploads."
+    )
+    github_token: str | None = Field(
+        default=None, description="GitHub token for creating Gist reports."
+    )
 
     @model_validator(mode="after")
     def validate_stratified_sampling(self) -> "HarnessConfig":

--- a/src/mcpbr/harness.py
+++ b/src/mcpbr/harness.py
@@ -1434,6 +1434,8 @@ async def run_evaluation(
 
     # Fire completion notification (v0.10.0)
     try:
+        import json as _json
+
         from .notifications import NotificationEvent, dispatch_notification
 
         notify_config = {}
@@ -1443,10 +1445,46 @@ async def run_evaluation(
             notify_config["discord_webhook"] = config.notify_discord_webhook
         if hasattr(config, "notify_email") and config.notify_email:
             notify_config["email"] = config.notify_email
+        if hasattr(config, "slack_bot_token") and config.slack_bot_token:
+            notify_config["slack_bot_token"] = config.slack_bot_token
+        if hasattr(config, "slack_channel") and config.slack_channel:
+            notify_config["slack_channel"] = config.slack_channel
+        if hasattr(config, "github_token") and config.github_token:
+            notify_config["github_token"] = config.github_token
         if notify_config:
             total = len(results)
             resolved = sum(1 for t in results if t.mcp and t.mcp.get("resolved"))
             cost = sum((t.mcp.get("cost", 0) or 0) for t in results if t.mcp)
+
+            # Build extra data for enriched notifications
+            task_results = [
+                {
+                    "instance_id": t.instance_id,
+                    "resolved": bool(t.mcp and t.mcp.get("resolved")),
+                }
+                for t in results
+            ]
+            extra: dict[str, Any] = {"task_results": task_results}
+
+            # Include tool stats if available
+            if mcp_tool_stats:
+                extra["tool_stats"] = mcp_tool_stats
+
+            # Serialize results for file upload / Gist
+            results_data = {
+                "metadata": metadata,
+                "summary": summary,
+                "tasks": [
+                    {
+                        "instance_id": t.instance_id,
+                        "mcp": t.mcp,
+                        "baseline": t.baseline,
+                    }
+                    for t in results
+                ],
+            }
+            extra["results_json"] = _json.dumps(results_data, default=str, indent=2)
+
             event = NotificationEvent(
                 event_type="completion",
                 benchmark=config.benchmark,
@@ -1455,6 +1493,7 @@ async def run_evaluation(
                 resolved_tasks=resolved,
                 resolution_rate=resolved / total if total > 0 else 0.0,
                 total_cost=cost,
+                extra=extra,
             )
             dispatch_notification(notify_config, event)
     except Exception:

--- a/src/mcpbr/harness.py
+++ b/src/mcpbr/harness.py
@@ -1466,6 +1466,15 @@ async def run_evaluation(
             ]
             extra: dict[str, Any] = {"task_results": task_results}
 
+            # Include MCP server identity
+            if hasattr(config, "mcp_server") and config.mcp_server:
+                srv = config.mcp_server
+                server_desc = srv.name or "unknown"
+                if srv.command:
+                    cmd_parts = [srv.command] + (srv.args or [])
+                    server_desc += f" ({' '.join(cmd_parts)})"
+                extra["mcp_server"] = server_desc
+
             # Include tool stats if available
             if mcp_tool_stats:
                 extra["tool_stats"] = mcp_tool_stats

--- a/tests/test_rich_notifications.py
+++ b/tests/test_rich_notifications.py
@@ -1,0 +1,304 @@
+"""Tests for rich Slack notifications — enriched messages, file upload, Gist links."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcpbr.notifications import (
+    NotificationEvent,
+    create_gist_report,
+    send_slack_notification,
+    upload_slack_file,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_event(**overrides):
+    defaults = {
+        "event_type": "completion",
+        "benchmark": "swe-bench-verified",
+        "model": "claude-sonnet-4-20250514",
+        "total_tasks": 10,
+        "resolved_tasks": 3,
+        "resolution_rate": 0.3,
+        "total_cost": 5.42,
+        "runtime_seconds": 300.0,
+    }
+    defaults.update(overrides)
+    return NotificationEvent(**defaults)
+
+
+SAMPLE_RESULTS_DICT = {
+    "metadata": {
+        "config": {"benchmark": "swe-bench-verified", "model": "claude-sonnet-4-20250514"}
+    },
+    "summary": {
+        "mcp": {"rate": 0.3, "total": 10, "resolved": 3, "total_cost": 5.42},
+    },
+    "tasks": [
+        {"instance_id": "astropy__astropy-12907", "mcp": {"resolved": False, "cost": 0.54}},
+        {"instance_id": "django__django-16379", "mcp": {"resolved": True, "cost": 0.32}},
+        {"instance_id": "sympy__sympy-24152", "mcp": {"resolved": True, "cost": 0.61}},
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# #395: Enriched Slack message
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichedSlackMessage:
+    """Slack notification includes per-task results and tool stats."""
+
+    @patch("mcpbr.notifications.requests.post")
+    def test_includes_per_task_results(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        event = _make_event(
+            extra={
+                "task_results": [
+                    {"instance_id": "task-1", "resolved": True},
+                    {"instance_id": "task-2", "resolved": False},
+                ],
+            }
+        )
+        send_slack_notification("https://hooks.slack.com/test", event)
+
+        payload = mock_post.call_args[1]["json"]
+        attachment = payload["attachments"][0]
+        # Should have a text block with per-task results
+        assert "text" in attachment
+        assert "task-1" in attachment["text"]
+        assert "task-2" in attachment["text"]
+
+    @patch("mcpbr.notifications.requests.post")
+    def test_includes_tool_stats(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        event = _make_event(
+            extra={
+                "tool_stats": {
+                    "total_calls": 30,
+                    "successful_calls": 23,
+                    "failed_calls": 7,
+                    "failure_rate": 0.233,
+                },
+            }
+        )
+        send_slack_notification("https://hooks.slack.com/test", event)
+
+        payload = mock_post.call_args[1]["json"]
+        attachment = payload["attachments"][0]
+        assert "text" in attachment
+        assert "30" in attachment["text"]
+
+    @patch("mcpbr.notifications.requests.post")
+    def test_includes_gist_url(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        event = _make_event(extra={"gist_url": "https://gist.github.com/user/abc123"})
+        send_slack_notification("https://hooks.slack.com/test", event)
+
+        payload = mock_post.call_args[1]["json"]
+        attachment = payload["attachments"][0]
+        assert "text" in attachment
+        assert "https://gist.github.com/user/abc123" in attachment["text"]
+
+    @patch("mcpbr.notifications.requests.post")
+    def test_no_extra_omits_text_block(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        event = _make_event()
+        send_slack_notification("https://hooks.slack.com/test", event)
+
+        payload = mock_post.call_args[1]["json"]
+        attachment = payload["attachments"][0]
+        # No extra data means no text block
+        assert "text" not in attachment or attachment["text"] == ""
+
+
+# ---------------------------------------------------------------------------
+# #396: Slack file upload
+# ---------------------------------------------------------------------------
+
+
+class TestSlackFileUpload:
+    """Upload results.json to Slack via bot token."""
+
+    @patch("mcpbr.notifications.requests.post")
+    def test_uploads_file_content(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+        mock_post.return_value.json.return_value = {"ok": True}
+
+        upload_slack_file(
+            bot_token="xoxb-test-token",
+            channel="C12345",
+            content=json.dumps(SAMPLE_RESULTS_DICT),
+            filename="results.json",
+            title="mcpbr results",
+        )
+
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        # Should use files.upload endpoint or similar
+        url = call_kwargs[0][0] if call_kwargs[0] else call_kwargs[1].get("url", "")
+        assert "slack.com" in url
+        assert "files" in url
+
+    @patch("mcpbr.notifications.requests.post")
+    def test_includes_auth_header(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+        mock_post.return_value.json.return_value = {"ok": True}
+
+        upload_slack_file(
+            bot_token="xoxb-test-token",
+            channel="C12345",
+            content="{}",
+            filename="results.json",
+        )
+
+        call_kwargs = mock_post.call_args[1]
+        headers = call_kwargs.get("headers", {})
+        assert "Bearer xoxb-test-token" in headers.get("Authorization", "")
+
+    @patch("mcpbr.notifications.requests.post")
+    def test_raises_on_slack_error(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+        mock_post.return_value.json.return_value = {"ok": False, "error": "not_authed"}
+
+        with pytest.raises(RuntimeError, match="not_authed"):
+            upload_slack_file(
+                bot_token="bad-token",
+                channel="C12345",
+                content="{}",
+                filename="results.json",
+            )
+
+
+# ---------------------------------------------------------------------------
+# #397: GitHub Gist creation
+# ---------------------------------------------------------------------------
+
+
+class TestGistCreation:
+    """Create a GitHub Gist with full report and return URL."""
+
+    @patch("mcpbr.notifications.requests.post")
+    def test_creates_gist_with_results(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=201)
+        mock_post.return_value.raise_for_status = MagicMock()
+        mock_post.return_value.json.return_value = {
+            "html_url": "https://gist.github.com/user/abc123"
+        }
+
+        url = create_gist_report(
+            github_token="ghp_test",
+            results_json=json.dumps(SAMPLE_RESULTS_DICT),
+            description="mcpbr swe-bench-verified results",
+        )
+
+        assert url == "https://gist.github.com/user/abc123"
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        assert "gist" in call_kwargs[0][0]
+        payload = call_kwargs[1]["json"]
+        assert "results.json" in payload["files"]
+
+    @patch("mcpbr.notifications.requests.post")
+    def test_gist_includes_auth_header(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=201)
+        mock_post.return_value.raise_for_status = MagicMock()
+        mock_post.return_value.json.return_value = {
+            "html_url": "https://gist.github.com/user/abc123"
+        }
+
+        create_gist_report(
+            github_token="ghp_test",
+            results_json="{}",
+            description="test",
+        )
+
+        call_kwargs = mock_post.call_args[1]
+        headers = call_kwargs.get("headers", {})
+        assert "token ghp_test" in headers.get("Authorization", "")
+
+    @patch("mcpbr.notifications.requests.post")
+    def test_gist_returns_none_on_failure(self, mock_post):
+        mock_post.side_effect = Exception("network error")
+
+        url = create_gist_report(
+            github_token="ghp_test",
+            results_json="{}",
+            description="test",
+        )
+
+        assert url is None
+
+
+# ---------------------------------------------------------------------------
+# dispatch_notification wiring
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchWithExtras:
+    """dispatch_notification passes extra data through."""
+
+    @patch("mcpbr.notifications.send_slack_notification")
+    def test_passes_results_dict_for_file_upload(self, mock_send):
+        from mcpbr.notifications import dispatch_notification
+
+        event = _make_event(extra={"results_json": '{"test": true}'})
+        config = {"slack_webhook": "https://hooks.slack.com/test"}
+
+        dispatch_notification(config, event)
+        mock_send.assert_called_once()
+
+    @patch("mcpbr.notifications.upload_slack_file")
+    def test_uploads_file_when_bot_token_present(self, mock_upload):
+        from mcpbr.notifications import dispatch_notification
+
+        event = _make_event(extra={"results_json": '{"test": true}'})
+        config = {
+            "slack_webhook": "https://hooks.slack.com/test",
+            "slack_bot_token": "xoxb-test",
+            "slack_channel": "C12345",
+        }
+
+        with patch("mcpbr.notifications.send_slack_notification"):
+            dispatch_notification(config, event)
+
+        mock_upload.assert_called_once()
+        call_kwargs = mock_upload.call_args[1]
+        assert call_kwargs["bot_token"] == "xoxb-test"
+
+    @patch("mcpbr.notifications.create_gist_report")
+    @patch("mcpbr.notifications.send_slack_notification")
+    def test_creates_gist_and_adds_url_to_event(self, mock_send, mock_gist):
+        from mcpbr.notifications import dispatch_notification
+
+        mock_gist.return_value = "https://gist.github.com/user/abc123"
+
+        event = _make_event(extra={"results_json": '{"test": true}'})
+        config = {
+            "slack_webhook": "https://hooks.slack.com/test",
+            "github_token": "ghp_test",
+        }
+
+        dispatch_notification(config, event)
+
+        mock_gist.assert_called_once()
+        # Gist URL should be added to event before sending Slack
+        sent_event = mock_send.call_args[0][1]
+        assert sent_event.extra.get("gist_url") == "https://gist.github.com/user/abc123"


### PR DESCRIPTION
## Summary
- **#395**: Enrich Slack notifications with per-task pass/fail results, tool usage stats (total calls, failures, failure rate), and Gist link when available
- **#396**: Upload full `results.json` as a Slack file via bot token (`--slack-bot-token`, `--slack-channel`)
- **#397**: Auto-create a private GitHub Gist with full results and include the link in Slack/Discord/email notifications (`--github-token`)

## New CLI flags
- `--slack-bot-token` — Slack bot token (xoxb-...) for file uploads
- `--slack-channel` — Slack channel ID for file uploads
- `--github-token` — GitHub token with gist scope for report links

## Test plan
- [x] 13 new tests in `tests/test_rich_notifications.py` covering enriched messages, file upload, Gist creation, and dispatch wiring
- [x] All 23 notification tests pass
- [x] Full suite: 3664 passed, 0 failed
- [x] Lint clean (ruff)

Closes #395, closes #396, closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI options for Slack bot token, Slack channel, and GitHub token credentials
  * Enriched notifications with detailed task results and statistics
  * Enabled file uploads to Slack for evaluation results
  * Enabled automatic GitHub Gist creation for report sharing in notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->