### PR TITLE
fix: Retry empty workspace after Docker copy (#405)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "mcpbr",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "mcpbr - MCP Benchmark Runner plugin marketplace",
   "owner": {
     "name": "mcpbr Contributors",
@@ -11,7 +11,7 @@
     {
       "name": "mcpbr",
       "description": "Expert benchmark runner for MCP servers using mcpbr. Handles Docker checks, config generation, and result parsing.",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "author": {
         "name": "mcpbr Contributors"
       },

--- a/.claude-plugin/package.json
+++ b/.claude-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@greynewell/mcpbr-claude-plugin",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Claude Code plugin for mcpbr - Expert benchmark runner for MCP servers with specialized skills",
   "keywords": [
     "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcpbr",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Expert benchmark runner for MCP servers using mcpbr. Handles Docker checks, config generation, and result parsing.",
   "schema_version": "1.0"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,14 +69,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - GitHub Pages CNAME configuration
   - All documentation URLs updated to mcpbr.org
 
-## [0.5.5] - 2026-02-06
-
-### Fixed
-
-- **Retry empty workspace after Docker copy** (#405): Under high concurrency, the Docker
-  filesystem copy from `/testbed` to `/workspace` can silently produce an empty workspace.
-  Now retries with a sync and, if necessary, a full re-copy before raising an error.
-
 ## [0.7.0] - 2026-02-06
 
 ### Added
@@ -133,6 +125,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `conda/meta.yaml` recipe for Conda packaging
   - `action/action.yml` GitHub Action with basic and matrix examples
   - `ci-templates/` for GitLab CI and CircleCI integration
+
+## [0.5.5] - 2026-02-06
+
+### Fixed
+
+- **Retry empty workspace after Docker copy** (#405): Under high concurrency, the Docker
+  filesystem copy from `/testbed` to `/workspace` can silently produce an empty workspace.
+  Now retries with a sync and, if necessary, a full re-copy before raising an error.
 
 ## [0.5.0] - 2026-02-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - GitHub Pages CNAME configuration
   - All documentation URLs updated to mcpbr.org
 
+## [0.5.5] - 2026-02-06
+
+### Fixed
+
+- **Retry empty workspace after Docker copy** (#405): Under high concurrency, the Docker
+  filesystem copy from `/testbed` to `/workspace` can silently produce an empty workspace.
+  Now retries with a sync and, if necessary, a full re-copy before raising an error.
+
 ## [0.7.0] - 2026-02-06
 
 ### Added
@@ -847,6 +855,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--no-prebuilt` CLI flag to disable pre-built images and build from scratch
 - Network access for containers to enable API calls from within Docker
 
+[0.5.5]: https://github.com/greynewell/mcpbr/releases/tag/v0.5.5
 [0.4.4]: https://github.com/greynewell/mcpbr/releases/tag/v0.4.4
 [0.4.3]: https://github.com/greynewell/mcpbr/releases/tag/v0.4.3
 [0.4.2]: https://github.com/greynewell/mcpbr/releases/tag/v0.4.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@greynewell/mcpbr",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Model Context Protocol Benchmark Runner - CLI tool for evaluating MCP servers",
   "keywords": [
     "mcpbr",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcpbr"
-version = "0.5.4"
+version = "0.5.5"
 description = "Model Context Protocol Benchmark Runner - evaluate MCP servers against software engineering benchmarks"
 readme = "README.md"
 license = "MIT"

--- a/src/mcpbr/docker_env.py
+++ b/src/mcpbr/docker_env.py
@@ -583,13 +583,13 @@ CMD ["/bin/bash"]
         return env
 
     async def _check_workspace_file_count(self, env: TaskEnvironment) -> int:
-        """Check the number of top-level entries in /workspace.
+        """Check whether /workspace has any top-level entries.
 
         Args:
             env: Task environment to check.
 
         Returns:
-            Number of top-level files/directories in /workspace.
+            Number of top-level files/directories found (capped at 5).
         """
         exit_code, stdout, _ = await env.exec_command(
             "find /workspace -maxdepth 1 -mindepth 1 | head -5 | wc -l",
@@ -658,7 +658,7 @@ CMD ["/bin/bash"]
             "Workspace still empty after sync retry — re-copying from /testbed "
             f"(instance={env.instance_id})"
         )
-        exit_code, stdout, stderr = await env.exec_command(
+        exit_code, _, stderr = await env.exec_command(
             "cp -r /testbed/. /workspace/",
             timeout=120,
         )
@@ -682,8 +682,9 @@ CMD ["/bin/bash"]
 
         # --- Exhausted ---
         raise RuntimeError(
-            "Workspace /workspace appears empty after copy from /testbed. "
-            "The filesystem may not have synced correctly."
+            f"Workspace /workspace appears empty after copy from /testbed "
+            f"(instance={env.instance_id}). "
+            f"The filesystem may not have synced correctly."
         )
 
     async def _install_claude_cli(self, env: TaskEnvironment) -> None:

--- a/src/mcpbr/docker_env.py
+++ b/src/mcpbr/docker_env.py
@@ -582,12 +582,32 @@ CMD ["/bin/bash"]
 
         return env
 
+    async def _check_workspace_file_count(self, env: TaskEnvironment) -> int:
+        """Check the number of top-level entries in /workspace.
+
+        Args:
+            env: Task environment to check.
+
+        Returns:
+            Number of top-level files/directories in /workspace.
+        """
+        exit_code, stdout, _ = await env.exec_command(
+            "find /workspace -maxdepth 1 -mindepth 1 | head -5 | wc -l",
+            timeout=10,
+        )
+        return int(stdout.strip()) if exit_code == 0 and stdout.strip().isdigit() else 0
+
     async def _copy_repo_to_workspace(self, env: TaskEnvironment) -> None:
         """Copy repo from pre-built image /testbed to /workspace for agent access.
+
+        Under high concurrency the Docker filesystem copy can silently produce
+        an empty workspace.  This method retries with a sync and, if necessary,
+        a full re-copy before giving up.
 
         Args:
             env: Task environment with pre-built image.
         """
+        # --- Phase 1: initial copy + verify ---
         exit_code, stdout, stderr = await env.exec_command(
             "cp -r /testbed/. /workspace/",
             timeout=120,
@@ -611,19 +631,60 @@ CMD ["/bin/bash"]
         # before any subsequent commands (e.g., setup_command) run.
         await env.exec_command("sync", timeout=10)
 
-        # Verify workspace is populated — catch copy failures early
-        exit_code, stdout, _ = await env.exec_command(
-            "find /workspace -maxdepth 1 -mindepth 1 | head -5 | wc -l",
-            timeout=10,
-        )
-        file_count = int(stdout.strip()) if exit_code == 0 and stdout.strip().isdigit() else 0
-        if file_count == 0:
-            raise RuntimeError(
-                "Workspace /workspace appears empty after copy from /testbed. "
-                "The filesystem may not have synced correctly."
-            )
+        file_count = await self._check_workspace_file_count(env)
+        if file_count > 0:
+            env.workdir = "/workspace"
+            return
 
-        env.workdir = "/workspace"
+        # --- Phase 2: sync retry ---
+        logger.warning(
+            "Workspace /workspace empty after initial copy — retrying with sync "
+            f"(instance={env.instance_id})"
+        )
+        await asyncio.sleep(2)
+        await env.exec_command("sync", timeout=10)
+
+        file_count = await self._check_workspace_file_count(env)
+        if file_count > 0:
+            logger.info(
+                "Workspace populated after sync retry "
+                f"(instance={env.instance_id}, files={file_count})"
+            )
+            env.workdir = "/workspace"
+            return
+
+        # --- Phase 3: full copy retry ---
+        logger.warning(
+            "Workspace still empty after sync retry — re-copying from /testbed "
+            f"(instance={env.instance_id})"
+        )
+        exit_code, stdout, stderr = await env.exec_command(
+            "cp -r /testbed/. /workspace/",
+            timeout=120,
+        )
+        if exit_code != 0:
+            raise RuntimeError(f"Failed to re-copy repo to workspace: {stderr}")
+
+        await env.exec_command(
+            "cd /workspace && git checkout -- . && git clean -fd",
+            timeout=30,
+        )
+        await env.exec_command("sync", timeout=10)
+
+        file_count = await self._check_workspace_file_count(env)
+        if file_count > 0:
+            logger.info(
+                "Workspace populated after full copy retry "
+                f"(instance={env.instance_id}, files={file_count})"
+            )
+            env.workdir = "/workspace"
+            return
+
+        # --- Exhausted ---
+        raise RuntimeError(
+            "Workspace /workspace appears empty after copy from /testbed. "
+            "The filesystem may not have synced correctly."
+        )
 
     async def _install_claude_cli(self, env: TaskEnvironment) -> None:
         """Install Node.js and Claude CLI in the container.

--- a/tests/test_setup_command_fixes.py
+++ b/tests/test_setup_command_fixes.py
@@ -1,11 +1,12 @@
-"""Tests for setup_command bug fixes (#386, #387, #388).
+"""Tests for setup_command bug fixes (#386, #387, #388) and workspace retry (#405).
 
 Bug #386: setup_command runs as root but agent runs as mcpbr user
 Bug #387: setup_command may execute before workspace is fully populated
 Bug #388: setup_command failures are silent unless --verbose is used
+Bug #405: Retry empty workspace after Docker copy
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -306,8 +307,9 @@ class TestWorkspaceVerification:
         assert len(find_calls) == 1
 
     @pytest.mark.asyncio
-    async def test_copy_repo_raises_on_empty_workspace(self):
-        """If workspace is empty after copy, a RuntimeError should be raised."""
+    @patch("asyncio.sleep", return_value=None)
+    async def test_copy_repo_raises_on_empty_workspace(self, mock_sleep):
+        """If workspace is empty after all retries, a RuntimeError should be raised."""
         container = MagicMock()
 
         def _exec_run(cmd, **kwargs):
@@ -358,6 +360,106 @@ class TestWorkspaceVerification:
         await manager._copy_repo_to_workspace(env)
 
         assert env.workdir == "/workspace"
+
+    @pytest.mark.asyncio
+    @patch("asyncio.sleep", return_value=None)
+    async def test_copy_repo_succeeds_after_sync_retry(self, mock_sleep):
+        """If workspace is empty initially but populated after sync retry, succeed."""
+        container = MagicMock()
+
+        wc_call_count = {"n": 0}
+
+        def _exec_run(cmd, **kwargs):
+            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+            result = MagicMock()
+            result.exit_code = 0
+            if "wc -l" in cmd_str:
+                wc_call_count["n"] += 1
+                if wc_call_count["n"] == 1:
+                    result.output = (b"0", b"")  # First check: empty
+                else:
+                    result.output = (b"3", b"")  # Second check: populated
+            else:
+                result.output = (b"", b"")
+            return result
+
+        container.exec_run = _exec_run
+
+        env = _make_task_env(container)
+        env.workdir = "/testbed"
+
+        from mcpbr.docker_env import DockerEnvironmentManager
+
+        manager = DockerEnvironmentManager.__new__(DockerEnvironmentManager)
+        await manager._copy_repo_to_workspace(env)
+
+        assert env.workdir == "/workspace"
+        mock_sleep.assert_awaited_once_with(2)
+
+    @pytest.mark.asyncio
+    @patch("asyncio.sleep", return_value=None)
+    async def test_copy_repo_succeeds_after_full_copy_retry(self, mock_sleep):
+        """If workspace is empty after sync retry but populated after full copy retry."""
+        container = MagicMock()
+
+        wc_call_count = {"n": 0}
+
+        def _exec_run(cmd, **kwargs):
+            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+            result = MagicMock()
+            result.exit_code = 0
+            if "wc -l" in cmd_str:
+                wc_call_count["n"] += 1
+                if wc_call_count["n"] <= 2:
+                    result.output = (b"0", b"")  # First two checks: empty
+                else:
+                    result.output = (b"5", b"")  # Third check: populated
+            else:
+                result.output = (b"", b"")
+            return result
+
+        container.exec_run = _exec_run
+
+        env = _make_task_env(container)
+        env.workdir = "/testbed"
+
+        from mcpbr.docker_env import DockerEnvironmentManager
+
+        manager = DockerEnvironmentManager.__new__(DockerEnvironmentManager)
+        await manager._copy_repo_to_workspace(env)
+
+        assert env.workdir == "/workspace"
+
+    @pytest.mark.asyncio
+    @patch("asyncio.sleep", return_value=None)
+    async def test_copy_repo_raises_after_all_retries_exhausted(self, mock_sleep):
+        """If workspace is empty after all retries, RuntimeError should be raised."""
+        container = MagicMock()
+
+        def _exec_run(cmd, **kwargs):
+            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+            result = MagicMock()
+            result.exit_code = 0
+            if "wc -l" in cmd_str:
+                result.output = (b"0", b"")  # Always empty
+            else:
+                result.output = (b"", b"")
+            return result
+
+        container.exec_run = _exec_run
+
+        env = _make_task_env(container)
+        env.workdir = "/testbed"
+
+        from mcpbr.docker_env import DockerEnvironmentManager
+
+        manager = DockerEnvironmentManager.__new__(DockerEnvironmentManager)
+
+        with pytest.raises(RuntimeError, match="appears empty after copy"):
+            await manager._copy_repo_to_workspace(env)
+
+        # Verify sleep was called (sync retry phase)
+        mock_sleep.assert_awaited_once_with(2)
 
 
 # ===========================================================================

--- a/tests/test_setup_command_fixes.py
+++ b/tests/test_setup_command_fixes.py
@@ -308,7 +308,7 @@ class TestWorkspaceVerification:
 
     @pytest.mark.asyncio
     @patch("asyncio.sleep", return_value=None)
-    async def test_copy_repo_raises_on_empty_workspace(self, mock_sleep):
+    async def test_copy_repo_raises_on_empty_workspace(self, _mock_sleep):
         """If workspace is empty after all retries, a RuntimeError should be raised."""
         container = MagicMock()
 
@@ -429,6 +429,8 @@ class TestWorkspaceVerification:
         await manager._copy_repo_to_workspace(env)
 
         assert env.workdir == "/workspace"
+        # Verify sleep was called during sync retry phase
+        mock_sleep.assert_awaited_once_with(2)
 
     @pytest.mark.asyncio
     @patch("asyncio.sleep", return_value=None)


### PR DESCRIPTION
## Summary

- Under high-concurrency SWE-bench evaluation runs (10+ containers), the Docker filesystem copy from `/testbed` to `/workspace` can silently produce an empty workspace
- Added a 3-phase retry strategy to `_copy_repo_to_workspace()` before giving up: initial copy → sync retry (2s delay) → full re-copy from `/testbed`
- Extracted `_check_workspace_file_count()` helper to avoid duplicating the `find/wc -l` verification
- Bumped version to 0.5.5 across all package files

## Test plan

- [x] Updated `test_copy_repo_raises_on_empty_workspace` to mock `asyncio.sleep` (now traverses retry paths)
- [x] Added `test_copy_repo_succeeds_after_sync_retry` — first wc-l returns 0, second returns 3
- [x] Added `test_copy_repo_succeeds_after_full_copy_retry` — first two wc-l return 0, third returns 5
- [x] Added `test_copy_repo_raises_after_all_retries_exhausted` — all wc-l return 0
- [x] All 2629 non-integration tests pass
- [x] Linting and formatting pass

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.5.5

* **Bug Fixes**
  * Fixed empty workspace issue after Docker copy under high concurrency. Added multi-phase retry mechanism that syncs the workspace and performs a full re-copy if needed before raising an error.

* **Chores**
  * Version bumped to 0.5.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->