### PR TITLE
feat: Add disallowed_native_tools and system_prompt_append to MCP config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **MCP native tool blocking** (#450): New `disallowed_native_tools` and `system_prompt_append`
+  fields in `mcp_server` config. When set, `--disallowedTools` strips specified native tools
+  (e.g., Read, Grep, Glob) from the API tool definitions, forcing the agent to use MCP
+  equivalents. `--append-system-prompt` can guide the agent toward MCP tools. Essential for
+  meaningful MCP vs native tool benchmarking.
 - **Eval started notifications** (#413): Notifications are now sent when an evaluation begins,
   including benchmark name, model, task count, concurrency, and infrastructure mode
 - **Infrastructure lifecycle notifications** (#414): `infra_provisioned` and `infra_teardown`

--- a/src/mcpbr/__init__.py
+++ b/src/mcpbr/__init__.py
@@ -3,7 +3,7 @@
 A benchmark runner for evaluating MCP servers against SWE-bench tasks.
 """
 
-__version__ = "0.12.4"
+__version__ = "0.12.5"
 
 from .sdk import (
     BenchmarkResult,

--- a/src/mcpbr/config.py
+++ b/src/mcpbr/config.py
@@ -129,6 +129,17 @@ class MCPServerConfig(BaseModel):
         "registered with the agent. Use when setup produces static files the agent "
         "reads with native tools.",
     )
+    disallowed_native_tools: list[str] = Field(
+        default_factory=list,
+        description="Native tool names to disable via --disallowedTools when MCP is "
+        "active. Use to prevent the agent from bypassing MCP tools with native "
+        "equivalents (e.g., ['Read', 'Grep', 'Glob'] for a filesystem MCP server).",
+    )
+    system_prompt_append: str | None = Field(
+        default=None,
+        description="Text to append to the system prompt via --append-system-prompt "
+        "when MCP is active. Use to guide the agent toward MCP tools.",
+    )
 
     @model_validator(mode="after")
     def validate_setup_only_requires_setup_command(self) -> "MCPServerConfig":

--- a/src/mcpbr/harnesses.py
+++ b/src/mcpbr/harnesses.py
@@ -693,6 +693,14 @@ class ClaudeCodeHarness:
             if self.model:
                 command.extend(["--model", self.model])
 
+            # When MCP is active, disable specified native tools and optionally
+            # append to system prompt so the agent uses MCP equivalents
+            if self.mcp_server and not self.mcp_server.setup_only:
+                if self.mcp_server.disallowed_native_tools:
+                    command.extend(["--disallowedTools", *self.mcp_server.disallowed_native_tools])
+                if self.mcp_server.system_prompt_append:
+                    command.extend(["--append-system-prompt", self.mcp_server.system_prompt_append])
+
             command.append(prompt)
 
             # Prepare environment variables
@@ -979,6 +987,17 @@ class ClaudeCodeHarness:
             if self.model:
                 claude_args.extend(["--model", self.model])
 
+            # When MCP is active, disable specified native tools and optionally
+            # append to system prompt so the agent uses MCP equivalents
+            mcp_append_prompt = ""
+            if self.mcp_server and not self.mcp_server.setup_only:
+                if self.mcp_server.disallowed_native_tools:
+                    claude_args.extend(
+                        ["--disallowedTools", *self.mcp_server.disallowed_native_tools]
+                    )
+                if self.mcp_server.system_prompt_append:
+                    mcp_append_prompt = self.mcp_server.system_prompt_append
+
             claude_args_str = " ".join(claude_args)
 
             # Run Claude Code (MCP server already registered above)
@@ -988,7 +1007,18 @@ class ClaudeCodeHarness:
             quoted_prompt_file = shlex.quote(prompt_file)
 
             # Build inner command first, then quote for su -c
-            inner_cmd = f'source {quoted_env_file} && cd {quoted_workdir} && claude {claude_args_str} "$(cat {quoted_prompt_file})"'
+            if mcp_append_prompt:
+                inner_cmd = (
+                    f"source {quoted_env_file} && cd {quoted_workdir} && "
+                    f"claude {claude_args_str} "
+                    f"--append-system-prompt {shlex.quote(mcp_append_prompt)} "
+                    f'"$(cat {quoted_prompt_file})"'
+                )
+            else:
+                inner_cmd = (
+                    f"source {quoted_env_file} && cd {quoted_workdir} && "
+                    f'claude {claude_args_str} "$(cat {quoted_prompt_file})"'
+                )
 
             command = [
                 "/bin/bash",

--- a/src/mcpbr/harnesses.py
+++ b/src/mcpbr/harnesses.py
@@ -998,7 +998,7 @@ class ClaudeCodeHarness:
                 if self.mcp_server.system_prompt_append:
                     mcp_append_prompt = self.mcp_server.system_prompt_append
 
-            claude_args_str = " ".join(claude_args)
+            claude_args_str = " ".join(shlex.quote(a) for a in claude_args)
 
             # Run Claude Code (MCP server already registered above)
             # Use shlex.quote() to prevent shell injection


### PR DESCRIPTION
## Summary

- Adds `disallowed_native_tools` field to `MCPServerConfig` - passes specified tool names to `--disallowedTools` so they're removed from API tool definitions
- Adds `system_prompt_append` field to `MCPServerConfig` - passes text to `--append-system-prompt` to guide the agent toward MCP tools
- Applied in both local and Docker execution paths when MCP is active and not `setup_only`

## Context

When benchmarking MCP tools vs native tools, Claude consistently prefers native Read/Grep/Glob over MCP filesystem equivalents — even when explicitly instructed in the prompt to use MCP. The only reliable way to force MCP tool usage is to remove the native tools from the API tool definitions entirely via `--disallowedTools`.

Example config:
```yaml
mcp_server:
  name: "filesystem"
  command: "npx"
  args: ["-y", "@modelcontextprotocol/server-filesystem", "{workdir}"]
  disallowed_native_tools:
    - Read
    - Grep
    - Glob
  system_prompt_append: |
    The Read, Grep, and Glob tools are disabled. Use MCP filesystem
    tools for all file reading and searching.
```

## Test plan

- [x] Verified `--disallowedTools` correctly removes native tools from API tool definitions
- [x] Verified agent uses MCP tools when native equivalents are disabled
- [ ] Run unit tests: `uv run pytest -m "not integration"`
- [ ] Integration test with MCP-enabled config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added MCP native tool blocking capabilities with new configuration options that allow you to disable specific native tools and optionally append custom text to the system prompt when an MCP server is active, providing finer control over tool availability and system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->