### PR TITLE
Fix zombie Docker containers after task timeout

### DIFF
--- a/src/mcpbr/__init__.py
+++ b/src/mcpbr/__init__.py
@@ -3,7 +3,7 @@
 A benchmark runner for evaluating MCP servers against SWE-bench tasks.
 """
 
-__version__ = "0.13.2"
+__version__ = "0.13.3"
 
 from .sdk import (
     BenchmarkResult,

--- a/tests/test_eval_reliability.py
+++ b/tests/test_eval_reliability.py
@@ -250,7 +250,14 @@ class TestEvalTimeoutInHarness:
 
         benchmark = Mock()
         benchmark.get_prompt_template.return_value = "Test prompt"
-        benchmark.create_environment = AsyncMock()
+        # Docker container methods (kill, remove) are synchronous in docker-py
+        mock_container = Mock()
+        mock_container.kill = Mock()
+        mock_container.remove = Mock()
+        mock_env = AsyncMock()
+        mock_env.container = mock_container
+        mock_env.cleanup = AsyncMock()
+        benchmark.create_environment = AsyncMock(return_value=mock_env)
         # Make evaluate take too long — should be caught by eval_timeout
         benchmark.evaluate = AsyncMock(side_effect=asyncio.TimeoutError())
 

--- a/tests/test_timeout_tracking.py
+++ b/tests/test_timeout_tracking.py
@@ -137,7 +137,14 @@ async def test_run_mcp_evaluation_timeout_fallback():
 
     benchmark = Mock()
     benchmark.get_prompt_template.return_value = "Test prompt"
-    benchmark.create_environment = AsyncMock()
+    # Docker container methods (kill, remove) are synchronous in docker-py
+    mock_container = Mock()
+    mock_container.kill = Mock()
+    mock_container.remove = Mock()
+    mock_env = AsyncMock()
+    mock_env.container = mock_container
+    mock_env.cleanup = AsyncMock()
+    benchmark.create_environment = AsyncMock(return_value=mock_env)
 
     docker_manager = Mock()
 


### PR DESCRIPTION
## Summary

- Force-kill containers with `container.kill()` (SIGKILL) immediately when `asyncio.TimeoutError` fires, for both MCP and baseline evaluation paths
- Upgrade the `finally`-block cleanup fallback from `container.remove(force=True)` to `container.kill()` + `container.remove(force=True)`

## Root cause

`asyncio.wait_for` cancels the asyncio `Future` on timeout, but the underlying thread running `docker exec_run` / `exec_start` (via `loop.run_in_executor`) cannot be interrupted. The thread keeps reading from the Docker socket indefinitely. The old `container.stop(timeout=5)` sends SIGTERM which Claude Code may ignore.

## Test results

```
With kill():    timeout 3.0s → kill 0.16s → total cleanup 3.7s  ✓
Without kill(): timeout 3.0s → container still running           ✗ (BUG)
```

## Test plan

- [x] Verified `container.kill()` is instant (0.07s vs `stop()` at 5.12s)
- [x] Full integration test: `asyncio.wait_for` + `run_in_executor` + timeout → container killed and cleaned up in <4s
- [x] Confirmed the bug: without `kill()`, container stays running after timeout
- [ ] Run benchmark with `timeout_seconds: 300` and verify no zombie containers after timed-out tasks

Closes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 0.13.3.

* **Bug Fixes**
  * Improved Docker container termination on timeouts and cleanup errors—containers are now force-killed immediately to prevent hanging processes and ensure faster resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->