### PR TITLE
Fix parallel run stability (#458, #459, #460)

### DIFF
--- a/src/mcpbr/__init__.py
+++ b/src/mcpbr/__init__.py
@@ -3,7 +3,7 @@
 A benchmark runner for evaluating MCP servers against SWE-bench tasks.
 """
 
-__version__ = "0.12.7"
+__version__ = "0.12.8"
 
 from .sdk import (
     BenchmarkResult,

--- a/src/mcpbr/cli.py
+++ b/src/mcpbr/cli.py
@@ -777,7 +777,8 @@ To archive:
                 console.print(f"[red]Error: {error_msg}[/red]")
                 sys.exit(1)
 
-    # Determine which tasks to run based on incremental flags
+    # Determine which tasks to run based on incremental flags.
+    # CLI --task/-t flags take precedence over config file task_ids.
     selected_task_ids: list[str] | None = None
     if use_incremental and state_tracker:
         if retry_failed:
@@ -793,8 +794,12 @@ To archive:
             selected_task_ids = None  # Let run_evaluation handle the from_task logic
         elif task_ids:
             selected_task_ids = list(task_ids)
+        elif config.task_ids:
+            selected_task_ids = list(config.task_ids)
     elif task_ids:
         selected_task_ids = list(task_ids)
+    elif config.task_ids:
+        selected_task_ids = list(config.task_ids)
 
     run_mcp = not baseline_only
     run_baseline = not mcp_only

--- a/src/mcpbr/docker_env.py
+++ b/src/mcpbr/docker_env.py
@@ -541,6 +541,8 @@ CMD ["/bin/bash"]
                         volumes=volumes_dict,
                         working_dir=container_workdir,
                         remove=False,
+                        mem_limit="4g",
+                        memswap_limit="6g",
                         labels={
                             MCPBR_LABEL: "true",
                             MCPBR_INSTANCE_LABEL: str(instance_id),


### PR DESCRIPTION
## Summary

- **Config `task_ids` ignored for local runs (#458):** Falls back to `config.task_ids` when no CLI `--task` flags are provided
- **Progress output unparseable when piped (#459):** Emits plain-text `[START]`/`[DONE]`/`[ERROR]`/`[SKIP]`/`[SUMMARY]` lines to stderr when not connected to a TTY
- **Containers OOM-kill each other under concurrency (#460):** Adds `mem_limit=4g` / `memswap_limit=6g` defaults to container creation

## Test plan

- [ ] `mcpbr run -c config-with-task-ids.yaml` only runs the specified tasks (not the full benchmark)
- [ ] `mcpbr run -c config.yaml 2>&1 | grep '\[DONE\]'` shows plain-text completion lines when piped
- [ ] 3 concurrent `mcpbr run` processes on the same 10 tasks complete without container crashes
- [ ] Single `mcpbr run` with `--task` CLI flag still takes precedence over config `task_ids`

Closes #458, closes #459, closes #460.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plain-text logging output for CI/automation environments with task status markers ([START], [DONE], [ERROR], [SKIP], [SUMMARY])

* **Improvements**
  * Implemented memory limits for Docker containers to improve resource management
  * Enhanced task selection logic to better handle configuration-based task IDs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->