### PR TITLE
feat: Add Claude Code version pinning for Docker containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (e.g., Read, Grep, Glob) from the API tool definitions, forcing the agent to use MCP
   equivalents. `--append-system-prompt` can guide the agent toward MCP tools. Essential for
   meaningful MCP vs native tool benchmarking.
+- **Claude Code version pinning** (#453): New `claude_code_version` config field lets you pin a
+  specific Claude Code version inside Docker containers (e.g., `claude_code_version: "2.1.37"`).
+  Useful for version comparison experiments. Older versions that lack `--max-turns` support
+  (pre-2.1.x) are automatically detected and the flag is omitted.
 - **Eval started notifications** (#413): Notifications are now sent when an evaluation begins,
   including benchmark name, model, task count, concurrency, and infrastructure mode
 - **Infrastructure lifecycle notifications** (#414): `infra_provisioned` and `infra_teardown`

--- a/src/mcpbr/config.py
+++ b/src/mcpbr/config.py
@@ -642,6 +642,12 @@ class HarnessConfig(BaseModel):
         description="Use pre-built SWE-bench Docker images when available",
     )
 
+    claude_code_version: str | None = Field(
+        default=None,
+        description="Pin a specific Claude Code version inside Docker containers "
+        "(e.g., '2.1.37'). Defaults to latest. Useful for version comparison experiments.",
+    )
+
     budget: float | None = Field(
         default=None,
         description="Maximum budget in USD for the evaluation (halts when reached)",

--- a/src/mcpbr/harness.py
+++ b/src/mcpbr/harness.py
@@ -271,6 +271,7 @@ def _create_mcp_agent(
         log_file=log_file,
         mcp_logs_dir=mcp_logs_dir,
         thinking_budget=config.thinking_budget,
+        claude_code_version=config.claude_code_version,
     )
 
 
@@ -303,6 +304,7 @@ def _create_baseline_agent(
         verbosity=verbosity,
         log_file=log_file,
         thinking_budget=config.thinking_budget,
+        claude_code_version=config.claude_code_version,
     )
 
 
@@ -1333,6 +1335,7 @@ async def run_evaluation(
         extra_volumes=config.volumes,
         sandbox_profile=sandbox_profile,
         audit_logger=audit_logger,
+        claude_code_version=config.claude_code_version,
     )
 
     # Build notification config early for lifecycle events (v0.13.0)

--- a/src/mcpbr/harnesses.py
+++ b/src/mcpbr/harnesses.py
@@ -533,6 +533,7 @@ class ClaudeCodeHarness:
         log_file: TextIO | InstanceLogWriter | None = None,
         mcp_logs_dir: Path | None = None,
         thinking_budget: int | None = None,
+        claude_code_version: str | None = None,
     ) -> None:
         """Initialize Claude Code harness.
 
@@ -545,6 +546,7 @@ class ClaudeCodeHarness:
             log_file: Optional file handle for writing raw JSON logs.
             mcp_logs_dir: Directory for MCP server logs. Default: ~/.mcpbr_state/logs
             thinking_budget: Extended thinking token budget. Set to enable thinking mode.
+            claude_code_version: Pinned Claude Code version (e.g., '2.1.37').
         """
         self.model = model
         self.mcp_server = mcp_server
@@ -556,6 +558,7 @@ class ClaudeCodeHarness:
         self.log_file = log_file
         self.mcp_logs_dir = mcp_logs_dir
         self.thinking_budget = thinking_budget
+        self.claude_code_version = claude_code_version
         self._console = Console()
 
     async def run_setup_command(
@@ -980,9 +983,12 @@ class ClaudeCodeHarness:
                 "--dangerously-skip-permissions",
                 "--output-format",
                 "stream-json",
-                "--max-turns",
-                str(self.max_iterations),
             ]
+
+            # --max-turns was added in Claude Code v2.1.x; skip for older versions
+            ver = self.claude_code_version or ""
+            if not ver or not ver.startswith(("0.", "1.", "2.0.")):
+                claude_args.extend(["--max-turns", str(self.max_iterations)])
 
             if self.model:
                 claude_args.extend(["--model", self.model])
@@ -1311,6 +1317,7 @@ def create_harness(
     log_file: TextIO | InstanceLogWriter | None = None,
     mcp_logs_dir: Path | None = None,
     thinking_budget: int | None = None,
+    claude_code_version: str | None = None,
 ) -> AgentHarness:
     """Factory function to create an agent harness.
 
@@ -1347,6 +1354,7 @@ def create_harness(
         log_file=log_file,
         mcp_logs_dir=mcp_logs_dir,
         thinking_budget=thinking_budget,
+        claude_code_version=claude_code_version,
     )
 
 


### PR DESCRIPTION
## Summary

- Adds `claude_code_version` config field to pin specific Claude Code npm versions inside Docker containers
- Threads the version through `HarnessConfig` → `create_harness()` → `ClaudeCodeHarness` → `DockerEnvironmentManager`
- Automatically omits `--max-turns` for pre-2.1.x versions that don't support the flag
- Useful for version comparison experiments that isolate behavior changes across Claude Code releases

## Example config

```yaml
claude_code_version: "2.1.37"  # Pin to a specific version
```

## Test plan

- [x] Verified correct version installed inside Docker (checked claude --version in init events)
- [x] Verified --max-turns omitted for v2.0.70
- [ ] Run unit tests: `uv run pytest -m "not integration"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)