### PR TITLE
fix: Improve error when agent writes then reverts changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Misleading 'no changes detected' error** (#409): When an agent wrote changes that were
+  later reverted, the error field incorrectly reported "no changes detected." Now reports
+  "working tree is clean - changes were likely reverted" with tool call counts, and suppresses
+  the error entirely when a patch was generated and evaluated.
+
 ### Documentation
 
 - **About page**: New docs/about.md page with the mcpbr origin story, project vision, community

--- a/src/mcpbr/harness.py
+++ b/src/mcpbr/harness.py
@@ -191,10 +191,17 @@ def agent_result_to_dict(
         data["profiling"] = result.profiling_report
 
     if result.error:
-        data["error"] = result.error
-        # Add status field to distinguish timeouts from other errors
-        if "timed out" in result.error.lower() or "timeout" in result.error.lower():
-            data["status"] = "timeout"
+        # Suppress misleading "no changes" / "clean" errors when a patch was
+        # actually generated and evaluated (the agent wrote then reverted).
+        if data["patch_generated"] and (
+            "no changes detected" in result.error or "working tree is clean" in result.error
+        ):
+            pass
+        else:
+            data["error"] = result.error
+            # Add status field to distinguish timeouts from other errors
+            if "timed out" in result.error.lower() or "timeout" in result.error.lower():
+                data["status"] = "timeout"
 
     if result.messages:
         data["messages"] = result.messages

--- a/src/mcpbr/harnesses.py
+++ b/src/mcpbr/harnesses.py
@@ -496,11 +496,13 @@ def _generate_no_patch_error_message(
     # If buggy line is not present (empty), it might have been fixed
     if not buggy_line:
         if edit_tools_used:
-            # Edit tools were used but no git changes detected
+            # Edit tools were used but no git changes detected at the end —
+            # the agent likely wrote changes that were reverted in later iterations
             tools_str = ", ".join(sorted(edit_tools_used))
+            edit_counts = ", ".join(f"{t} x{tool_usage[t]}" for t in sorted(edit_tools_used))
             return (
-                f"{tools_str} tool(s) used but no changes detected - "
-                "file may be unchanged or changes were reverted"
+                f"{tools_str} tool(s) used ({edit_counts}) but final working tree is clean - "
+                "changes were likely reverted during later iterations"
             )
         else:
             # No edit tools used and buggy line not found


### PR DESCRIPTION
## Summary

- Fixes misleading "no changes detected" error when agent wrote changes that were later reverted during evaluation (#409)
- Changes error wording to "working tree is clean - changes were likely reverted" with tool call counts (e.g., `Write x5`)
- Adds defensive guard in `agent_result_to_dict` to suppress the error when `patch_generated` is True (patch was actually extracted and evaluated)

## Test plan

- [x] Updated existing error message tests to match new wording
- [x] Added 4 new tests in `TestErrorSuppression`:
  - Error suppressed when patch exists
  - Error kept when no patch
  - Timeout errors never suppressed
  - Legacy "no changes detected" message also suppressed
- [x] 4038 tests passing, all linting clean

Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)