### PR TITLE
refactor: Migrate Slack notifications to bot API with threaded file snippets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "requests>=2.31.0",
     "psutil>=5.9.0",
     "paramiko>=3.4.0",
+    "slack_sdk>=3.27.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,10 @@ dependencies = [
     "requests>=2.31.0",
     "psutil>=5.9.0",
     "paramiko>=3.4.0",
-    "slack_sdk>=3.27.0",
 ]
 
 [project.optional-dependencies]
+slack = ["slack_sdk>=3.27.0"]
 dev = [
     "pytest>=9.0.2",
     "pytest-asyncio>=0.21.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
     "pytest-asyncio>=0.21.0",
     "ruff>=0.1.0",
     "pre-commit>=3.0.0",
+    "slack_sdk>=3.27.0",
 ]
 docs = [
     "mkdocs>=1.5.0",

--- a/src/mcpbr/notifications.py
+++ b/src/mcpbr/notifications.py
@@ -124,65 +124,88 @@ def send_slack_notification(webhook_url: str, event: NotificationEvent) -> None:
     response.raise_for_status()
 
 
-def upload_slack_file(
+def send_slack_bot_notification(
     bot_token: str,
     channel: str,
-    content: str,
-    filename: str = "results.json",
-    title: str | None = None,
-) -> None:
-    """Upload a file to a Slack channel via the sequenced upload API.
+    event: NotificationEvent,
+) -> str | None:
+    """Send notification via Slack Bot API and return the message timestamp.
 
-    Uses the files.getUploadURLExternal → PUT → files.completeUploadExternal
-    flow (files.upload was sunset Nov 2025).
-
-    Requires a bot token with files:write scope.
+    Uses chat.postMessage so we can thread replies (e.g. results JSON).
+    Returns the message ``ts`` on success, or ``None`` on failure.
 
     Args:
         bot_token: Slack bot token (xoxb-...).
         channel: Slack channel ID.
-        content: File content as string.
-        filename: Filename for the upload.
-        title: Optional title for the file.
+        event: Notification event payload.
     """
-    headers = {"Authorization": f"Bearer {bot_token}"}
-    content_bytes = content.encode("utf-8")
+    color_emoji = "\u2705" if event.resolution_rate >= 0.3 else "\u26a0\ufe0f"
+    if event.event_type == "regression" and event.regression_count:
+        color_emoji = "\ud83d\udea8"
 
-    # Step 1: Get upload URL
-    url_resp = requests.get(
-        "https://slack.com/api/files.getUploadURLExternal",
-        headers=headers,
-        params={"filename": filename, "length": len(content_bytes)},
+    title = f"*mcpbr {event.event_type.title()}: {event.benchmark}*"
+
+    lines = [title, ""]
+
+    text = _build_slack_text(event)
+    if text:
+        lines.append(text)
+        lines.append("")
+
+    summary_parts = [
+        f"*Model:* {event.model}",
+        f"*Resolution Rate:* {color_emoji} {event.resolution_rate:.1%}",
+        f"*Tasks:* {event.resolved_tasks}/{event.total_tasks}",
+    ]
+    if event.total_cost is not None:
+        summary_parts.append(f"*Cost:* ${event.total_cost:.2f}")
+    if event.runtime_seconds is not None:
+        mins = event.runtime_seconds / 60
+        summary_parts.append(f"*Runtime:* {mins:.1f} min")
+    lines.append(" | ".join(summary_parts))
+
+    message_text = "\n".join(lines)
+
+    resp = requests.post(
+        "https://slack.com/api/chat.postMessage",
+        data={"token": bot_token, "channel": channel, "text": message_text},
         timeout=30,
     )
-    url_resp.raise_for_status()
-    url_data = url_resp.json()
-    if not url_data.get("ok"):
-        raise RuntimeError(f"Slack getUploadURLExternal failed: {url_data.get('error', 'unknown')}")
+    resp.raise_for_status()
+    data = resp.json()
+    if not data.get("ok"):
+        raise RuntimeError(f"Slack chat.postMessage failed: {data.get('error', 'unknown')}")
+    return data.get("ts")
 
-    upload_url = url_data["upload_url"]
-    file_id = url_data["file_id"]
 
-    # Step 2: Upload file content
-    put_resp = requests.put(upload_url, data=content_bytes, timeout=30)
-    put_resp.raise_for_status()
+def post_slack_thread_reply(
+    bot_token: str,
+    channel: str,
+    thread_ts: str,
+    content: str,
+) -> None:
+    """Post a code-block reply in a Slack thread.
 
-    # Step 3: Complete the upload
-    complete_resp = requests.post(
-        "https://slack.com/api/files.completeUploadExternal",
-        headers={**headers, "Content-Type": "application/json"},
-        json={
-            "files": [{"id": file_id, "title": title or filename}],
-            "channel_id": channel,
+    Args:
+        bot_token: Slack bot token (xoxb-...).
+        channel: Slack channel ID.
+        thread_ts: Parent message timestamp to reply to.
+        content: Text content to wrap in a code block.
+    """
+    resp = requests.post(
+        "https://slack.com/api/chat.postMessage",
+        data={
+            "token": bot_token,
+            "channel": channel,
+            "thread_ts": thread_ts,
+            "text": f"```\n{content}\n```",
         },
         timeout=30,
     )
-    complete_resp.raise_for_status()
-    complete_data = complete_resp.json()
-    if not complete_data.get("ok"):
-        raise RuntimeError(
-            f"Slack completeUploadExternal failed: {complete_data.get('error', 'unknown')}"
-        )
+    resp.raise_for_status()
+    data = resp.json()
+    if not data.get("ok"):
+        raise RuntimeError(f"Slack thread reply failed: {data.get('error', 'unknown')}")
 
 
 def create_gist_report(
@@ -348,26 +371,35 @@ def dispatch_notification(config: dict[str, Any], event: NotificationEvent) -> N
         except Exception as e:
             logger.warning("Failed to create Gist: %s", e)
 
-    if config.get("slack_webhook"):
+    # Prefer bot API (supports threaded results reply) over webhook
+    slack_ts: str | None = None
+    if config.get("slack_bot_token") and config.get("slack_channel"):
+        try:
+            slack_ts = send_slack_bot_notification(
+                bot_token=config["slack_bot_token"],
+                channel=config["slack_channel"],
+                event=event,
+            )
+        except Exception as e:
+            logger.warning("Failed to send Slack bot notification: %s", e)
+
+        # Post results JSON as a threaded reply
+        if slack_ts and event.extra.get("results_json"):
+            try:
+                post_slack_thread_reply(
+                    bot_token=config["slack_bot_token"],
+                    channel=config["slack_channel"],
+                    thread_ts=slack_ts,
+                    content=event.extra["results_json"],
+                )
+            except Exception as e:
+                logger.warning("Failed to post Slack thread reply: %s", e)
+    elif config.get("slack_webhook"):
+        # Fall back to webhook when bot token is not configured
         try:
             send_slack_notification(config["slack_webhook"], event)
         except Exception as e:
             logger.warning("Failed to send Slack notification: %s", e)
-
-    # Upload results file to Slack when bot token is configured
-    if config.get("slack_bot_token") and config.get("slack_channel"):
-        try:
-            results_json = event.extra.get("results_json", "")
-            if results_json:
-                upload_slack_file(
-                    bot_token=config["slack_bot_token"],
-                    channel=config["slack_channel"],
-                    content=results_json,
-                    filename=f"mcpbr-{event.benchmark}-results.json",
-                    title=f"mcpbr {event.benchmark} — {event.resolution_rate:.1%}",
-                )
-        except Exception as e:
-            logger.warning("Failed to upload Slack file: %s", e)
 
     if config.get("discord_webhook"):
         try:

--- a/src/mcpbr/notifications.py
+++ b/src/mcpbr/notifications.py
@@ -58,9 +58,9 @@ def _build_slack_text(event: NotificationEvent) -> str:
     # Tool stats
     tool_stats = event.extra.get("tool_stats")
     if tool_stats:
-        total = tool_stats.get("total_calls", 0)
-        success = tool_stats.get("successful_calls", 0)
-        failed = tool_stats.get("failed_calls", 0)
+        total = tool_stats.get("total_tool_calls", 0)
+        failed = tool_stats.get("total_failures", 0)
+        success = total - failed
         rate = tool_stats.get("failure_rate", 0)
         sections.append(
             f"*Tool Usage:* {total} calls ({success} ok, {failed} failed, {rate:.0%} failure rate)"

--- a/tests/test_rich_notifications.py
+++ b/tests/test_rich_notifications.py
@@ -8,8 +8,9 @@ import pytest
 from mcpbr.notifications import (
     NotificationEvent,
     create_gist_report,
+    post_slack_thread_reply,
+    send_slack_bot_notification,
     send_slack_notification,
-    upload_slack_file,
 )
 
 # ---------------------------------------------------------------------------
@@ -144,88 +145,84 @@ class TestEnrichedSlackMessage:
 
 
 # ---------------------------------------------------------------------------
-# #396: Slack file upload
+# #396: Slack bot notification + threaded reply
 # ---------------------------------------------------------------------------
 
 
-class TestSlackFileUpload:
-    """Upload results.json to Slack via sequenced upload API."""
+class TestSlackBotNotification:
+    """Send notification via bot API and post results as threaded reply."""
 
-    @patch("mcpbr.notifications.requests.put")
     @patch("mcpbr.notifications.requests.post")
-    @patch("mcpbr.notifications.requests.get")
-    def test_three_step_upload_flow(self, mock_get, mock_post, mock_put):
-        # Step 1: getUploadURLExternal
-        mock_get.return_value = MagicMock(status_code=200)
-        mock_get.return_value.raise_for_status = MagicMock()
-        mock_get.return_value.json.return_value = {
-            "ok": True,
-            "upload_url": "https://files.slack.com/upload/v1/abc123",
-            "file_id": "F123",
-        }
-        # Step 2: PUT (no json needed)
-        mock_put.return_value = MagicMock(status_code=200)
-        mock_put.return_value.raise_for_status = MagicMock()
-        # Step 3: completeUploadExternal
+    def test_sends_message_and_returns_ts(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+        mock_post.return_value.json.return_value = {"ok": True, "ts": "1234.5678"}
+
+        event = _make_event(extra={"mcp_server": "supermodel (npx mcp-server)"})
+        ts = send_slack_bot_notification("xoxb-test", "C12345", event)
+
+        assert ts == "1234.5678"
+        mock_post.assert_called_once()
+        call_data = mock_post.call_args[1]["data"]
+        assert call_data["token"] == "xoxb-test"
+        assert call_data["channel"] == "C12345"
+        assert "swe-bench-verified" in call_data["text"]
+
+    @patch("mcpbr.notifications.requests.post")
+    def test_message_includes_enriched_text(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+        mock_post.return_value.json.return_value = {"ok": True, "ts": "1234.5678"}
+
+        event = _make_event(
+            extra={
+                "mcp_server": "supermodel",
+                "task_results": [{"instance_id": "task-1", "resolved": True}],
+                "tool_stats": {"total_tool_calls": 30, "total_failures": 7, "failure_rate": 0.233},
+            }
+        )
+        send_slack_bot_notification("xoxb-test", "C12345", event)
+
+        text = mock_post.call_args[1]["data"]["text"]
+        assert "supermodel" in text
+        assert "task-1" in text
+        assert "30" in text
+
+    @patch("mcpbr.notifications.requests.post")
+    def test_raises_on_error(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+        mock_post.return_value.json.return_value = {"ok": False, "error": "channel_not_found"}
+
+        with pytest.raises(RuntimeError, match="channel_not_found"):
+            send_slack_bot_notification("xoxb-test", "C12345", _make_event())
+
+
+class TestSlackThreadReply:
+    """Post results JSON as a code block in a Slack thread."""
+
+    @patch("mcpbr.notifications.requests.post")
+    def test_posts_code_block_in_thread(self, mock_post):
         mock_post.return_value = MagicMock(status_code=200)
         mock_post.return_value.raise_for_status = MagicMock()
         mock_post.return_value.json.return_value = {"ok": True}
 
-        upload_slack_file(
-            bot_token="xoxb-test-token",
-            channel="C12345",
-            content=json.dumps(SAMPLE_RESULTS_DICT),
-            filename="results.json",
-            title="mcpbr results",
-        )
+        post_slack_thread_reply("xoxb-test", "C12345", "1234.5678", '{"test": true}')
 
-        # Verify step 1: GET to getUploadURLExternal
-        mock_get.assert_called_once()
-        get_url = mock_get.call_args[0][0]
-        assert "getUploadURLExternal" in get_url
-
-        # Verify step 2: PUT to upload URL
-        mock_put.assert_called_once()
-        assert mock_put.call_args[0][0] == "https://files.slack.com/upload/v1/abc123"
-
-        # Verify step 3: POST to completeUploadExternal
         mock_post.assert_called_once()
-        post_url = mock_post.call_args[0][0]
-        assert "completeUploadExternal" in post_url
+        call_data = mock_post.call_args[1]["data"]
+        assert call_data["thread_ts"] == "1234.5678"
+        assert "```" in call_data["text"]
+        assert '{"test": true}' in call_data["text"]
 
-    @patch("mcpbr.notifications.requests.get")
-    def test_includes_auth_header(self, mock_get):
-        mock_get.return_value = MagicMock(status_code=200)
-        mock_get.return_value.raise_for_status = MagicMock()
-        mock_get.return_value.json.return_value = {
-            "ok": False,
-            "error": "not_authed",
-        }
-
-        with pytest.raises(RuntimeError, match="not_authed"):
-            upload_slack_file(
-                bot_token="xoxb-test-token",
-                channel="C12345",
-                content="{}",
-                filename="results.json",
-            )
-
-        headers = mock_get.call_args[1].get("headers", {})
-        assert "Bearer xoxb-test-token" in headers.get("Authorization", "")
-
-    @patch("mcpbr.notifications.requests.get")
-    def test_raises_on_get_url_error(self, mock_get):
-        mock_get.return_value = MagicMock(status_code=200)
-        mock_get.return_value.raise_for_status = MagicMock()
-        mock_get.return_value.json.return_value = {"ok": False, "error": "not_authed"}
+    @patch("mcpbr.notifications.requests.post")
+    def test_raises_on_error(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+        mock_post.return_value.json.return_value = {"ok": False, "error": "not_authed"}
 
         with pytest.raises(RuntimeError, match="not_authed"):
-            upload_slack_file(
-                bot_token="bad-token",
-                channel="C12345",
-                content="{}",
-                filename="results.json",
-            )
+            post_slack_thread_reply("xoxb-bad", "C12345", "1234.5678", "{}")
 
 
 # ---------------------------------------------------------------------------
@@ -294,10 +291,10 @@ class TestGistCreation:
 
 
 class TestDispatchWithExtras:
-    """dispatch_notification passes extra data through."""
+    """dispatch_notification wires bot notification + threaded reply."""
 
     @patch("mcpbr.notifications.send_slack_notification")
-    def test_passes_results_dict_for_file_upload(self, mock_send):
+    def test_falls_back_to_webhook_without_bot_token(self, mock_send):
         from mcpbr.notifications import dispatch_notification
 
         event = _make_event(extra={"results_json": '{"test": true}'})
@@ -306,23 +303,63 @@ class TestDispatchWithExtras:
         dispatch_notification(config, event)
         mock_send.assert_called_once()
 
-    @patch("mcpbr.notifications.upload_slack_file")
-    def test_uploads_file_when_bot_token_present(self, mock_upload):
+    @patch("mcpbr.notifications.post_slack_thread_reply")
+    @patch("mcpbr.notifications.send_slack_bot_notification")
+    def test_bot_sends_notification_and_thread_reply(self, mock_bot, mock_reply):
         from mcpbr.notifications import dispatch_notification
 
+        mock_bot.return_value = "1234.5678"
+
         event = _make_event(extra={"results_json": '{"test": true}'})
+        config = {
+            "slack_bot_token": "xoxb-test",
+            "slack_channel": "C12345",
+        }
+
+        dispatch_notification(config, event)
+
+        mock_bot.assert_called_once()
+        mock_reply.assert_called_once()
+        call_kwargs = mock_reply.call_args[1]
+        assert call_kwargs["thread_ts"] == "1234.5678"
+        assert call_kwargs["content"] == '{"test": true}'
+
+    @patch("mcpbr.notifications.post_slack_thread_reply")
+    @patch("mcpbr.notifications.send_slack_bot_notification")
+    def test_skips_thread_reply_without_results_json(self, mock_bot, mock_reply):
+        from mcpbr.notifications import dispatch_notification
+
+        mock_bot.return_value = "1234.5678"
+
+        event = _make_event()
+        config = {
+            "slack_bot_token": "xoxb-test",
+            "slack_channel": "C12345",
+        }
+
+        dispatch_notification(config, event)
+
+        mock_bot.assert_called_once()
+        mock_reply.assert_not_called()
+
+    @patch("mcpbr.notifications.send_slack_bot_notification")
+    @patch("mcpbr.notifications.send_slack_notification")
+    def test_bot_takes_priority_over_webhook(self, mock_webhook, mock_bot):
+        from mcpbr.notifications import dispatch_notification
+
+        mock_bot.return_value = "1234.5678"
+
+        event = _make_event()
         config = {
             "slack_webhook": "https://hooks.slack.com/test",
             "slack_bot_token": "xoxb-test",
             "slack_channel": "C12345",
         }
 
-        with patch("mcpbr.notifications.send_slack_notification"):
-            dispatch_notification(config, event)
+        dispatch_notification(config, event)
 
-        mock_upload.assert_called_once()
-        call_kwargs = mock_upload.call_args[1]
-        assert call_kwargs["bot_token"] == "xoxb-test"
+        mock_bot.assert_called_once()
+        mock_webhook.assert_not_called()
 
     @patch("mcpbr.notifications.create_gist_report")
     @patch("mcpbr.notifications.send_slack_notification")
@@ -340,6 +377,5 @@ class TestDispatchWithExtras:
         dispatch_notification(config, event)
 
         mock_gist.assert_called_once()
-        # Gist URL should be added to event before sending Slack
         sent_event = mock_send.call_args[0][1]
         assert sent_event.extra.get("gist_url") == "https://gist.github.com/user/abc123"

--- a/tests/test_rich_notifications.py
+++ b/tests/test_rich_notifications.py
@@ -85,9 +85,8 @@ class TestEnrichedSlackMessage:
         event = _make_event(
             extra={
                 "tool_stats": {
-                    "total_calls": 30,
-                    "successful_calls": 23,
-                    "failed_calls": 7,
+                    "total_tool_calls": 30,
+                    "total_failures": 7,
                     "failure_rate": 0.233,
                 },
             }


### PR DESCRIPTION
## Summary
- Fixed key mismatch between harness output (`total_tool_calls`, `total_failures`) and notification reader (`total_calls`, `successful_calls`, `failed_calls`)
- This caused Slack messages to show "0 calls (0 ok, 0 failed, 20% failure rate)" instead of the actual counts
- Updated tests to match actual harness output format

## Test plan
- [x] All 14 rich notification tests pass
- [ ] Live test with `--notify-slack` shows correct tool usage stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack notifications now send via Slack Bot API (preferred) with richer message content and optional threaded results snippets; webhook delivery remains as a fallback.

* **Bug Fixes**
  * Tool statistics in notifications corrected for accurate total and failure reporting.

* **Tests**
  * Notification tests updated to validate bot delivery, threading, enriched content, fallback behavior, and error handling.

* **Chores**
  * Optional Slack SDK dependency added for bot-based notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->