### PR TITLE
Fix: activate conda testbed env for agent in SWE-bench containers

### DIFF
--- a/src/mcpbr/__init__.py
+++ b/src/mcpbr/__init__.py
@@ -3,7 +3,7 @@
 A benchmark runner for evaluating MCP servers against SWE-bench tasks.
 """
 
-__version__ = "0.12.6"
+__version__ = "0.12.7"
 
 from .sdk import (
     BenchmarkResult,

--- a/src/mcpbr/docker_env.py
+++ b/src/mcpbr/docker_env.py
@@ -817,6 +817,20 @@ CMD ["/bin/bash"]
         if exit_code != 0:
             raise RuntimeError(f"Failed to create non-root user: {stderr}")
 
+        # For prebuilt SWE-bench images, add conda testbed activation to the
+        # mcpbr user's .bashrc so that interactive shells and any shell that
+        # sources .bashrc will have access to pytest and project dependencies.
+        if env.uses_prebuilt:
+            conda_bashrc = (
+                "source /opt/miniconda3/etc/profile.d/conda.sh\\nconda activate testbed\\n"
+            )
+            exit_code, _, stderr = await env.exec_command(
+                f'echo -e "{conda_bashrc}" >> /home/mcpbr/.bashrc',
+                timeout=10,
+            )
+            if exit_code != 0:
+                logger.warning("Failed to add conda activation to .bashrc: %s", stderr)
+
     async def _setup_repo(
         self,
         env: TaskEnvironment,

--- a/src/mcpbr/harnesses.py
+++ b/src/mcpbr/harnesses.py
@@ -894,6 +894,16 @@ class ClaudeCodeHarness:
         if self.thinking_budget is not None:
             env_exports += f"export MAX_THINKING_TOKENS={shlex.quote(str(self.thinking_budget))}\n"
 
+        # Activate conda testbed environment for prebuilt SWE-bench images
+        # so the agent's Bash tool has access to pytest and project dependencies.
+        # This must come before the env_exports so conda PATH is set first,
+        # then our explicit exports (like ANTHROPIC_API_KEY) layer on top.
+        if env.uses_prebuilt:
+            conda_activate = (
+                "source /opt/miniconda3/etc/profile.d/conda.sh\nconda activate testbed\n"
+            )
+            env_exports = conda_activate + env_exports
+
         await env.exec_command(
             f"cat > {env_file} << 'MCPBR_ENV_EOF'\n{env_exports}MCPBR_ENV_EOF",
             timeout=10,


### PR DESCRIPTION
## Summary

- Prebuilt SWE-bench Docker images install project dependencies (pytest, matplotlib, sympy, etc.) in a conda `testbed` environment, but the agent runs with system Python which lacks these packages
- The agent's self-verification attempts (e.g. `python -m pytest`) fail with `ModuleNotFoundError`, impairing its ability to validate fixes during the solving phase
- Prepends conda testbed activation to the env_file sourced before launching Claude, so the agent process and its Bash tool children inherit the correct PATH
- Adds conda activation to the mcpbr user's `.bashrc` for interactive shell coverage

## Test plan

- [ ] Run a SWE-bench task with a prebuilt image (e.g. `matplotlib__matplotlib-24627`) and verify the agent can successfully run `python -m pytest` without import errors
- [ ] Verify evaluation scoring still works correctly (uses its own conda activation path in `evaluation.py`)
- [ ] Verify non-prebuilt fallback path is unaffected

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.12.7
  * Improved Docker environment initialization for prebuilt SWE-bench images with automatic conda activation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->