### PR TITLE
Surface statistical significance in default run output

### DIFF
--- a/src/mcpbr/__init__.py
+++ b/src/mcpbr/__init__.py
@@ -3,7 +3,7 @@
 A benchmark runner for evaluating MCP servers against SWE-bench tasks.
 """
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 
 from .sdk import (
     BenchmarkResult,

--- a/src/mcpbr/analytics/__init__.py
+++ b/src/mcpbr/analytics/__init__.py
@@ -39,8 +39,10 @@ from .statistical import (
     chi_squared_test,
     compare_resolution_rates,
     effect_size_cohens_d,
+    interpret_effect_size,
     mann_whitney_u,
     permutation_test,
+    wilson_score_interval,
 )
 from .trends import calculate_moving_average, calculate_trends, detect_trend_direction
 
@@ -71,9 +73,11 @@ __all__ = [
     "format_comparison_table",
     "generate_leaderboard",
     "identify_flaky_tasks",
+    "interpret_effect_size",
     "mann_whitney_u",
     "pearson_correlation",
     "permutation_test",
     "run_ab_test",
     "spearman_correlation",
+    "wilson_score_interval",
 ]


### PR DESCRIPTION
## Summary

Closes #454

- Add Wilson score confidence intervals for resolution rates (proper binomial CI that handles 0% and 100% correctly)
- Surface chi-squared significance testing with p-values and effect size (Cohen's phi) in both console and markdown report output
- Add `interpret_effect_size()` for human-readable effect size labels (negligible/small/medium/large)
- Display small sample size warnings when n < 30

## Test plan

- [x] `pytest tests/test_analytics.py tests/test_reporting.py -v` — 158 tests pass
- [x] `ruff check` — all checks pass
- [ ] Manual verification with a real benchmark run to confirm output formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)