### PR TITLE
fix: Sync __version__ in __init__.py with pyproject.toml

### DIFF
--- a/config/supermodel-eval-0.9.2-test10.yaml
+++ b/config/supermodel-eval-0.9.2-test10.yaml
@@ -1,0 +1,61 @@
+# Supermodel MCP v0.9.2 eval — 10-task test run on Azure
+#
+# Run:
+#   mcpbr run -c config/supermodel-eval-0.9.2-test10.yaml -v
+
+mcp_server:
+  name: "supermodel"
+  command: "npx"
+  args:
+    - "-y"
+    - "@supermodeltools/mcp-server@0.9.2"
+    - "{workdir}"
+    - "--precache"
+  env:
+    SUPERMODEL_API_KEY: "${SUPERMODEL_API_KEY}"
+    SUPERMODEL_BASE_URL: "https://api.supermodeltools.com"
+    SUPERMODEL_CACHE_DIR: "/tmp/supermodel-cache"
+  setup_command: "npx -y @supermodeltools/mcp-server@0.9.2 precache {workdir} --output-dir /tmp/supermodel-cache"
+  setup_timeout_ms: 900000
+
+provider: "anthropic"
+
+agent_harness: "claude-code"
+
+model: "claude-sonnet-4-20250514"
+
+benchmark: "swe-bench-verified"
+
+sample_size: 10
+
+timeout_seconds: 300
+
+max_concurrent: 4
+
+max_iterations: 30
+
+# Azure infrastructure
+infrastructure:
+  mode: azure
+  azure:
+    resource_group: "mcpbr-benchmarks"
+    location: "eastus"
+    cpu_cores: 16
+    memory_gb: 64
+    disk_gb: 200
+    auto_shutdown: true
+    preserve_on_error: true
+    env_keys_to_export:
+      - "ANTHROPIC_API_KEY"
+      - "SUPERMODEL_API_KEY"
+      - "AZURE_STORAGE_KEY"
+
+# Cloud storage for incremental result persistence
+cloud_storage:
+  provider: "azure_blob"
+  account: "mcpbrbenchmarks"
+  container: "eval-runs"
+
+# Slack notifications (bot API with file upload)
+slack_bot_token: "${SLACK_BOT_TOKEN}"
+slack_channel: "${SLACK_CHANNEL}"

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -101,6 +101,28 @@ def update_marketplace_json(marketplace_json_path: Path, version: str) -> None:
     print(f"Updated {marketplace_json_path}: {old_version} -> {version}")
 
 
+def update_init_py(init_py_path: Path, version: str) -> None:
+    """Update __version__ in src/mcpbr/__init__.py."""
+    if not init_py_path.exists():
+        print(f"Warning: {init_py_path} does not exist. Skipping.")
+        return
+
+    content = init_py_path.read_text(encoding="utf-8")
+    import re
+
+    new_content, count = re.subn(
+        r'__version__\s*=\s*"[^"]*"',
+        f'__version__ = "{version}"',
+        content,
+    )
+    if count == 0:
+        print(f"Warning: No __version__ found in {init_py_path}")
+        return
+
+    init_py_path.write_text(new_content, encoding="utf-8")
+    print(f"Updated {init_py_path}: __version__ -> {version}")
+
+
 def main() -> None:
     """Main entry point."""
     project_root = Path(__file__).parent.parent
@@ -109,6 +131,7 @@ def main() -> None:
     marketplace_json_path = project_root / ".claude-plugin" / "marketplace.json"
     plugin_package_json_path = project_root / ".claude-plugin" / "package.json"
     package_json_path = project_root / "package.json"
+    init_py_path = project_root / "src" / "mcpbr" / "__init__.py"
 
     if not pyproject_path.exists():
         print(f"Error: {pyproject_path} not found", file=sys.stderr)
@@ -129,6 +152,9 @@ def main() -> None:
 
     # Update root package.json (if it exists)
     update_package_json(package_json_path, version)
+
+    # Update __init__.py
+    update_init_py(init_py_path, version)
 
     print("\nVersion sync complete!")
 

--- a/src/mcpbr/__init__.py
+++ b/src/mcpbr/__init__.py
@@ -3,7 +3,7 @@
 A benchmark runner for evaluating MCP servers against SWE-bench tasks.
 """
 
-__version__ = "0.12.0"
+__version__ = "0.12.3"
 
 from .sdk import (
     BenchmarkResult,


### PR DESCRIPTION
## Summary

- Fix `__version__` in `src/mcpbr/__init__.py` being stuck at `0.12.0` while `pyproject.toml` was at `0.12.3`
- Add `__init__.py` syncing to `scripts/sync_version.py` pre-commit hook
- Add 10-task test config for supermodel eval

The version sync script updated plugin.json, marketplace.json, and package.json but not `__init__.py`. This caused the Azure infrastructure provisioner to install `mcpbr==0.12.0` on VMs (reading `__version__` at runtime) instead of the actual release version.

## Test plan

- [x] Pre-commit hooks pass (ruff, ruff format, yaml check)
- [x] Version sync script now includes `__init__.py` in its sync targets
- [ ] Next Azure eval run should install the correct mcpbr version on the VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)