### PR TITLE
feat: Add setup_only mode for static file generation workflows

### DIFF
--- a/src/mcpbr/config.py
+++ b/src/mcpbr/config.py
@@ -130,6 +130,16 @@ class MCPServerConfig(BaseModel):
         "reads with native tools.",
     )
 
+    @model_validator(mode="after")
+    def validate_setup_only_requires_setup_command(self) -> "MCPServerConfig":
+        """Ensure setup_command is provided when setup_only is True."""
+        if self.setup_only and not self.setup_command:
+            raise ValueError(
+                "setup_command is required when setup_only is True. "
+                "Without it, no MCP server is started and no setup runs."
+            )
+        return self
+
     def get_args_for_workdir(self, workdir: str) -> list[str]:
         """Replace {workdir} placeholder in args with actual path."""
         result = []

--- a/src/mcpbr/config.py
+++ b/src/mcpbr/config.py
@@ -123,6 +123,12 @@ class MCPServerConfig(BaseModel):
         default=900000,
         description="Timeout in milliseconds for the setup_command (default: 15 min)",
     )
+    setup_only: bool = Field(
+        default=False,
+        description="When true, only run setup_command. No MCP server is started or "
+        "registered with the agent. Use when setup produces static files the agent "
+        "reads with native tools.",
+    )
 
     def get_args_for_workdir(self, workdir: str) -> list[str]:
         """Replace {workdir} placeholder in args with actual path."""

--- a/src/mcpbr/harnesses.py
+++ b/src/mcpbr/harnesses.py
@@ -590,11 +590,10 @@ class ClaudeCodeHarness:
             safe_key = key.replace("-", "_").replace(".", "_")
             env_exports += f"export {safe_key}={shlex.quote(value)}\n"
 
-        if env_exports:
-            await env.exec_command(
-                f"cat > {env_file} << 'MCPBR_SETUP_ENV_EOF'\n{env_exports}MCPBR_SETUP_ENV_EOF",
-                timeout=10,
-            )
+        await env.exec_command(
+            f"cat > {env_file} << 'MCPBR_SETUP_ENV_EOF'\n{env_exports}MCPBR_SETUP_ENV_EOF",
+            timeout=10,
+        )
 
         setup_full_cmd = f"source {shlex.quote(env_file)} && {setup_cmd}"
 
@@ -711,7 +710,7 @@ class ClaudeCodeHarness:
                 )
                 formatter = StreamEventFormatter(self._console, config, self.log_file)
 
-                run_type = "mcp" if self.mcp_server else "baseline"
+                run_type = "mcp" if mcp_server_name else "baseline"
                 formatter.print_run_start(instance_id, run_type)
 
                 exit_code, stdout, stderr = await _run_cli_streaming(
@@ -1000,7 +999,7 @@ class ClaudeCodeHarness:
             # Set up MCP server log file if MCP is enabled
             mcp_log_file = None
             mcp_log_path = None
-            if self.mcp_server:
+            if mcp_server_name:
                 from pathlib import Path
 
                 # Determine logs directory: use mcp_logs_dir if provided, otherwise fall back to home directory
@@ -1024,7 +1023,7 @@ class ClaudeCodeHarness:
                 )
                 formatter = StreamEventFormatter(self._console, config, self.log_file)
 
-                run_type = "mcp" if self.mcp_server else "baseline"
+                run_type = "mcp" if mcp_server_name else "baseline"
                 formatter.print_run_start(instance_id, run_type)
 
                 def on_stdout(line: str) -> None:
@@ -1091,7 +1090,7 @@ class ClaudeCodeHarness:
                     else:
                         error_msg = f"Agent failed before making any progress (exit {exit_code}). {error_msg}"
 
-                    if self.mcp_server:
+                    if mcp_server_name:
                         error_msg += f"\n\nMCP server was registered: {mcp_server_name}. Check MCP server logs for initialization issues."
                         if mcp_log_path:
                             error_msg += f"\nMCP server logs saved to: {mcp_log_path}"
@@ -1215,7 +1214,7 @@ class ClaudeCodeHarness:
                         self._console.print(f"[dim red]Failed to clean up .mcp.json: {e}[/dim red]")
 
             error_msg = f"Task execution timed out after {timeout}s."
-            if self.mcp_server:
+            if mcp_server_name:
                 error_msg += f" MCP server '{mcp_server_name}' was registered successfully but the agent failed to complete within the timeout."
                 if mcp_log_path:
                     error_msg += f"\nMCP server logs saved to: {mcp_log_path}"


### PR DESCRIPTION
## Summary

- Adds `setup_only: bool` field to `MCPServerConfig` (default `false`)
- When `true`, the harness runs `setup_command` but skips MCP server registration, `.mcp.json` creation, and MCP timeout environment variables
- User-defined env vars are always exported since `setup_command` needs them
- Enables workflows where setup produces static files (e.g., a pre-computed code graph as markdown) that the agent reads with native `Read` tool instead of MCP tool calls

## Motivation

MCP tool calls are serialized (1 per agent turn, 0 parallelism), while native tools (`Read`, `Grep`, `Glob`) parallelize freely within a single turn. For use cases where the MCP server's value is primarily in its pre-computed data (not runtime tool execution), `setup_only` lets you generate a static file during setup and skip the MCP server entirely, giving the agent full parallelism.

## Test plan

- [x] `pytest tests/test_config.py` -- 25 passed
- [x] `pytest tests/test_config_validator.py tests/test_comparison_config.py` -- 36 passed
- [ ] End-to-end: `mcpbr run` with `setup_only: true` config -- verify no `.mcp.json` created, no MCP tools registered, setup_command runs and produces output file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "setup-only" mode for MCP servers. When enabled, only the server's initialization command runs; the MCP server is not launched or registered with the agent. This mode prevents runtime MCP involvement (timeouts, registration, and runtime environment injection), while still honoring user-specified environment variables during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->