### PR TITLE
Fix zombie containers and setup_command cache mismatch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "mcpbr",
-  "version": "0.12.7",
+  "version": "0.13.0",
   "description": "mcpbr - MCP Benchmark Runner plugin marketplace",
   "owner": {
     "name": "mcpbr Contributors",
@@ -11,7 +11,7 @@
     {
       "name": "mcpbr",
       "description": "Expert benchmark runner for MCP servers using mcpbr. Handles Docker checks, config generation, and result parsing.",
-      "version": "0.12.7",
+      "version": "0.13.0",
       "author": {
         "name": "mcpbr Contributors"
       },

--- a/.claude-plugin/package.json
+++ b/.claude-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@greynewell/mcpbr-claude-plugin",
-  "version": "0.12.7",
+  "version": "0.13.0",
   "description": "Claude Code plugin for mcpbr - Expert benchmark runner for MCP servers with specialized skills",
   "keywords": [
     "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcpbr",
-  "version": "0.12.7",
+  "version": "0.13.0",
   "description": "Expert benchmark runner for MCP servers using mcpbr. Handles Docker checks, config generation, and result parsing.",
   "schema_version": "1.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@greynewell/mcpbr",
-  "version": "0.12.7",
+  "version": "0.13.0",
   "description": "Model Context Protocol Benchmark Runner - CLI tool for evaluating MCP servers",
   "keywords": [
     "mcpbr",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcpbr"
-version = "0.12.7"
+version = "0.13.0"
 description = "Model Context Protocol Benchmark Runner - evaluate MCP servers against software engineering benchmarks"
 readme = "README.md"
 license = "MIT"

--- a/src/mcpbr/__init__.py
+++ b/src/mcpbr/__init__.py
@@ -3,7 +3,7 @@
 A benchmark runner for evaluating MCP servers against SWE-bench tasks.
 """
 
-__version__ = "0.12.7"
+__version__ = "0.13.0"
 
 from .sdk import (
     BenchmarkResult,

--- a/src/mcpbr/docker_env.py
+++ b/src/mcpbr/docker_env.py
@@ -926,8 +926,8 @@ CMD ["/bin/bash"]
                 container.stop(timeout=5)
             except docker.errors.NotFound:
                 pass  # Already removed (e.g., by TaskEnvironment.cleanup)
-            except Exception:
-                pass  # Best-effort stop
+            except Exception as exc:
+                logger.debug("Failed to stop container %s: %s", container_name, exc)
 
             try:
                 container.remove(force=True)
@@ -1011,8 +1011,8 @@ CMD ["/bin/bash"]
                 container.stop(timeout=5)
             except docker.errors.NotFound:
                 continue
-            except Exception:
-                pass  # Best-effort stop
+            except Exception as exc:
+                logger.debug("Failed to stop stale container %s: %s", name, exc)
 
             try:
                 container.remove(force=True)

--- a/src/mcpbr/harness.py
+++ b/src/mcpbr/harness.py
@@ -1338,6 +1338,13 @@ async def run_evaluation(
         claude_code_version=config.claude_code_version,
     )
 
+    # Clean up containers from previous sessions that may have been orphaned
+    stale_count = docker_manager.cleanup_stale_session_containers()
+    if stale_count > 0:
+        console.print(
+            f"[yellow]Cleaned up {stale_count} stale container(s) from previous run(s)[/yellow]"
+        )
+
     # Build notification config early for lifecycle events (v0.13.0)
     notify_config = _build_notify_config(config)
     eval_start_time = time.time()

--- a/tests/test_docker_cleanup.py
+++ b/tests/test_docker_cleanup.py
@@ -422,7 +422,7 @@ class TestTaskEnvironmentCleanup:
         env = TaskEnvironment(
             container=mock_container,
             workdir="/workspace",
-            host_workdir="/tmp/test",
+            host_workdir="/tmp/test",  # noqa: S108
             instance_id="test-instance",
             _temp_dir=mock_temp_dir,
             _manager=manager,
@@ -448,7 +448,7 @@ class TestTaskEnvironmentCleanup:
         env = TaskEnvironment(
             container=mock_container,
             workdir="/workspace",
-            host_workdir="/tmp/test",
+            host_workdir="/tmp/test",  # noqa: S108
             instance_id="test-instance",
             _temp_dir=None,
             _manager=None,
@@ -475,7 +475,7 @@ class TestTaskEnvironmentCleanup:
         env = TaskEnvironment(
             container=mock_container,
             workdir="/workspace",
-            host_workdir="/tmp/test",
+            host_workdir="/tmp/test",  # noqa: S108
             instance_id="test-instance",
             _temp_dir=mock_temp_dir,
             _manager=manager,
@@ -504,7 +504,7 @@ class TestTaskEnvironmentCleanup:
         env = TaskEnvironment(
             container=mock_container,
             workdir="/workspace",
-            host_workdir="/tmp/test",
+            host_workdir="/tmp/test",  # noqa: S108
             instance_id="test-instance",
             _temp_dir=mock_temp_dir1,
             _manager=manager,
@@ -541,11 +541,12 @@ class TestSignalHandlers:
         register_signal_handlers()
 
 
+@pytest.mark.usefixtures("mock_docker_client")
 class TestTaskEnvironmentCleanupRetry:
     """Test TaskEnvironment cleanup retry, logging, and container tracking (#439)."""
 
     @pytest.mark.asyncio
-    async def test_task_environment_cleanup_logs_warning_on_failure(self, mock_docker_client):
+    async def test_task_environment_cleanup_logs_warning_on_failure(self, tmp_path):
         """Test that cleanup logs a warning when container stop fails but still succeeds."""
         manager = DockerEnvironmentManager()
         mock_container = MagicMock()
@@ -557,7 +558,7 @@ class TestTaskEnvironmentCleanupRetry:
         env = TaskEnvironment(
             container=mock_container,
             workdir="/workspace",
-            host_workdir="/tmp/test",
+            host_workdir=str(tmp_path),
             instance_id="test-instance",
             _temp_dir=None,
             _manager=manager,
@@ -572,7 +573,7 @@ class TestTaskEnvironmentCleanupRetry:
         mock_container.remove.assert_called_once_with(force=True)
 
     @pytest.mark.asyncio
-    async def test_task_environment_cleanup_retries_remove(self, mock_docker_client):
+    async def test_task_environment_cleanup_retries_remove(self, tmp_path):
         """Test that cleanup retries container.remove up to 3 times."""
         manager = DockerEnvironmentManager()
         mock_container = MagicMock()
@@ -589,7 +590,7 @@ class TestTaskEnvironmentCleanupRetry:
         env = TaskEnvironment(
             container=mock_container,
             workdir="/workspace",
-            host_workdir="/tmp/test",
+            host_workdir=str(tmp_path),
             instance_id="test-instance",
             _temp_dir=None,
             _manager=manager,
@@ -602,7 +603,7 @@ class TestTaskEnvironmentCleanupRetry:
         assert mock_container not in manager._containers
 
     @pytest.mark.asyncio
-    async def test_task_environment_cleanup_removes_from_containers_list(self, mock_docker_client):
+    async def test_task_environment_cleanup_removes_from_containers_list(self, tmp_path):
         """Test that successful cleanup removes container from manager._containers."""
         manager = DockerEnvironmentManager()
         mock_container = MagicMock()
@@ -614,7 +615,7 @@ class TestTaskEnvironmentCleanupRetry:
         env = TaskEnvironment(
             container=mock_container,
             workdir="/workspace",
-            host_workdir="/tmp/test",
+            host_workdir=str(tmp_path),
             instance_id="test-instance",
             _temp_dir=None,
             _manager=manager,
@@ -625,7 +626,7 @@ class TestTaskEnvironmentCleanupRetry:
         assert mock_container not in manager._containers
 
     @pytest.mark.asyncio
-    async def test_task_environment_cleanup_keeps_in_list_on_failure(self, mock_docker_client):
+    async def test_task_environment_cleanup_keeps_in_list_on_failure(self, tmp_path):
         """Test that failed cleanup keeps container in manager._containers for retry at exit."""
         manager = DockerEnvironmentManager()
         mock_container = MagicMock()
@@ -638,7 +639,7 @@ class TestTaskEnvironmentCleanupRetry:
         env = TaskEnvironment(
             container=mock_container,
             workdir="/workspace",
-            host_workdir="/tmp/test",
+            host_workdir=str(tmp_path),
             instance_id="test-instance",
             _temp_dir=None,
             _manager=manager,
@@ -689,7 +690,7 @@ class TestTaskEnvironmentCleanupRetry:
         current_container.stop.assert_not_called()
         current_container.remove.assert_not_called()
 
-    def test_cleanup_all_sync_handles_not_found(self, mock_docker_client):
+    def test_cleanup_all_sync_handles_not_found(self):
         """Test that cleanup_all_sync treats NotFound as success."""
         manager = DockerEnvironmentManager()
 

--- a/tests/test_setup_env_vars.py
+++ b/tests/test_setup_env_vars.py
@@ -1,0 +1,201 @@
+"""Tests for MCPBR_* env var injection and placeholder expansion (#440)."""
+
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcpbr.config import MCPServerConfig
+from mcpbr.docker_env import TaskEnvironment
+
+
+@pytest.fixture
+def mock_docker_client():
+    """Create a mock Docker client."""
+    with patch("mcpbr.docker_env.docker.from_env") as mock_from_env:
+        mock_client = MagicMock()
+        mock_from_env.return_value = mock_client
+        yield mock_client
+
+
+@pytest.fixture
+def mock_env(mock_docker_client):
+    """Create a mock TaskEnvironment with repo metadata."""
+    from mcpbr.docker_env import DockerEnvironmentManager
+
+    manager = DockerEnvironmentManager()
+    mock_container = MagicMock()
+    mock_container.name = "test-container"
+
+    # exec_command returns (exit_code, stdout, stderr)
+    mock_container.exec_run.return_value = MagicMock(exit_code=0, output=(b"", b""))
+
+    env = TaskEnvironment(
+        container=mock_container,
+        workdir="/workspace",
+        host_workdir="/tmp/test",
+        instance_id="django__django-12345",
+        repo="django/django",
+        base_commit="abc123def",
+        uses_prebuilt=True,
+        claude_cli_installed=True,
+        _temp_dir=None,
+        _manager=manager,
+    )
+    return env
+
+
+class TestMCPBREnvVarsInSetupCommand:
+    """Test MCPBR_* vars are present in env file from run_setup_command."""
+
+    @pytest.mark.asyncio
+    async def test_setup_command_env_file_contains_mcpbr_vars(self, mock_env):
+        """Test that run_setup_command writes MCPBR_* vars to env file."""
+        from mcpbr.harnesses import ClaudeCodeHarness
+
+        mcp_config = MCPServerConfig(
+            command="python",
+            args=["-m", "my_server", "{workdir}"],
+            setup_command="echo setup",
+        )
+        harness = ClaudeCodeHarness(mcp_server=mcp_config)
+
+        # Capture what gets written to the env file
+        written_content = {}
+
+        async def mock_exec(cmd, timeout=60, user=None, workdir=None, environment=None):
+            if isinstance(cmd, str) and "cat > /tmp/.mcpbr_env.sh" in cmd:
+                written_content["env_file"] = cmd
+            return (0, "", "")
+
+        mock_env.exec_command = AsyncMock(side_effect=mock_exec)
+
+        await harness.run_setup_command(mock_env, verbose=False)
+
+        env_file = written_content.get("env_file", "")
+        assert "MCPBR_REPO=" in env_file
+        assert "django/django" in env_file
+        assert "MCPBR_REPO_NAME=" in env_file
+        assert "MCPBR_REPO_NAME=django" in env_file
+        assert "MCPBR_BASE_COMMIT=" in env_file
+        assert "abc123def" in env_file
+        assert "MCPBR_INSTANCE_ID=" in env_file
+        assert "django__django-12345" in env_file
+
+
+class TestMCPBREnvVarsInMCPJson:
+    """Test MCPBR_* vars are present in .mcp.json env block."""
+
+    @pytest.mark.asyncio
+    async def test_mcp_json_contains_mcpbr_vars(self, mock_env):
+        """Test that _solve_in_docker writes MCPBR_* vars to .mcp.json."""
+        from mcpbr.harnesses import ClaudeCodeHarness
+
+        mcp_config = MCPServerConfig(
+            command="python",
+            args=["-m", "my_server", "{workdir}"],
+        )
+        harness = ClaudeCodeHarness(mcp_server=mcp_config, max_iterations=1)
+
+        # Capture what gets written to .mcp.json
+        written_mcp_json = {}
+
+        async def mock_exec(cmd, timeout=60, user=None, workdir=None, environment=None):
+            if isinstance(cmd, (str, list)):
+                cmd_str = cmd if isinstance(cmd, str) else " ".join(cmd)
+                if ".mcp.json" in cmd_str and "cat >" in cmd_str:
+                    # Extract JSON content between heredoc markers
+                    content = cmd_str.split("MCP_JSON_EOF")[0]
+                    # Find the JSON portion
+                    json_start = content.find("{")
+                    if json_start >= 0:
+                        json_str = content[json_start:]
+                        try:
+                            written_mcp_json["config"] = json.loads(json_str)
+                        except json.JSONDecodeError:
+                            written_mcp_json["raw"] = json_str
+            return (0, "", "")
+
+        mock_env.exec_command = AsyncMock(side_effect=mock_exec)
+        mock_env.exec_command_streaming = AsyncMock(return_value=(0, "", ""))
+
+        # Need ANTHROPIC_API_KEY to be set
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+            try:
+                await harness._solve_in_docker(
+                    task={
+                        "problem_statement": "test",
+                        "instance_id": "django__django-12345",
+                        "repo": "django/django",
+                        "base_commit": "abc123def",
+                    },
+                    env=mock_env,
+                    timeout=10,
+                    verbose=False,
+                    task_id="django__django-12345",
+                )
+            except Exception:
+                pass  # We just want to check what was written
+
+        if "config" in written_mcp_json:
+            mcp_config_data = written_mcp_json["config"]
+            server_env = mcp_config_data["mcpServers"]["mcpbr"]["env"]
+            assert server_env.get("MCPBR_REPO") == "django/django"
+            assert server_env.get("MCPBR_REPO_NAME") == "django"
+            assert server_env.get("MCPBR_BASE_COMMIT") == "abc123def"
+            assert server_env.get("MCPBR_INSTANCE_ID") == "django__django-12345"
+
+
+class TestPlaceholderExpansion:
+    """Test placeholder expansion in config methods."""
+
+    def test_args_expand_repo_name(self):
+        """Test {repo_name} placeholder in args."""
+        config = MCPServerConfig(
+            command="python",
+            args=["-m", "server", "--cache", "/tmp/{repo_name}_cache", "{workdir}"],
+        )
+        args = config.get_args_for_workdir(
+            "/workspace",
+            repo="django/django",
+            repo_name="django",
+            base_commit="abc123",
+            instance_id="django__django-12345",
+        )
+        assert args == ["-m", "server", "--cache", "/tmp/django_cache", "/workspace"]
+
+    def test_setup_command_expand_placeholders(self):
+        """Test placeholder expansion in setup_command."""
+        config = MCPServerConfig(
+            command="python",
+            args=[],
+            setup_command="index-repo --repo {repo_name} --workdir {workdir}",
+        )
+        cmd = config.get_setup_command_for_workdir(
+            "/workspace",
+            repo="django/django",
+            repo_name="django",
+            base_commit="abc123",
+            instance_id="django__django-12345",
+        )
+        assert cmd == "index-repo --repo django --workdir /workspace"
+
+    def test_unknown_placeholders_left_untouched(self):
+        """Test that unknown placeholders are not expanded (backward compat)."""
+        config = MCPServerConfig(
+            command="python",
+            args=["--flag", "{unknown_placeholder}", "{workdir}"],
+        )
+        args = config.get_args_for_workdir("/workspace", repo="django/django")
+        assert args == ["--flag", "{unknown_placeholder}", "/workspace"]
+
+    def test_setup_command_unknown_placeholders_untouched(self):
+        """Test that unknown placeholders in setup_command are left untouched."""
+        config = MCPServerConfig(
+            command="python",
+            args=[],
+            setup_command="run {custom} in {workdir}",
+        )
+        cmd = config.get_setup_command_for_workdir("/workspace")
+        assert cmd == "run {custom} in /workspace"


### PR DESCRIPTION
## Summary

Fixes two P1 bugs in mcpbr v0.12.x that cause reliability regressions during SWE-bench evaluations:

- **#439 — Zombie Docker containers**: Containers left running indefinitely after task completion (observed 15+ hours in 500-task eval). Root causes: silent cleanup failure, missing tracking list removal, no startup orphan cleanup.
- **#440 — setup_command cache not found by MCP server**: `basename("/workspace")` → `"workspace"` doesn't match the repo name used as cache key, causing 5/446 tasks (1.1%) to time out with 0 iterations.

### Bug #439 changes
- `TaskEnvironment.cleanup()`: retry `container.remove()` up to 3 times with 1s/2s backoff, log warnings instead of silently swallowing errors, handle `docker.errors.NotFound` gracefully
- Remove container from `_containers` list on successful cleanup; keep on failure so `cleanup_all_sync` retries at exit
- New `cleanup_stale_session_containers()` method removes orphans from previous sessions at startup
- `cleanup_all_sync()`: split stop/remove into separate try-blocks, treat `NotFound` as success

### Bug #440 changes
- Add `repo`, `base_commit` fields and `repo_name` property to `TaskEnvironment`
- Inject `MCPBR_REPO`, `MCPBR_REPO_NAME`, `MCPBR_BASE_COMMIT`, `MCPBR_INSTANCE_ID` env vars into `run_setup_command`, `_solve_in_docker` env file, and `.mcp.json` env block
- Add `{repo}`, `{repo_name}`, `{base_commit}`, `{instance_id}` placeholder expansion to `get_args_for_workdir()` and `get_setup_command_for_workdir()`

### Other
- Bump version to 0.13.0
- Skip gated dataset benchmarks in integration tests
- 13 new tests (7 for #439, 6 for #440)

## Test plan

- [x] `pytest tests/test_docker_cleanup.py` — 40 tests pass (33 existing + 7 new)
- [x] `pytest tests/test_setup_env_vars.py` — 6 new tests pass
- [x] `pytest tests/test_config.py` — all pass (placeholder expansion)
- [x] `ruff check src/` — no lint errors
- [x] Pre-commit hooks pass (ruff, ruff-format, version sync)
- [ ] Manual: `mcpbr run -c quick-test.yaml -B -t django__django-13410 -vv` — container cleaned up after task
- [ ] Manual: run, kill with SIGKILL, run again — logs "Cleaned up N stale container(s)"
- [ ] Manual: verify `MCPBR_REPO_NAME` set inside container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for expanded placeholder substitution in configuration, including repository metadata and instance identifiers.
  * Introduced automatic cleanup of stale Docker containers from previous sessions.

* **Bug Fixes**
  * Improved Docker container cleanup with retry logic and enhanced error handling for removal failures.
  * Added proper handling for "NotFound" errors during container cleanup operations.

* **Tests**
  * Added comprehensive test coverage for environment variable injection and placeholder expansion behavior.
  * Introduced tests for Docker container cleanup retry mechanisms and stale session removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->