### PR TITLE
fix: Wire up SUPERMODEL_CACHE_DIR in supermodel config

### DIFF
--- a/config/supermodel.yaml
+++ b/config/supermodel.yaml
@@ -8,9 +8,15 @@ mcp_server:
   command: "npx"
   args:
     - "-y"
-    - "@supermodeltools/mcp-server"
+    - "@supermodeltools/mcp-server@0.9.1"
+    - "{workdir}"
+    - "--precache"
   env:
     SUPERMODEL_API_KEY: "${SUPERMODEL_API_KEY}"
+    SUPERMODEL_BASE_URL: "https://api.supermodeltools.com"
+    SUPERMODEL_CACHE_DIR: "/tmp/supermodel-cache"
+  setup_command: "npx -y @supermodeltools/mcp-server@0.9.1 precache {workdir} --output-dir /tmp/supermodel-cache"
+  setup_timeout_ms: 900000
 
 provider: "anthropic"
 
@@ -18,9 +24,9 @@ agent_harness: "claude-code"
 
 model: "claude-sonnet-4-20250514"
 
-dataset: "SWE-bench/SWE-bench_Lite"
+benchmark: "swe-bench-verified"
 
-sample_size: 10  # Run full SWE-bench Lite dataset
+sample_size: 10
 
 timeout_seconds: 300
 


### PR DESCRIPTION
## Summary

- Pin to `@supermodeltools/mcp-server@0.9.1` (has non-blocking precache fix)
- Add `{workdir}` and `--precache` args so the server knows which repo to cache
- Set `SUPERMODEL_CACHE_DIR=/tmp/supermodel-cache` in env
- Add matching `--output-dir /tmp/supermodel-cache` to `setup_command`
- Add `setup_timeout_ms: 900000` for long initial API calls
- Switch dataset to `swe-bench-verified`

## Context

The `setup_command` pre-computes a graph cache and saves it to disk, but the MCP server's env didn't include `SUPERMODEL_CACHE_DIR`. The server couldn't find the cache, re-called the API on startup, and blocked the MCP handshake — causing 65% connection failures in the 500-task SWE-bench run.

Companion PR: https://github.com/supermodeltools/mcp/pull/new/fix/non-blocking-precache-startup (server-side fix to connect transport before precache)

## Test plan

- [ ] Run a small mcpbr eval with the updated config and verify MCP server connects successfully
- [ ] Verify `setup_command` writes cache to `/tmp/supermodel-cache`
- [ ] Verify MCP server reads cache from `/tmp/supermodel-cache` via `SUPERMODEL_CACHE_DIR`

🤖 Generated with [Claude Code](https://claude.com/claude-code)