### PR TITLE
feat: Incremental cloud storage uploads during evaluation runs

### DIFF
--- a/config/supermodel-eval-0.9.2.yaml
+++ b/config/supermodel-eval-0.9.2.yaml
@@ -46,6 +46,13 @@ infrastructure:
     env_keys_to_export:
       - "ANTHROPIC_API_KEY"
       - "SUPERMODEL_API_KEY"
+      - "AZURE_STORAGE_KEY"
+
+# Cloud storage for incremental result persistence
+cloud_storage:
+  provider: "azure_blob"
+  account: "mcpbrbenchmarks"
+  container: "eval-runs"
 
 # Slack notifications (bot API with file upload)
 slack_bot_token: "${SLACK_BOT_TOKEN}"

--- a/src/mcpbr/cli.py
+++ b/src/mcpbr/cli.py
@@ -889,6 +889,8 @@ To archive:
             )
             results = infra_result["results"]
         else:
+            # Enable incremental save for crash recovery
+            incremental_path = final_output_dir / "incremental_results"
             results = asyncio.run(
                 run_evaluation(
                     config=config,
@@ -901,6 +903,7 @@ To archive:
                     task_ids=selected_task_ids,
                     state_tracker=state_tracker,
                     from_task=from_task,
+                    incremental_save_path=incremental_path,
                     mcp_logs_dir=final_output_dir,
                 )
             )


### PR DESCRIPTION
## Summary

- Add incremental cloud storage uploads after each task completes during evaluation runs
- Wire `incremental_save_path` from CLI to harness (parameter was accepted but never passed)
- Add cloud storage config to supermodel eval YAML with Azure Blob Storage backend

This prevents total data loss when Azure VMs crash or are terminated mid-evaluation. Previously, cloud upload only happened after the full run completed — if the VM died, all results were lost.

## Changes

- **`src/mcpbr/harness.py`**: Add `_upload_to_cloud_async()` helper that uploads files in background threads. Initialize cloud storage from `config.cloud_storage` at evaluation start. Upload incremental JSONL and new log files after each task completes.
- **`src/mcpbr/cli.py`**: Pass `incremental_save_path` to `run_evaluation()` (was accepted as a parameter but never wired from the CLI).
- **`config/supermodel-eval-0.9.2.yaml`**: Add `cloud_storage` config block and `AZURE_STORAGE_KEY` to env exports.

## Test plan

- [x] All 736 existing tests pass (1 pre-existing failure on gated dataset unrelated)
- [x] `ruff` and `ruff format` pass
- [ ] Verify incremental uploads work on Azure eval run
- [ ] Verify partial results are recoverable from blob storage after VM termination

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)