### PR TITLE
Harden concurrent evaluations against container failures

### DIFF
--- a/src/mcpbr/__init__.py
+++ b/src/mcpbr/__init__.py
@@ -3,7 +3,7 @@
 A benchmark runner for evaluating MCP servers against SWE-bench tasks.
 """
 
-__version__ = "0.13.3"
+__version__ = "0.13.4"
 
 from .sdk import (
     BenchmarkResult,

--- a/src/mcpbr/cli.py
+++ b/src/mcpbr/cli.py
@@ -856,6 +856,10 @@ To archive:
     if config.benchmark == "cybergym":
         console.print(f"  CyberGym Level: {config.cybergym_level}")
     console.print(f"  Sample size: {config.sample_size or 'full'}")
+    if selected_task_ids:
+        console.print(
+            f"  Task IDs: {len(selected_task_ids)} pinned ({', '.join(selected_task_ids[:3])}{'...' if len(selected_task_ids) > 3 else ''})"
+        )
     console.print(f"  Run MCP: {run_mcp}, Run Baseline: {run_baseline}")
     console.print(f"  Pre-built images: {config.use_prebuilt_images}")
     infra_mode = getattr(getattr(config, "infrastructure", None), "mode", "local")

--- a/src/mcpbr/cli.py
+++ b/src/mcpbr/cli.py
@@ -720,8 +720,10 @@ def run(
         # Config setting
         final_output_dir = Path(config.output_dir)
     else:
-        # Default: timestamped directory
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        # Default: timestamped directory with microseconds for uniqueness.
+        # Second-level precision causes collisions when multiple runs launch
+        # simultaneously, corrupting shared state and results.
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         final_output_dir = Path(f".mcpbr_run_{timestamp}")
 
     # Override state_dir to use output directory if not explicitly set

--- a/src/mcpbr/harness.py
+++ b/src/mcpbr/harness.py
@@ -1252,7 +1252,10 @@ async def run_evaluation(
                     f"[cyan]Using cached results for {skipped_count} completed tasks[/cyan]"
                 )
 
-    console.print(f"[dim]Evaluating {len(tasks_to_run)} tasks[/dim]")
+    task_ids_loaded = [t["instance_id"] for t in tasks_to_run]
+    console.print(
+        f"[dim]Evaluating {len(tasks_to_run)} tasks: {', '.join(task_ids_loaded[:5])}{'...' if len(task_ids_loaded) > 5 else ''}[/dim]"
+    )
     console.print(f"[dim]Provider: {config.provider}, Harness: {config.agent_harness}[/dim]")
 
     # Initialize cache if enabled


### PR DESCRIPTION
## Summary
- **Fix output directory collision**: Add microsecond precision to timestamps so simultaneous `mcpbr run` launches get unique directories
- **Print pinned task IDs**: Show which tasks are selected in evaluation output so filtering issues are immediately visible
- **Retry Node.js/CLI install**: 3 attempts with exponential backoff for transient apt-get failures under resource contention
- **Harden concurrent evaluations**: `ContainerDiedError` for Docker 409 errors, broader `_is_infra_failure` task-level retry (container deaths, install failures, API errors), and 5s stagger interval across all batches (was 1s first-batch-only)

## Context
Running 3+ parallel evaluation trials causes containers to compete for I/O, network, and memory during `apt-get install nodejs`. This produced 21 infrastructure failures across 3 trials: 8x "container not running" (409), 7x empty-stderr Node.js install failures, 5x apt-get failures with debconf warnings, 1x legitimate timeout.

## Test plan
- [ ] Run 3 concurrent `mcpbr run` trials on same host, verify <5% infra failure rate
- [ ] Verify `ContainerDiedError` message appears in logs instead of raw Docker 409
- [ ] Verify task-level retry fires on install failures and container deaths
- [ ] Verify stagger delay applies to every batch (not just the first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added timestamps to output directories to reduce collision risk in concurrent runs.
  * Display pinned task IDs count and preview in run summary.
  * Retry with exponential backoff for installation steps.

* **Improvements**
  * Enhanced detection and handling of infrastructure failures (e.g., container crashes, install hiccups).
  * Increased cold-start stagger interval and applied staggering per batch for improved reliability.
  * Improved error visibility and messaging during evaluations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->