### PR TITLE
fix: Ensure non-root user cache directory has proper permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **MCP log directory permission error** (#449): Claude CLI running as non-root `mcpbr` user
+  could fail with `EACCES` when creating MCP log directories under `~/.cache/`. The home
+  directory and `.cache` subdirectory are now explicitly created and owned by the `mcpbr` user
+  during container setup
 - **K8s async context crash** (#424): Replaced `run_until_complete` with `await` in K8s
   provider async methods, fixing crashes when called from an existing event loop
 - **SQLite UPSERT timestamp preservation** (#425): Changed `INSERT OR REPLACE` to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **MCP log directory permission error** (#449): Claude CLI running as non-root `mcpbr` user
+- **MCP log directory permission error** (#451): Claude CLI running as non-root `mcpbr` user
   could fail with `EACCES` when creating MCP log directories under `~/.cache/`. The home
   directory and `.cache` subdirectory are now explicitly created and owned by the `mcpbr` user
   during container setup

--- a/src/mcpbr/__init__.py
+++ b/src/mcpbr/__init__.py
@@ -3,7 +3,7 @@
 A benchmark runner for evaluating MCP servers against SWE-bench tasks.
 """
 
-__version__ = "0.12.4"
+__version__ = "0.12.5"
 
 from .sdk import (
     BenchmarkResult,

--- a/src/mcpbr/docker_env.py
+++ b/src/mcpbr/docker_env.py
@@ -794,8 +794,12 @@ CMD ["/bin/bash"]
 
         # Create a non-root user for running Claude CLI
         # Claude CLI blocks --dangerously-skip-permissions when running as root
+        # Ensure home directory (including .cache) is fully owned by mcpbr
+        # so Claude CLI can create MCP log directories at runtime
         create_user_cmd = (
             "useradd -m -s /bin/bash mcpbr && "
+            "mkdir -p /home/mcpbr/.cache && "
+            "chown -R mcpbr:mcpbr /home/mcpbr && "
             "chown -R mcpbr:mcpbr /workspace && "
             f"chown -R mcpbr:mcpbr {env.workdir}"
         )


### PR DESCRIPTION
## Summary

- Claude CLI fails with `EACCES: permission denied` when creating MCP log directories at `~/.cache/claude-cli-nodejs/-workspace/mcp-logs-*` inside Docker containers
- The `mcpbr` non-root user's home directory needs `.cache` pre-created with correct ownership
- Explicitly creates `/home/mcpbr/.cache` and recursively chowns the entire home directory during container setup

## Context

Discovered while running MCP benchmark comparisons across Claude Code versions. The `mcpbr` user is created via `useradd -m` which creates the home directory, but Claude CLI at runtime needs to create subdirectories under `~/.cache/` for MCP server log files. Without the `.cache` directory pre-existing with correct ownership, older Claude Code versions fail during MCP initialization.

## Test plan

- [x] Verified fix resolves the EACCES error when running Claude Code v2.0.70 with MCP servers in Docker containers
- [ ] Run existing unit tests: `uv run pytest -m "not integration"`
- [ ] Run integration test with an MCP-enabled config to verify MCP server starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved permission errors that occurred when Claude CLI created MCP log directories in containerized environments running with non-root privileges. Home and cache directories are now properly initialized with correct ownership during container setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->