### PR TITLE
fix: Retry empty workspace after Docker copy (#405)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Retry empty workspace after Docker copy** (#405): Under high concurrency, the Docker
+  filesystem copy from `/testbed` to `/workspace` can silently produce an empty workspace.
+  Now retries with a sync and, if necessary, a full re-copy before raising an error.
 - **setup_command runs as mcpbr user in Docker** (#386): setup_command now executes as the
   mcpbr user instead of root, preventing EACCES permission errors when the agent accesses
   files created during setup (e.g., npm cache)
@@ -135,6 +138,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `conda/meta.yaml` recipe for Conda packaging
   - `action/action.yml` GitHub Action with basic and matrix examples
   - `ci-templates/` for GitLab CI and CircleCI integration
+
+## [0.5.5] - 2026-02-06
+
+### Fixed
+
+- **Retry empty workspace after Docker copy** (#405): Under high concurrency, the Docker
+  filesystem copy from `/testbed` to `/workspace` can silently produce an empty workspace.
+  Now retries with a sync and, if necessary, a full re-copy before raising an error.
 
 ## [0.5.0] - 2026-02-05
 
@@ -857,6 +868,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--no-prebuilt` CLI flag to disable pre-built images and build from scratch
 - Network access for containers to enable API calls from within Docker
 
+[0.5.5]: https://github.com/greynewell/mcpbr/releases/tag/v0.5.5
 [0.4.4]: https://github.com/greynewell/mcpbr/releases/tag/v0.4.4
 [0.4.3]: https://github.com/greynewell/mcpbr/releases/tag/v0.4.3
 [0.4.2]: https://github.com/greynewell/mcpbr/releases/tag/v0.4.2

--- a/src/mcpbr/docker_env.py
+++ b/src/mcpbr/docker_env.py
@@ -583,12 +583,32 @@ CMD ["/bin/bash"]
 
         return env
 
+    async def _check_workspace_file_count(self, env: TaskEnvironment) -> int:
+        """Check whether /workspace has any top-level entries.
+
+        Args:
+            env: Task environment to check.
+
+        Returns:
+            Number of top-level files/directories found (capped at 5).
+        """
+        exit_code, stdout, _ = await env.exec_command(
+            "find /workspace -maxdepth 1 -mindepth 1 | head -5 | wc -l",
+            timeout=10,
+        )
+        return int(stdout.strip()) if exit_code == 0 and stdout.strip().isdigit() else 0
+
     async def _copy_repo_to_workspace(self, env: TaskEnvironment) -> None:
         """Copy repo from pre-built image /testbed to /workspace for agent access.
+
+        Under high concurrency the Docker filesystem copy can silently produce
+        an empty workspace.  This method retries with a sync and, if necessary,
+        a full re-copy before giving up.
 
         Args:
             env: Task environment with pre-built image.
         """
+        # --- Phase 1: initial copy + verify ---
         exit_code, stdout, stderr = await env.exec_command(
             "cp -r /testbed/. /workspace/",
             timeout=120,
@@ -612,19 +632,61 @@ CMD ["/bin/bash"]
         # before any subsequent commands (e.g., setup_command) run.
         await env.exec_command("sync", timeout=10)
 
-        # Verify workspace is populated — catch copy failures early
-        exit_code, stdout, _ = await env.exec_command(
-            "find /workspace -maxdepth 1 -mindepth 1 | head -5 | wc -l",
-            timeout=10,
-        )
-        file_count = int(stdout.strip()) if exit_code == 0 and stdout.strip().isdigit() else 0
-        if file_count == 0:
-            raise RuntimeError(
-                "Workspace /workspace appears empty after copy from /testbed. "
-                "The filesystem may not have synced correctly."
-            )
+        file_count = await self._check_workspace_file_count(env)
+        if file_count > 0:
+            env.workdir = "/workspace"
+            return
 
-        env.workdir = "/workspace"
+        # --- Phase 2: sync retry ---
+        logger.warning(
+            "Workspace /workspace empty after initial copy — retrying with sync "
+            f"(instance={env.instance_id})"
+        )
+        await asyncio.sleep(2)
+        await env.exec_command("sync", timeout=10)
+
+        file_count = await self._check_workspace_file_count(env)
+        if file_count > 0:
+            logger.info(
+                "Workspace populated after sync retry "
+                f"(instance={env.instance_id}, files={file_count})"
+            )
+            env.workdir = "/workspace"
+            return
+
+        # --- Phase 3: full copy retry ---
+        logger.warning(
+            "Workspace still empty after sync retry — re-copying from /testbed "
+            f"(instance={env.instance_id})"
+        )
+        exit_code, _, stderr = await env.exec_command(
+            "cp -r /testbed/. /workspace/",
+            timeout=120,
+        )
+        if exit_code != 0:
+            raise RuntimeError(f"Failed to re-copy repo to workspace: {stderr}")
+
+        await env.exec_command(
+            "cd /workspace && git checkout -- . && git clean -fd",
+            timeout=30,
+        )
+        await env.exec_command("sync", timeout=10)
+
+        file_count = await self._check_workspace_file_count(env)
+        if file_count > 0:
+            logger.info(
+                "Workspace populated after full copy retry "
+                f"(instance={env.instance_id}, files={file_count})"
+            )
+            env.workdir = "/workspace"
+            return
+
+        # --- Exhausted ---
+        raise RuntimeError(
+            f"Workspace /workspace appears empty after copy from /testbed "
+            f"(instance={env.instance_id}). "
+            f"The filesystem may not have synced correctly."
+        )
 
     async def _install_claude_cli(self, env: TaskEnvironment) -> None:
         """Install Node.js and Claude CLI in the container.

--- a/src/mcpbr/docker_env.py
+++ b/src/mcpbr/docker_env.py
@@ -592,11 +592,14 @@ CMD ["/bin/bash"]
         Returns:
             Number of top-level files/directories found (capped at 5).
         """
-        exit_code, stdout, _ = await env.exec_command(
-            "find /workspace -maxdepth 1 -mindepth 1 | head -5 | wc -l",
-            timeout=10,
-        )
-        return int(stdout.strip()) if exit_code == 0 and stdout.strip().isdigit() else 0
+        try:
+            exit_code, stdout, _ = await env.exec_command(
+                "find /workspace -maxdepth 1 -mindepth 1 | head -5 | wc -l",
+                timeout=10,
+            )
+            return int(stdout.strip()) if exit_code == 0 and stdout.strip().isdigit() else 0
+        except Exception:
+            return 0
 
     async def _copy_repo_to_workspace(self, env: TaskEnvironment) -> None:
         """Copy repo from pre-built image /testbed to /workspace for agent access.


### PR DESCRIPTION
## Summary

Cherry-pick of #406 from `release/v0.5.x` to `main`.

- Under high-concurrency SWE-bench evaluation runs (10+ containers), the Docker filesystem copy from `/testbed` to `/workspace` can silently produce an empty workspace
- Added a 3-phase retry strategy to `_copy_repo_to_workspace()`: initial copy → sync retry (2s delay) → full re-copy from `/testbed`
- Extracted `_check_workspace_file_count()` helper to avoid duplicating the `find/wc -l` verification

## Test plan

- [x] `test_copy_repo_raises_on_empty_workspace` — updated to account for retry paths
- [x] `test_copy_repo_succeeds_after_sync_retry` — first wc-l returns 0, second returns 3
- [x] `test_copy_repo_succeeds_after_full_copy_retry` — first two wc-l return 0, third returns 5
- [x] `test_copy_repo_raises_after_all_retries_exhausted` — all wc-l return 0
- [x] All tests pass, linting clean

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved issue where workspace could remain empty after Docker copy operations, with improved retry handling to ensure workspace is properly populated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->